### PR TITLE
feat: Auto-route generation from ToolRegistry (Phase 5)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1294,6 +1294,8 @@ def create_core_app(...) -> FastAPI:
 
 Add ETag-based change detection to the `/openapi.json` endpoint, enabling clients to efficiently detect tool list changes.
 
+> **Phase 5 compatibility note:** Phase 5's `setup_dynamic_openapi()` replaces `app.openapi` with a custom function that regenerates the schema on every call (no caching). Phase 7d should either extend `setup_dynamic_openapi()` to include ETag computation, or create an explicit `GET /openapi.json` route that wraps `app.openapi()` and adds ETag/`If-None-Match` headers. The latter approach is recommended since `app.openapi` replacement only controls schema content, not HTTP response headers. Consider using Phase 6a's observer callback to invalidate a cached schema (only regenerate on enable/disable state changes).
+
 **Implementation:**
 
 1. **ETag header on `/openapi.json`**: Compute ETag from the hash of the OpenAPI spec content. Return it in the response `ETag` header.
@@ -1337,6 +1339,8 @@ async def openapi_endpoint(request: Request):
 > **Issues:** [Oaklight/toolregistry-hub#32](https://github.com/Oaklight/toolregistry-hub/issues/32)
 
 Once auto-route is validated end-to-end (at least one release cycle after Phase 5):
+
+> **Phase 5 compatibility note:** Phase 5 added `test_core_app_has_legacy_routes` in `tests/test_autoroute.py` to verify legacy routes exist during the migration period. This test must be removed (or inverted) when legacy routes are removed in this phase.
 
 - [ ] Remove hand-written route files: `calculator.py`, `fetch.py`, `datetime_tools.py`, `unit_converter.py`, `think.py`, `todo_list.py`
 - [ ] Remove `routes/websearch/` hand-written files

--- a/src/toolregistry_hub/server/autoroute.py
+++ b/src/toolregistry_hub/server/autoroute.py
@@ -1,0 +1,332 @@
+"""Automatic route generation from a ToolRegistry.
+
+Converts a :class:`~toolregistry.ToolRegistry` into a FastAPI
+:class:`~fastapi.APIRouter` by introspecting each registered
+:class:`~toolregistry.tool.Tool` and dynamically creating Pydantic
+request models and route handlers.
+"""
+
+from typing import Any, Dict, List, Tuple, Type
+
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.openapi.utils import get_openapi
+from loguru import logger
+from pydantic import BaseModel, Field, create_model
+from toolregistry import ToolRegistry
+from toolregistry.tool import Tool
+
+# ---------------------------------------------------------------------------
+# JSON Schema type → Python type mapping
+# ---------------------------------------------------------------------------
+
+_JSON_TYPE_MAP: Dict[str, Type] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve a single field schema to a Python type
+# ---------------------------------------------------------------------------
+
+
+def _resolve_type(field_schema: Dict[str, Any]) -> Type:
+    """Resolve a JSON Schema field description to a Python type.
+
+    Handles basic types, ``array`` with ``items``, nested ``object`` with
+    ``properties`` (recursively creates a Pydantic model), ``enum`` via
+    ``Literal``, and falls back to ``Any`` for unknown schemas.
+
+    Args:
+        field_schema: A single-field JSON Schema dict (e.g.
+            ``{"type": "string"}`` or ``{"type": "array", "items": {...}}``).
+
+    Returns:
+        The resolved Python type suitable for use in a Pydantic model field.
+    """
+    # Handle enum → Literal
+    if "enum" in field_schema:
+        from typing import Literal  # noqa: UP035 – needed at runtime
+
+        values = tuple(field_schema["enum"])
+        return Literal[values]  # type: ignore[valid-type]
+
+    json_type = field_schema.get("type")
+
+    if json_type == "array":
+        items_schema = field_schema.get("items")
+        if items_schema:
+            inner = _resolve_type(items_schema)
+            return List[inner]  # type: ignore[valid-type]
+        return list
+
+    if json_type == "object" and "properties" in field_schema:
+        # Recursively build a nested Pydantic model
+        return _schema_to_pydantic("NestedModel", field_schema)
+
+    if json_type is not None:
+        return _JSON_TYPE_MAP.get(json_type, Any)  # type: ignore[return-value]
+
+    # anyOf / oneOf patterns (e.g. Optional fields from toolregistry)
+    any_of = field_schema.get("anyOf") or field_schema.get("oneOf")
+    if any_of:
+        non_null = [s for s in any_of if s.get("type") != "null"]
+        if len(non_null) == 1:
+            return _resolve_type(non_null[0])
+
+    return Any  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema → Pydantic model
+# ---------------------------------------------------------------------------
+
+
+def _schema_to_pydantic(name: str, schema: Dict[str, Any]) -> Type[BaseModel]:
+    """Convert a JSON Schema ``object`` definition into a dynamic Pydantic model.
+
+    Args:
+        name: The class name for the generated model.
+        schema: A JSON Schema dict with ``properties`` (and optionally
+            ``required``).
+
+    Returns:
+        A dynamically created :class:`pydantic.BaseModel` subclass whose
+        fields mirror the schema properties.
+    """
+    properties: Dict[str, Any] = schema.get("properties", {})
+    if not properties:
+        # Return an empty model when there are no properties
+        return create_model(name)  # type: ignore[call-overload]
+
+    required_fields: List[str] = schema.get("required", [])
+    field_definitions: Dict[str, Tuple[Type, Any]] = {}
+
+    for field_name, field_schema in properties.items():
+        py_type = _resolve_type(field_schema)
+        description = field_schema.get("description")
+
+        is_required = field_name in required_fields
+        default_value = field_schema.get("default", ... if is_required else None)
+
+        field_kwargs: Dict[str, Any] = {}
+        if description:
+            field_kwargs["description"] = description
+
+        if default_value is ...:
+            field_definitions[field_name] = (py_type, Field(**field_kwargs))
+        else:
+            field_definitions[field_name] = (
+                py_type,
+                Field(default=default_value, **field_kwargs),
+            )
+
+    return create_model(name, **field_definitions)  # type: ignore[call-overload]
+
+
+# ---------------------------------------------------------------------------
+# Route generation
+# ---------------------------------------------------------------------------
+
+
+def _add_route(router: APIRouter, tool: Tool, registry: ToolRegistry) -> None:
+    """Create and register a POST route for a single tool.
+
+    The route path is ``/{namespace}/{method_name}``.  If either attribute is
+    ``None``, the values are inferred from ``tool.name`` by splitting on
+    ``-``.
+
+    For async tools the handler is an ``async def``; for sync tools a plain
+    ``def`` is used.  A closure is used to correctly capture the loop
+    variable.
+
+    Each endpoint checks at request time whether the tool is still enabled
+    via ``registry.is_enabled()``.  If the tool has been disabled at runtime,
+    the endpoint returns HTTP 503 Service Unavailable.
+
+    Args:
+        router: The :class:`~fastapi.APIRouter` to add the route to.
+        tool: The :class:`~toolregistry.tool.Tool` to expose.
+        registry: The :class:`~toolregistry.ToolRegistry` used for runtime
+            enable/disable checks.
+    """
+    namespace = tool.namespace
+    method_name = tool.method_name
+
+    # Infer namespace / method_name from tool.name when not set
+    if namespace is None or method_name is None:
+        parts = tool.name.split("-", 1)
+        if len(parts) == 2:
+            namespace = namespace or parts[0]
+            method_name = method_name or parts[1]
+        else:
+            namespace = namespace or "default"
+            method_name = method_name or tool.name
+
+    path = f"/{namespace}/{method_name}"
+
+    # Determine request model
+    request_model: Type[BaseModel]
+    if tool.parameters_model is not None:
+        request_model = tool.parameters_model
+    else:
+        model_name = f"{tool.name.replace('-', '_').title().replace('_', '')}Request"
+        request_model = _schema_to_pydantic(model_name, tool.parameters)
+
+    summary = (tool.description or "")[:120]
+    tags = [namespace] if namespace else []
+
+    # Capture tool_name as a string to avoid closure-over-loop-variable issues.
+    tool_name = tool.name
+
+    # Use factory functions to capture tool, RequestModel, registry, and
+    # tool_name per iteration via closure.  We must NOT expose the Tool as a
+    # default parameter because Pydantic v2 rejects underscore-prefixed field
+    # names and FastAPI would try to treat it as a body parameter.
+
+    if tool.is_async:
+
+        def _make_async_endpoint(
+            t: Tool = tool,
+            M: Type[BaseModel] = request_model,  # type: ignore[assignment]
+            reg: ToolRegistry = registry,
+            tname: str = tool_name,
+        ):
+            async def _endpoint(data: M) -> Any:  # type: ignore[valid-type]
+                if not reg.is_enabled(tname):
+                    raise HTTPException(
+                        status_code=503,
+                        detail=f"Tool '{tname}' is currently disabled",
+                    )
+                return await t.arun(data.model_dump())
+
+            return _endpoint
+
+        router.add_api_route(
+            path,
+            _make_async_endpoint(),
+            methods=["POST"],
+            operation_id=tool.name,
+            summary=summary,
+            tags=tags,
+        )
+    else:
+
+        def _make_sync_endpoint(
+            t: Tool = tool,
+            M: Type[BaseModel] = request_model,  # type: ignore[assignment]
+            reg: ToolRegistry = registry,
+            tname: str = tool_name,
+        ):
+            def _endpoint(data: M) -> Any:  # type: ignore[valid-type]
+                if not reg.is_enabled(tname):
+                    raise HTTPException(
+                        status_code=503,
+                        detail=f"Tool '{tname}' is currently disabled",
+                    )
+                return t.run(data.model_dump())
+
+            return _endpoint
+
+        router.add_api_route(
+            path,
+            _make_sync_endpoint(),
+            methods=["POST"],
+            operation_id=tool.name,
+            summary=summary,
+            tags=tags,
+        )
+
+    logger.debug(f"Auto-route registered: POST {router.prefix}{path} → {tool.name}")
+
+
+def registry_to_router(
+    registry: ToolRegistry,
+    prefix: str = "/tools",
+) -> APIRouter:
+    """Convert a :class:`~toolregistry.ToolRegistry` into a FastAPI router.
+
+    Routes are generated for **all** registered tools regardless of their
+    current enabled/disabled state.  Each endpoint checks
+    ``registry.is_enabled()`` at request time and returns HTTP 503 if the
+    tool has been disabled, allowing runtime enable/disable without
+    restarting the server.
+
+    Args:
+        registry: The tool registry to convert.
+        prefix: URL prefix for all generated routes.
+
+    Returns:
+        A :class:`~fastapi.APIRouter` with one POST route per registered tool.
+    """
+    router = APIRouter(prefix=prefix)
+
+    for tool in registry._tools.values():
+        _add_route(router, tool, registry)
+
+    logger.info(
+        f"Auto-router created with {len(router.routes)} route(s) under '{prefix}'"
+    )
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Dynamic OpenAPI schema generation
+# ---------------------------------------------------------------------------
+
+
+def setup_dynamic_openapi(app: FastAPI, registry: ToolRegistry) -> None:
+    """Configure dynamic OpenAPI schema generation that filters out disabled tools.
+
+    This replaces FastAPI's default cached OpenAPI schema with a dynamic one
+    that checks tool enable/disable status on every request to ``/openapi.json``.
+    Disabled tools are excluded from the schema so they do not appear in
+    ``/docs`` or ``/openapi.json``, and re-enabling them makes them visible
+    again immediately.
+
+    Args:
+        app: The FastAPI application instance.
+        registry: The tool registry used for enable/disable status checks.
+    """
+
+    def custom_openapi() -> Dict[str, Any]:
+        # Generate a fresh OpenAPI schema on every call (no caching)
+        # so it always reflects the current enable/disable state.
+        openapi_schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+        )
+
+        # Collect operation_ids of disabled tools
+        disabled_operation_ids: set[str] = set()
+        for tool in registry._tools.values():
+            if not registry.is_enabled(tool.name):
+                disabled_operation_ids.add(tool.name)
+
+        # Filter out paths whose operations correspond to disabled tools
+        if disabled_operation_ids and "paths" in openapi_schema:
+            filtered_paths: Dict[str, Any] = {}
+            for path, path_item in openapi_schema["paths"].items():
+                filtered_methods: Dict[str, Any] = {}
+                for method, operation in path_item.items():
+                    if isinstance(operation, dict):
+                        op_id = operation.get("operationId", "")
+                        if op_id not in disabled_operation_ids:
+                            filtered_methods[method] = operation
+                    else:
+                        filtered_methods[method] = operation
+                if filtered_methods:
+                    filtered_paths[path] = filtered_methods
+            openapi_schema["paths"] = filtered_paths
+
+        # Do NOT cache (app.openapi_schema is not set) so the schema
+        # is regenerated on every request, reflecting runtime changes.
+        return openapi_schema
+
+    app.openapi = custom_openapi  # type: ignore[method-assign]

--- a/src/toolregistry_hub/server/server_core.py
+++ b/src/toolregistry_hub/server/server_core.py
@@ -12,6 +12,8 @@ from fastapi import FastAPI
 from loguru import logger
 
 from ..__init__ import version
+from .autoroute import registry_to_router, setup_dynamic_openapi
+from .registry import get_registry
 from .routes import get_all_routers
 
 # Load environment variables
@@ -45,14 +47,26 @@ def create_core_app(dependencies: Optional[List[Any]] = None) -> FastAPI:
             version=version,
         )
 
-    # Automatically discover and include all routers
+    # New: registry-driven auto-generated routes (Phase 5)
+    registry = get_registry()
+    auto_router = registry_to_router(registry, prefix="/tools")
+    app.include_router(auto_router)
+    logger.info(
+        f"Included auto-generated router with {len(auto_router.routes)} routes at /tools"
+    )
+
+    # Legacy: keep existing hand-written routes during migration (removed in Phase 8)
     routers = get_all_routers()
-    # Include all routers from the routes module
     for router in routers:
         app.include_router(router)
-        logger.info(f"Included router with prefix: {router.prefix or '/'}")
+        logger.info(f"Included legacy router with prefix: {router.prefix or '/'}")
 
-    logger.info(f"Core FastAPI app initialized with {len(routers)} routers")
+    # Dynamic OpenAPI: hide disabled tools from /docs and /openapi.json
+    setup_dynamic_openapi(app, registry)
+
+    logger.info(
+        f"Core FastAPI app initialized with auto-routes + {len(routers)} legacy routers"
+    )
     return app
 
 

--- a/tests/test_autoroute.py
+++ b/tests/test_autoroute.py
@@ -1,0 +1,537 @@
+"""Tests for the automatic route generation module (autoroute.py).
+
+Covers:
+- _schema_to_pydantic: JSON Schema → Pydantic model conversion
+- _resolve_type: single-field type resolution
+- registry_to_router: ToolRegistry → APIRouter conversion
+- _add_route: individual route registration (sync / async)
+- Integration tests with create_core_app()
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal, get_args, get_origin
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from toolregistry import ToolRegistry
+
+from toolregistry_hub.server.autoroute import (
+    _add_route,
+    _resolve_type,
+    _schema_to_pydantic,
+    registry_to_router,
+    setup_dynamic_openapi,
+)
+
+
+# =========================================================================
+# 1a. _schema_to_pydantic tests
+# =========================================================================
+
+
+class TestSchemaToPydantic:
+    """Tests for _schema_to_pydantic."""
+
+    def test_empty_schema(self):
+        """Empty schema {} should return an empty Pydantic model."""
+        Model = _schema_to_pydantic("EmptyModel", {})
+        assert issubclass(Model, BaseModel)
+        # Should have no user-defined fields
+        assert len(Model.model_fields) == 0
+        # Should be instantiable with no arguments
+        instance = Model()
+        assert instance is not None
+
+    def test_basic_types(self):
+        """Test string, integer, number, boolean type mapping."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+                "score": {"type": "number"},
+                "active": {"type": "boolean"},
+            },
+            "required": ["name", "age", "score", "active"],
+        }
+        Model = _schema_to_pydantic("BasicModel", schema)
+        fields = Model.model_fields
+
+        assert fields["name"].annotation is str
+        assert fields["age"].annotation is int
+        assert fields["score"].annotation is float
+        assert fields["active"].annotation is bool
+
+    def test_required_and_optional(self):
+        """Required fields have no default; optional fields default to None."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "required_field": {"type": "string"},
+                "optional_field": {"type": "string"},
+            },
+            "required": ["required_field"],
+        }
+        Model = _schema_to_pydantic("ReqOptModel", schema)
+        fields = Model.model_fields
+
+        # Required field should not have a default (is_required)
+        assert fields["required_field"].is_required()
+        # Optional field should have default None
+        assert not fields["optional_field"].is_required()
+        assert fields["optional_field"].default is None
+
+    def test_default_values(self):
+        """Schema-specified default values should be preserved."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "count": {"type": "integer", "default": 10},
+                "label": {"type": "string", "default": "hello"},
+            },
+            "required": [],
+        }
+        Model = _schema_to_pydantic("DefaultModel", schema)
+        fields = Model.model_fields
+
+        assert fields["count"].default == 10
+        assert fields["label"].default == "hello"
+
+        # Instantiate with defaults
+        instance = Model()
+        assert instance.count == 10
+        assert instance.label == "hello"
+
+    def test_array_type(self):
+        """Array with items should map to List[inner_type]."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "tags": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["tags"],
+        }
+        Model = _schema_to_pydantic("ArrayModel", schema)
+        field_type = Model.model_fields["tags"].annotation
+
+        assert get_origin(field_type) is list
+        args = get_args(field_type)
+        assert len(args) == 1
+        assert args[0] is str
+
+    def test_nested_object(self):
+        """Nested object should recursively create a nested Pydantic model."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "street": {"type": "string"},
+                        "city": {"type": "string"},
+                    },
+                    "required": ["street"],
+                },
+            },
+            "required": ["address"],
+        }
+        Model = _schema_to_pydantic("NestedModel", schema)
+        address_type = Model.model_fields["address"].annotation
+
+        # Should be a Pydantic model subclass
+        assert issubclass(address_type, BaseModel)
+        nested_fields = address_type.model_fields
+        assert "street" in nested_fields
+        assert "city" in nested_fields
+
+    def test_enum_type(self):
+        """Fields with enum should use Literal type."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "color": {"type": "string", "enum": ["red", "green", "blue"]},
+            },
+            "required": ["color"],
+        }
+        Model = _schema_to_pydantic("EnumModel", schema)
+        field_type = Model.model_fields["color"].annotation
+
+        assert get_origin(field_type) is Literal
+        assert set(get_args(field_type)) == {"red", "green", "blue"}
+
+
+# =========================================================================
+# 1b. _resolve_type tests
+# =========================================================================
+
+
+class TestResolveType:
+    """Tests for _resolve_type."""
+
+    def test_basic_type_mapping(self):
+        """Verify all basic JSON Schema types map correctly."""
+        assert _resolve_type({"type": "string"}) is str
+        assert _resolve_type({"type": "integer"}) is int
+        assert _resolve_type({"type": "number"}) is float
+        assert _resolve_type({"type": "boolean"}) is bool
+        assert _resolve_type({"type": "array"}) is list
+        assert _resolve_type({"type": "object"}) is dict
+
+    def test_unknown_type_fallback(self):
+        """Unknown type should fallback to Any."""
+        result = _resolve_type({"type": "foobar"})
+        assert result is Any
+
+    def test_no_type_fallback(self):
+        """Schema without type key should fallback to Any."""
+        result = _resolve_type({})
+        assert result is Any
+
+
+# =========================================================================
+# 1c. registry_to_router tests
+# =========================================================================
+
+
+def _make_simple_registry() -> ToolRegistry:
+    """Create a simple ToolRegistry with one function for testing."""
+    registry = ToolRegistry()
+
+    def greet(name: str) -> str:
+        """Say hello."""
+        return f"Hello, {name}!"
+
+    registry.register(greet, namespace="test")
+    return registry
+
+
+class TestRegistryToRouter:
+    """Tests for registry_to_router."""
+
+    def test_router_generation(self):
+        """A simple registry should produce a router with routes."""
+        registry = _make_simple_registry()
+        router = registry_to_router(registry, prefix="/tools")
+
+        assert isinstance(router, APIRouter)
+        # Should have at least one route
+        assert len(router.routes) > 0
+
+    def test_disabled_tools_return_503(self):
+        """Disabled tools should have routes but return 503 when called."""
+        registry = _make_simple_registry()
+        # Find the tool name and disable it
+        tool_names = list(registry._tools.keys())
+        assert len(tool_names) > 0
+        for name in tool_names:
+            registry.disable(name)
+
+        router = registry_to_router(registry, prefix="/tools")
+        # Routes should still be generated for disabled tools
+        assert len(router.routes) > 0
+
+        # Calling a disabled tool should return 503
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post("/tools/test/greet", json={"name": "World"})
+        assert response.status_code == 503
+        assert "currently disabled" in response.json()["detail"]
+
+    def test_runtime_disable(self):
+        """Disabling a tool at runtime should cause its endpoint to return 503."""
+        registry = _make_simple_registry()
+        router = registry_to_router(registry, prefix="/tools")
+
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        # Tool is enabled — should work
+        response = client.post("/tools/test/greet", json={"name": "World"})
+        assert response.status_code == 200
+
+        # Disable at runtime
+        tool_name = list(registry._tools.keys())[0]
+        registry.disable(tool_name)
+
+        # Now should return 503
+        response = client.post("/tools/test/greet", json={"name": "World"})
+        assert response.status_code == 503
+        assert "currently disabled" in response.json()["detail"]
+
+    def test_runtime_enable(self):
+        """Re-enabling a tool at runtime should restore its endpoint."""
+        registry = _make_simple_registry()
+        tool_name = list(registry._tools.keys())[0]
+        registry.disable(tool_name)
+
+        router = registry_to_router(registry, prefix="/tools")
+
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        # Tool is disabled — should return 503
+        response = client.post("/tools/test/greet", json={"name": "World"})
+        assert response.status_code == 503
+
+        # Re-enable at runtime
+        registry.enable(tool_name)
+
+        # Now should work
+        response = client.post("/tools/test/greet", json={"name": "World"})
+        assert response.status_code == 200
+
+    def test_route_path_format(self):
+        """Route paths should follow /tools/{namespace}/{method_name} format."""
+        registry = _make_simple_registry()
+        router = registry_to_router(registry, prefix="/tools")
+
+        paths = [route.path for route in router.routes]
+        # The tool registered with namespace="test" and function name "greet"
+        # should produce path /test/greet
+        assert any("/test/greet" in p for p in paths)
+
+
+# =========================================================================
+# 1d. _add_route tests
+# =========================================================================
+
+
+class TestAddRoute:
+    """Tests for _add_route."""
+
+    def test_sync_endpoint(self):
+        """Sync tool should generate a sync endpoint."""
+        registry = ToolRegistry()
+
+        def add(a: float, b: float) -> float:
+            """Add two numbers."""
+            return a + b
+
+        registry.register(add, namespace="math")
+        tool = list(registry._tools.values())[0]
+
+        router = APIRouter()
+        _add_route(router, tool, registry)
+
+        assert len(router.routes) == 1
+        route = router.routes[0]
+        # The endpoint should NOT be a coroutine function for sync tools
+        assert not asyncio.iscoroutinefunction(route.endpoint)
+
+    def test_async_endpoint(self):
+        """Async tool should generate an async endpoint."""
+        registry = ToolRegistry()
+
+        async def async_fetch(url: str) -> str:
+            """Fetch a URL."""
+            return f"fetched: {url}"
+
+        registry.register(async_fetch, namespace="net")
+        tool = list(registry._tools.values())[0]
+
+        router = APIRouter()
+        _add_route(router, tool, registry)
+
+        assert len(router.routes) == 1
+        route = router.routes[0]
+        # The endpoint SHOULD be a coroutine function for async tools
+        assert asyncio.iscoroutinefunction(route.endpoint)
+
+
+# =========================================================================
+# 1e. Integration tests
+# =========================================================================
+
+
+class TestIntegration:
+    """Integration tests with create_core_app()."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_registry_singleton(self):
+        """Reset the registry singleton before and after each test."""
+        from toolregistry_hub.server import registry as registry_module
+
+        original = registry_module._registry
+        registry_module._registry = None
+        yield
+        registry_module._registry = original
+
+    def test_core_app_has_auto_routes(self):
+        """create_core_app() should include /tools/ prefix routes."""
+        from toolregistry_hub.server.server_core import create_core_app
+
+        app = create_core_app()
+        paths = [route.path for route in app.routes]
+        tools_paths = [p for p in paths if p.startswith("/tools/")]
+        assert len(tools_paths) > 0, f"Expected /tools/ routes, got paths: {paths}"
+
+    def test_core_app_has_legacy_routes(self):
+        """create_core_app() should still include legacy hand-written routes."""
+        from toolregistry_hub.server.server_core import create_core_app
+
+        app = create_core_app()
+        paths = [route.path for route in app.routes]
+        # Legacy calculator route uses prefix /calc (not /calculator)
+        has_legacy = any(
+            p.startswith("/calc/") and not p.startswith("/tools/") for p in paths
+        )
+        assert has_legacy, f"Expected legacy /calc/ routes, got paths: {paths}"
+
+    def test_calculator_auto_route_works(self):
+        """POST /tools/calculator/evaluate should return the correct result."""
+        from toolregistry_hub.server.server_core import create_core_app
+
+        app = create_core_app()
+        client = TestClient(app)
+
+        response = client.post(
+            "/tools/calculator/evaluate",
+            json={"expression": "2 + 3"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data == 5 or data == 5.0
+
+
+# =========================================================================
+# 1f. Dynamic OpenAPI schema tests
+# =========================================================================
+
+
+def _make_two_tool_registry() -> ToolRegistry:
+    """Create a ToolRegistry with two tools for OpenAPI filtering tests."""
+    registry = ToolRegistry()
+
+    def greet(name: str) -> str:
+        """Say hello."""
+        return f"Hello, {name}!"
+
+    def farewell(name: str) -> str:
+        """Say goodbye."""
+        return f"Goodbye, {name}!"
+
+    registry.register(greet, namespace="test")
+    registry.register(farewell, namespace="test")
+    return registry
+
+
+class TestDynamicOpenAPI:
+    """Tests for setup_dynamic_openapi."""
+
+    def _make_app(self, registry: ToolRegistry) -> FastAPI:
+        """Build a minimal FastAPI app with auto-routes and dynamic OpenAPI."""
+        app = FastAPI(title="Test", version="0.0.1")
+        router = registry_to_router(registry, prefix="/tools")
+        app.include_router(router)
+        setup_dynamic_openapi(app, registry)
+        return app
+
+    def test_openapi_schema_hides_disabled_tools(self):
+        """Disabled tools should not appear in /openapi.json."""
+        registry = _make_two_tool_registry()
+        tool_names = list(registry._tools.keys())
+        # Disable the first tool
+        registry.disable(tool_names[0])
+
+        app = self._make_app(registry)
+        client = TestClient(app)
+
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        schema = response.json()
+
+        # Collect all operationIds in the schema
+        operation_ids = set()
+        for path_item in schema.get("paths", {}).values():
+            for method_detail in path_item.values():
+                if isinstance(method_detail, dict) and "operationId" in method_detail:
+                    operation_ids.add(method_detail["operationId"])
+
+        assert tool_names[0] not in operation_ids, (
+            f"Disabled tool '{tool_names[0]}' should not appear in OpenAPI schema"
+        )
+        assert tool_names[1] in operation_ids, (
+            f"Enabled tool '{tool_names[1]}' should appear in OpenAPI schema"
+        )
+
+    def test_openapi_schema_shows_enabled_tools(self):
+        """All enabled tools should appear in /openapi.json."""
+        registry = _make_two_tool_registry()
+
+        app = self._make_app(registry)
+        client = TestClient(app)
+
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        schema = response.json()
+
+        operation_ids = set()
+        for path_item in schema.get("paths", {}).values():
+            for method_detail in path_item.values():
+                if isinstance(method_detail, dict) and "operationId" in method_detail:
+                    operation_ids.add(method_detail["operationId"])
+
+        for name in registry._tools:
+            assert name in operation_ids, (
+                f"Enabled tool '{name}' should appear in OpenAPI schema"
+            )
+
+    def test_openapi_schema_dynamic_update(self):
+        """Disabling/enabling a tool at runtime should update the schema dynamically."""
+        registry = _make_two_tool_registry()
+        tool_names = list(registry._tools.keys())
+
+        app = self._make_app(registry)
+        client = TestClient(app)
+
+        def _get_operation_ids() -> set:
+            resp = client.get("/openapi.json")
+            assert resp.status_code == 200
+            schema = resp.json()
+            ids = set()
+            for path_item in schema.get("paths", {}).values():
+                for method_detail in path_item.values():
+                    if (
+                        isinstance(method_detail, dict)
+                        and "operationId" in method_detail
+                    ):
+                        ids.add(method_detail["operationId"])
+            return ids
+
+        # Initially both tools should be visible
+        ids = _get_operation_ids()
+        assert tool_names[0] in ids
+        assert tool_names[1] in ids
+
+        # Disable the first tool — it should disappear from the schema
+        registry.disable(tool_names[0])
+        ids = _get_operation_ids()
+        assert tool_names[0] not in ids
+        assert tool_names[1] in ids
+
+        # Re-enable the first tool — it should reappear
+        registry.enable(tool_names[0])
+        ids = _get_operation_ids()
+        assert tool_names[0] in ids
+        assert tool_names[1] in ids
+
+        # Disable both tools — paths should be empty or absent
+        registry.disable(tool_names[0])
+        registry.disable(tool_names[1])
+        ids = _get_operation_ids()
+        assert tool_names[0] not in ids
+        assert tool_names[1] not in ids


### PR DESCRIPTION
## Summary

Implements Phase 5: Auto-route generation from ToolRegistry.

### Changes
- **New**: `autoroute.py` — Automatic FastAPI route generation from registered tools in ToolRegistry
- **Modified**: `server_core.py` — Integrate auto-route into server startup with fallback to manual routes
- **New**: `test_autoroute.py` — Comprehensive tests for autoroute functionality
- **Updated**: `PLAN.md` — Reflect Phase 5 progress

### How it works
The autoroute module introspects tools registered in ToolRegistry and automatically generates FastAPI endpoint handlers, eliminating the need for hand-written route boilerplate.

Closes #31