### PR TITLE
📝 docs(datetime_utils): enhance documentation for DateTime methods

### DIFF
--- a/src/toolregistry_hub/datetime_utils.py
+++ b/src/toolregistry_hub/datetime_utils.py
@@ -88,8 +88,19 @@ class DateTime:
     def now(timezone_name: Optional[str] = None) -> str:
         """Get current time in ISO 8601 format.
 
+        As an LLM, you have no sense of current time; use this tool to obtain accurate,
+        up-to-date time information. Essential for answering time-related questions,
+        generating timestamps, or scheduling tasks. Especially useful when performing
+        searches, taking notes, or communicating where current time context is needed.
+
         Args:
-            timezone_name: Optional timezone name (e.g., "Asia/Shanghai", "UTC+5"). Defaults to UTC if None.
+            timezone_name: Optional timezone name (e.g., "Asia/Shanghai", "UTC+5").
+                Defaults to UTC if None. Supports both IANA timezone names
+                (e.g., "America/New_York") and UTC/GMT offset formats
+                (e.g., "UTC+5", "GMT-3", "UTC+5:30").
+
+        Returns:
+            Current time as ISO 8601 formatted string.
 
         Raises:
             ValueError: If timezone is invalid.
@@ -108,10 +119,17 @@ class DateTime:
     ) -> Dict[str, Any]:
         """Convert time between timezones.
 
+        As an LLM, you may need to convert times across timezones for scheduling,
+        coordination, or understanding global events. Use this tool to accurately
+        convert a given time from one timezone to another.
+
         Args:
             time_str: Time in 24-hour format (HH:MM)
-            source_timezone: Source timezone (e.g., "America/Chicago", "UTC+5")
-            target_timezone: Target timezone (e.g., "Asia/Shanghai", "GMT-3")
+            source_timezone: Source timezone (e.g., "America/Chicago", "UTC+5").
+                Supports both IANA timezone names (e.g., "America/New_York") and
+                UTC/GMT offset formats (e.g., "UTC+5", "GMT-3", "UTC+5:30").
+            target_timezone: Target timezone (e.g., "Asia/Shanghai", "GMT-3").
+                Supports both IANA timezone names and UTC/GMT offset formats.
 
         Returns:
             Dict with source_time, target_time, time_difference, and timezone info.

--- a/src/toolregistry_hub/server/routes/datetime_tools.py
+++ b/src/toolregistry_hub/server/routes/datetime_tools.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
 from ...datetime_utils import DateTime
@@ -72,7 +72,7 @@ router = APIRouter(prefix="/time", tags=["datetime"])
 @router.post(
     "/now",
     summary="Get current time in ISO 8601 format",
-    description="Get current time in ISO 8601 format. Optionally specify a timezone, otherwise returns UTC time.",
+    description=DateTime.now.__doc__,
     operation_id="time-now",
     response_model=TimeNowResponse,
 )
@@ -104,7 +104,7 @@ def time_now(request: TimeNowRequest) -> TimeNowResponse:
 @router.post(
     "/convert",
     summary="Convert time between timezones",
-    description="Convert a specific time from one timezone to another. Supports both IANA timezone names and UTC/GMT offset formats.",
+    description=DateTime.convert_timezone.__doc__,
     operation_id="time-convert-timezone",
     response_model=ConvertTimezoneResponse,
 )


### PR DESCRIPTION
- add detailed descriptions for `now()` and `convert_timezone()` methods to clarify usage for LLM context
- expand parameter documentation with supported timezone format examples
- update FastAPI route descriptions to use method docstrings for consistency

【docs】update server route descriptions to reference method docstrings directly