### PR TITLE
refactor: restructure server optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,19 @@ dev = [
     "twine>=6.1.0",
     "pytest>=7.0.0",
 ]
-server_openapi = ["fastapi>=0.119.0", "uvicorn[standard]>=0.24.0"]
-server_mcp = ["fastapi>=0.119.0", "fastmcp>=2.12.4; python_version >= '3.10'"]
-server = [
+server_openapi = [
+    "toolregistry>=0.4.14",
     "fastapi>=0.119.0",
     "uvicorn[standard]>=0.24.0",
+]
+server_mcp = [
+    "toolregistry>=0.4.14",
+    "fastapi>=0.119.0",
     "fastmcp>=2.12.4; python_version >= '3.10'",
+]
+server = [
+    "toolregistry-hub[server_openapi]",
+    "toolregistry-hub[server_mcp]",
 ]
 
 [project.urls]

--- a/src/toolregistry_hub/server/cli.py
+++ b/src/toolregistry_hub/server/cli.py
@@ -143,12 +143,8 @@ def main():
         except ImportError as e:
             logger.error(f"OpenAPI server dependencies not installed: {e}")
             logger.info("Installation options:")
-            logger.info(
-                "  OpenAPI only: pip install toolregistry-hub[server_openapi] (requires Python 3.8+)"
-            )
-            logger.info(
-                "  All server modes: pip install toolregistry-hub[server] (requires Python 3.10+)"
-            )
+            logger.info("  OpenAPI only: pip install toolregistry-hub[server_openapi]")
+            logger.info("  Full server:  pip install toolregistry-hub[server]")
             sys.exit(1)
 
         # Set server info
@@ -161,10 +157,10 @@ def main():
             logger.error(f"MCP server dependencies not installed: {e}")
             logger.info("Installation options:")
             logger.info(
-                "  MCP only: pip install toolregistry-hub[server_mcp] (requires Python 3.10+)"
+                "  MCP only:    pip install toolregistry-hub[server_mcp] (requires Python 3.10+)"
             )
             logger.info(
-                "  All server modes: pip install toolregistry-hub[server] (requires Python 3.10+)"
+                "  Full server: pip install toolregistry-hub[server] (requires Python 3.10+)"
             )
             sys.exit(1)
 


### PR DESCRIPTION
## Summary

Restructure the optional dependencies for the server layer as part of Phase 1 dependency refactoring.

## Changes

### pyproject.toml
- **`server_openapi`**: Added `toolregistry>=0.4.14` (was: fastapi + uvicorn only)
- **`server_mcp`**: Added `toolregistry>=0.4.14` (was: fastapi + fastmcp only)
- **`server`**: Refactored to use self-referencing composition:
  ```toml
  server = ["toolregistry-hub[server_openapi]", "toolregistry-hub[server_mcp]"]
  ```

### cli.py
- Updated ImportError messages to use consistent formatting
- Changed "All server modes" to "Full server"

## Extras Structure

| Extra | Dependencies | Use Case |
|-------|-------------|----------|
| `server_openapi` | toolregistry + fastapi + uvicorn | OpenAPI only |
| `server_mcp` | toolregistry + fastapi + fastmcp | MCP only (Python 3.10+) |
| `server` | server_openapi + server_mcp | Full server |

## Related

- Companion issue: Oaklight/ToolRegistry#50 (remove hub optional dep from toolregistry)
- PR: Oaklight/ToolRegistry#56

Closes #29