### PR TITLE
feat: add startup tool configuration via JSONC file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,6 +207,9 @@ marimo/_lsp/
 __marimo__/
 github_refs
 
+# Tool configuration (user-local)
+tools.jsonc
+
 references/
 .kilocode/
 .cline/

--- a/PLAN.md
+++ b/PLAN.md
@@ -1675,6 +1675,72 @@ This is a low-priority optimization — the current per-call connection pattern 
 
 ---
 
+### Startup Tool Configuration (JSONC)
+
+> **Issues:** [Oaklight/toolregistry-hub#37](https://github.com/Oaklight/toolregistry-hub/issues/37)
+
+Add a startup-time configuration file (`tools.jsonc`) that controls which tool namespaces are enabled or disabled when the server starts. This complements the existing `Configurable` auto-disable (Phase 4) and runtime enable/disable (Phase 3) mechanisms.
+
+**Motivation:** Even when a tool is properly configured (has API keys, etc.), an operator may want to restrict which tools are exposed at startup for security or policy reasons (e.g., disabling `filesystem` and `file_ops` in production). The configuration file provides a declarative way to do this without modifying code.
+
+**Dependencies:** Phase 4 (`build_registry()` must exist). Independent of Phase 5+ — works with both legacy and auto-generated routes since it operates at the `ToolRegistry.disable()` level.
+
+#### Format: JSONC (JSON with Comments)
+
+Uses standard library `json` with a lightweight comment-stripping preprocessor (~15 lines of regex). Zero external dependencies across all Python versions.
+
+```jsonc
+{
+    // Startup tool configuration for ToolRegistry Hub.
+    // Mode: "denylist" (default) or "allowlist"
+    "mode": "denylist",
+
+    // Denylist mode: tools to disable at startup
+    "disabled": [
+        "filesystem",      // filesystem operations — security sensitive
+        "file_ops",        // file editing — security sensitive
+        "fetch"            // HTTP requests — may be abused
+    ]
+
+    // Allowlist mode: only enable listed tools
+    // "mode": "allowlist",
+    // "enabled": ["calculator", "datetime", "unit_converter"]
+}
+```
+
+#### Discovery Order
+
+1. CLI argument: `--tools-config path/to/tools.jsonc`
+2. Environment variable: `TOOLS_CONFIG=path/to/tools.jsonc`
+3. Working directory: `./tools.jsonc`
+4. No file found → all tools enabled (backward compatible)
+
+#### Priority Model
+
+```
+Highest priority:  Startup config file (tools.jsonc)
+                   ↓ even if tool is configured, config file can disable it
+Medium priority:   Configurable auto-disable (missing API keys)
+                   ↓ tools without required env vars are auto-disabled
+Lowest priority:   Default state (all enabled)
+
+Runtime override:  Admin API can enable/disable at any time
+                   Server restart re-applies config file state
+```
+
+#### Implementation
+
+| File | Change |
+|------|--------|
+| `src/.../server/tool_config.py` | New: JSONC parser, `ToolConfig` dataclass, `load_tool_config()`, `apply_tool_config()` |
+| `src/.../server/registry.py` | Call `apply_tool_config()` at end of `build_registry()` |
+| `src/.../server/cli.py` | Add `--tools-config` CLI argument |
+| `tools.jsonc.example` | Example configuration file |
+| `.gitignore` | Add `tools.jsonc` (user-local config) |
+| `tests/test_tool_config.py` | Unit tests for denylist/allowlist/discovery/error handling |
+
+---
+
 ## Summary of Changes by Repository
 
 ### `toolregistry`
@@ -1712,6 +1778,7 @@ This is a low-priority optimization — the current per-call connection pattern 
 | `src/.../server/cli.py` | Update MCP mode startup to use new `create_mcp_server()` | 6c |
 | `src/.../server/auth.py` | Migrate from FastMCP `DebugTokenVerifier` to Starlette middleware | 6d |
 | `src/.../server/mcp_compat.py` | New: 集中 FastMCP/DebugTokenVerifier 导入，为 v2 迁移做准备 | Independent |
+| `src/.../server/tool_config.py` | New: JSONC parser, `ToolConfig` dataclass, `load_tool_config()`, `apply_tool_config()` | Independent |
 | `src/.../server/routes/*.py` | Removed in Phase 8 | 8 |
 | `src/.../server/routes/__init__.py` | Remove `discover_routers()` in Phase 8 | 8 |
 
@@ -1756,6 +1823,7 @@ Independent: MCP SDK v2 迁移准备 — compat 层 + 版本上界 (any time, ze
 Independent: Progressive Disclosure for MCP (upstream ToolRegistry, after Phase 6)
 Independent: Remote Tool Source Refresh (depends on Phase 7d for ETag support)
 Independent: Connection Pooling Optimization (low priority, any time)
+Independent: Startup Tool Configuration (JSONC) — depends on Phase 4 only
 ```
 
 ### Risk Mitigation

--- a/src/toolregistry_hub/server/cli.py
+++ b/src/toolregistry_hub/server/cli.py
@@ -127,6 +127,13 @@ def main():
         help="MCP transport mode for mcp mode. Default is streamable-http.",
     )
     parser.add_argument(
+        "--tools-config",
+        type=str,
+        default=None,
+        help="Path to a JSONC tool configuration file (tools.jsonc). "
+        "Controls which tools are enabled/disabled at startup.",
+    )
+    parser.add_argument(
         "--version",
         "-V",
         action="version",
@@ -134,6 +141,15 @@ def main():
         help="Show the version and check for updates",
     )
     args = parser.parse_args()
+
+    # Apply tools config to the registry before starting the server
+    if args.tools_config is not None:
+        from .registry import build_registry
+
+        # Rebuild registry with the specified config path
+        import toolregistry_hub.server.registry as _reg_mod
+
+        _reg_mod._registry = build_registry(tools_config_path=args.tools_config)
 
     if args.mode == "openapi":
         try:

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -54,6 +54,7 @@ ALL_TOOLS: List[Tuple[Type, str]] = [
 
 def build_registry(
     tool_kwargs: Optional[Dict[str, dict]] = None,
+    tools_config_path: Optional[str] = None,
 ) -> ToolRegistry:
     """Build the hub tool registry with all tools registered and auto-disabled
     based on instance configuration state.
@@ -62,13 +63,19 @@ def build_registry(
         tool_kwargs: Optional mapping of namespace to constructor kwargs.
             Allows passing API keys or other config without env vars.
             Example: ``{"brave_search": {"api_keys": "my-key"}}``
+        tools_config_path: Optional path to a JSONC tool configuration file.
+            If ``None``, the default discovery order is used (env var, then
+            ``./tools.jsonc``).
 
     Returns:
         A fully configured ToolRegistry instance with all tools registered.
         Tools whose configuration is incomplete (as reported by the
         :class:`~toolregistry_hub.utils.Configurable` protocol) will be
-        automatically disabled.
+        automatically disabled.  Additional disable/enable rules from the
+        tool configuration file are applied afterwards.
     """
+    from .tool_config import apply_tool_config, load_tool_config
+
     registry = ToolRegistry(name="hub")
 
     for cls, namespace in ALL_TOOLS:
@@ -92,6 +99,11 @@ def build_registry(
                     if tool.namespace == namespace:
                         registry.disable(tool_name, reason=reason)
                 logger.info(f"Disabled {namespace}: {reason}")
+
+    # Apply startup tool configuration (highest priority)
+    config = load_tool_config(tools_config_path)
+    if config is not None:
+        apply_tool_config(registry, config)
 
     return registry
 

--- a/src/toolregistry_hub/server/tool_config.py
+++ b/src/toolregistry_hub/server/tool_config.py
@@ -1,0 +1,249 @@
+"""Startup tool configuration via JSONC files.
+
+Provides a declarative way to control which tool namespaces are enabled or
+disabled when the server starts.  The configuration file uses JSONC format
+(JSON with ``//`` and ``/* */`` comments), parsed with zero external
+dependencies via a lightweight regex preprocessor.
+
+Discovery order:
+    1. Explicit *config_path* argument (from CLI ``--tools-config``)
+    2. ``TOOLS_CONFIG`` environment variable
+    3. ``./tools.jsonc`` in the current working directory
+    4. No file found → ``None`` (all tools enabled, backward compatible)
+
+Priority model::
+
+    Config file  >  Configurable auto-disable  >  Default (all enabled)
+"""
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+from loguru import logger
+from toolregistry import ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# JSONC preprocessor
+# ---------------------------------------------------------------------------
+
+# Matches: double-quoted strings | // line comments | /* block comments */
+_JSONC_RE = re.compile(
+    r'"(?:[^"\\]|\\.)*"'  # double-quoted string (group 0 implicit)
+    r"|//[^\n]*"  # single-line comment
+    r"|/\*.*?\*/",  # block comment (non-greedy)
+    re.DOTALL,
+)
+
+
+def _strip_json_comments(text: str) -> str:
+    """Remove ``//`` and ``/* */`` comments from JSONC text.
+
+    Preserves comment-like content inside double-quoted strings.
+
+    Args:
+        text: Raw JSONC text.
+
+    Returns:
+        Clean JSON text suitable for ``json.loads()``.
+    """
+
+    def _replacer(match: re.Match) -> str:
+        s = match.group(0)
+        if s.startswith('"'):
+            return s  # preserve strings
+        return ""  # strip comments
+
+    return _JSONC_RE.sub(_replacer, text)
+
+
+# ---------------------------------------------------------------------------
+# ToolConfig dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolConfig:
+    """Parsed startup tool configuration.
+
+    Attributes:
+        mode: Either ``"denylist"`` (disable listed namespaces) or
+            ``"allowlist"`` (enable only listed namespaces).
+        disabled: Namespaces to disable (used in denylist mode).
+        enabled: Namespaces to enable (used in allowlist mode).
+        source: Path of the configuration file that was loaded.
+    """
+
+    mode: str = "denylist"
+    disabled: List[str] = field(default_factory=list)
+    enabled: List[str] = field(default_factory=list)
+    source: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Load
+# ---------------------------------------------------------------------------
+
+
+def load_tool_config(config_path: Optional[str] = None) -> Optional[ToolConfig]:
+    """Discover and parse a JSONC tool configuration file.
+
+    Args:
+        config_path: Explicit path to the config file.  If ``None``, the
+            discovery order described in the module docstring is used.
+
+    Returns:
+        A :class:`ToolConfig` instance, or ``None`` if no config file was
+        found (backward-compatible default).
+
+    Raises:
+        ValueError: If the config file exists but contains invalid JSON or
+            has an unrecognised ``mode`` value.
+        FileNotFoundError: If *config_path* is given explicitly but does not
+            exist.
+    """
+    path = _resolve_config_path(config_path)
+    if path is None:
+        return None
+
+    text = path.read_text(encoding="utf-8")
+    clean = _strip_json_comments(text)
+
+    try:
+        data = json.loads(clean)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Config file {path} must contain a JSON object, got {type(data).__name__}"
+        )
+
+    mode = data.get("mode", "denylist")
+    if mode not in ("denylist", "allowlist"):
+        raise ValueError(
+            f"Invalid mode '{mode}' in {path}. Must be 'denylist' or 'allowlist'."
+        )
+
+    disabled = data.get("disabled", [])
+    enabled = data.get("enabled", [])
+
+    if not isinstance(disabled, list) or not all(isinstance(x, str) for x in disabled):
+        raise ValueError(f"'disabled' in {path} must be a list of strings.")
+
+    if not isinstance(enabled, list) or not all(isinstance(x, str) for x in enabled):
+        raise ValueError(f"'enabled' in {path} must be a list of strings.")
+
+    return ToolConfig(
+        mode=mode,
+        disabled=disabled,
+        enabled=enabled,
+        source=str(path),
+    )
+
+
+def _resolve_config_path(config_path: Optional[str]) -> Optional[Path]:
+    """Resolve the configuration file path using the discovery order.
+
+    Args:
+        config_path: Explicit path from CLI argument.
+
+    Returns:
+        Resolved :class:`Path`, or ``None`` if no config file was found.
+
+    Raises:
+        FileNotFoundError: If *config_path* is given but does not exist.
+    """
+    # 1. Explicit CLI argument
+    if config_path is not None:
+        p = Path(config_path)
+        if not p.is_file():
+            raise FileNotFoundError(f"Tools config file not found: {config_path}")
+        return p
+
+    # 2. Environment variable
+    env_path = os.environ.get("TOOLS_CONFIG")
+    if env_path:
+        p = Path(env_path)
+        if p.is_file():
+            return p
+        logger.warning(f"TOOLS_CONFIG={env_path} does not exist, ignoring.")
+
+    # 3. Working directory default
+    default = Path("tools.jsonc")
+    if default.is_file():
+        return default
+
+    # 4. No config found
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+def apply_tool_config(registry: ToolRegistry, config: ToolConfig) -> None:
+    """Apply a :class:`ToolConfig` to a :class:`ToolRegistry`.
+
+    In **denylist** mode, every namespace listed in ``config.disabled`` is
+    disabled.  In **allowlist** mode, every namespace *not* listed in
+    ``config.enabled`` is disabled.
+
+    Args:
+        registry: The registry to modify.
+        config: The parsed tool configuration.
+    """
+    # Collect all known namespaces from the registry
+    namespaces = {
+        tool.namespace
+        for tool in registry._tools.values()
+        if tool.namespace is not None
+    }
+
+    if config.mode == "denylist":
+        _apply_denylist(registry, config.disabled, namespaces)
+    else:
+        _apply_allowlist(registry, config.enabled, namespaces)
+
+    logger.info(f"Applied tool config from {config.source} (mode={config.mode})")
+
+
+def _apply_denylist(
+    registry: ToolRegistry,
+    disabled_namespaces: List[str],
+    known_namespaces: set,
+) -> None:
+    """Disable tools belonging to the listed namespaces."""
+    for ns in disabled_namespaces:
+        if ns not in known_namespaces:
+            logger.warning(f"Config denylist: unknown namespace '{ns}', skipping.")
+            continue
+        for tool_name, tool in registry._tools.items():
+            if tool.namespace == ns:
+                registry.disable(tool_name, reason="Disabled by config file")
+        logger.info(f"Config denylist: disabled namespace '{ns}'")
+
+
+def _apply_allowlist(
+    registry: ToolRegistry,
+    enabled_namespaces: List[str],
+    known_namespaces: set,
+) -> None:
+    """Disable tools whose namespace is NOT in the allow list."""
+    # Warn about unknown namespaces in the allow list
+    for ns in enabled_namespaces:
+        if ns not in known_namespaces:
+            logger.warning(f"Config allowlist: unknown namespace '{ns}', skipping.")
+
+    allowed = set(enabled_namespaces)
+    for tool_name, tool in registry._tools.items():
+        if tool.namespace is not None and tool.namespace not in allowed:
+            registry.disable(tool_name, reason="Not in allowlist")
+            logger.debug(
+                f"Config allowlist: disabled '{tool_name}' (namespace '{tool.namespace}')"
+            )

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -1,0 +1,438 @@
+"""Tests for the startup tool configuration module (JSONC)."""
+
+import json
+import textwrap
+from unittest.mock import MagicMock
+
+import pytest
+
+from toolregistry_hub.server.tool_config import (
+    ToolConfig,
+    _strip_json_comments,
+    apply_tool_config,
+    load_tool_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# _strip_json_comments
+# ---------------------------------------------------------------------------
+
+
+class TestStripJsonComments:
+    """Tests for the JSONC comment stripper."""
+
+    def test_no_comments(self):
+        raw = '{"key": "value"}'
+        assert _strip_json_comments(raw) == raw
+
+    def test_single_line_comment(self):
+        raw = textwrap.dedent("""\
+            {
+                // this is a comment
+                "key": "value"
+            }""")
+        result = _strip_json_comments(raw)
+        data = json.loads(result)
+        assert data == {"key": "value"}
+
+    def test_block_comment(self):
+        raw = textwrap.dedent("""\
+            {
+                /* block comment */
+                "key": "value"
+            }""")
+        result = _strip_json_comments(raw)
+        data = json.loads(result)
+        assert data == {"key": "value"}
+
+    def test_multiline_block_comment(self):
+        raw = textwrap.dedent("""\
+            {
+                /*
+                 * multi-line
+                 * block comment
+                 */
+                "key": "value"
+            }""")
+        result = _strip_json_comments(raw)
+        data = json.loads(result)
+        assert data == {"key": "value"}
+
+    def test_inline_comment(self):
+        raw = '{"key": "value"} // trailing comment'
+        result = _strip_json_comments(raw)
+        data = json.loads(result)
+        assert data == {"key": "value"}
+
+    def test_comment_like_in_string_preserved(self):
+        raw = '{"url": "http://example.com"}'
+        result = _strip_json_comments(raw)
+        data = json.loads(result)
+        assert data == {"url": "http://example.com"}
+
+    def test_double_slash_in_string_preserved(self):
+        raw = '{"msg": "use // for comments"}'
+        result = _strip_json_comments(raw)
+        data = json.loads(result)
+        assert data == {"msg": "use // for comments"}
+
+    def test_escaped_quotes_in_string(self):
+        raw = r'{"msg": "say \"hello\""}'
+        result = _strip_json_comments(raw)
+        data = json.loads(result)
+        assert data == {"msg": 'say "hello"'}
+
+    def test_mixed_comments(self):
+        raw = textwrap.dedent("""\
+            {
+                // line comment
+                "a": 1, /* inline block */
+                "b": "// not a comment",
+                /* another
+                   block */
+                "c": true
+            }""")
+        result = _strip_json_comments(raw)
+        data = json.loads(result)
+        assert data == {"a": 1, "b": "// not a comment", "c": True}
+
+
+# ---------------------------------------------------------------------------
+# load_tool_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadToolConfig:
+    """Tests for config file loading and parsing."""
+
+    def test_no_config_returns_none(self, tmp_path, monkeypatch):
+        """No config file anywhere → returns None."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("TOOLS_CONFIG", raising=False)
+        assert load_tool_config() is None
+
+    def test_explicit_path(self, tmp_path):
+        """Explicit path loads the file."""
+        cfg = tmp_path / "my_config.jsonc"
+        cfg.write_text('{"mode": "denylist", "disabled": ["fetch"]}')
+        result = load_tool_config(str(cfg))
+        assert result is not None
+        assert result.mode == "denylist"
+        assert result.disabled == ["fetch"]
+        assert result.source == str(cfg)
+
+    def test_explicit_path_not_found(self):
+        """Explicit path that doesn't exist raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_tool_config("/nonexistent/path/tools.jsonc")
+
+    def test_env_var_discovery(self, tmp_path, monkeypatch):
+        """TOOLS_CONFIG env var is used for discovery."""
+        cfg = tmp_path / "env_config.jsonc"
+        cfg.write_text('{"mode": "allowlist", "enabled": ["calculator"]}')
+        monkeypatch.setenv("TOOLS_CONFIG", str(cfg))
+        monkeypatch.chdir(tmp_path)
+        result = load_tool_config()
+        assert result is not None
+        assert result.mode == "allowlist"
+        assert result.enabled == ["calculator"]
+
+    def test_env_var_nonexistent_warns(self, tmp_path, monkeypatch, caplog):
+        """TOOLS_CONFIG pointing to nonexistent file logs warning."""
+        monkeypatch.setenv("TOOLS_CONFIG", "/nonexistent/tools.jsonc")
+        monkeypatch.chdir(tmp_path)
+        result = load_tool_config()
+        assert result is None
+
+    def test_working_dir_discovery(self, tmp_path, monkeypatch):
+        """./tools.jsonc in working directory is discovered."""
+        cfg = tmp_path / "tools.jsonc"
+        cfg.write_text('{"mode": "denylist", "disabled": ["filesystem"]}')
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("TOOLS_CONFIG", raising=False)
+        result = load_tool_config()
+        assert result is not None
+        assert result.disabled == ["filesystem"]
+
+    def test_default_mode_is_denylist(self, tmp_path):
+        """Missing 'mode' key defaults to denylist."""
+        cfg = tmp_path / "config.jsonc"
+        cfg.write_text('{"disabled": ["fetch"]}')
+        result = load_tool_config(str(cfg))
+        assert result is not None
+        assert result.mode == "denylist"
+
+    def test_invalid_mode_raises(self, tmp_path):
+        """Invalid mode value raises ValueError."""
+        cfg = tmp_path / "config.jsonc"
+        cfg.write_text('{"mode": "blocklist"}')
+        with pytest.raises(ValueError, match="Invalid mode"):
+            load_tool_config(str(cfg))
+
+    def test_invalid_json_raises(self, tmp_path):
+        """Malformed JSON raises ValueError."""
+        cfg = tmp_path / "config.jsonc"
+        cfg.write_text("{invalid json}")
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            load_tool_config(str(cfg))
+
+    def test_non_object_raises(self, tmp_path):
+        """Top-level array raises ValueError."""
+        cfg = tmp_path / "config.jsonc"
+        cfg.write_text('["not", "an", "object"]')
+        with pytest.raises(ValueError, match="must contain a JSON object"):
+            load_tool_config(str(cfg))
+
+    def test_disabled_not_list_raises(self, tmp_path):
+        """'disabled' as a string raises ValueError."""
+        cfg = tmp_path / "config.jsonc"
+        cfg.write_text('{"disabled": "fetch"}')
+        with pytest.raises(ValueError, match="must be a list"):
+            load_tool_config(str(cfg))
+
+    def test_enabled_not_list_raises(self, tmp_path):
+        """'enabled' as a number raises ValueError."""
+        cfg = tmp_path / "config.jsonc"
+        cfg.write_text('{"mode": "allowlist", "enabled": 42}')
+        with pytest.raises(ValueError, match="must be a list"):
+            load_tool_config(str(cfg))
+
+    def test_jsonc_with_comments(self, tmp_path):
+        """Full JSONC file with comments parses correctly."""
+        cfg = tmp_path / "config.jsonc"
+        cfg.write_text(
+            textwrap.dedent("""\
+            {
+                // Startup config
+                "mode": "denylist",
+                /* Security: disable filesystem access */
+                "disabled": [
+                    "filesystem",  // fs ops
+                    "file_ops"     // file editing
+                ]
+            }""")
+        )
+        result = load_tool_config(str(cfg))
+        assert result is not None
+        assert result.mode == "denylist"
+        assert result.disabled == ["filesystem", "file_ops"]
+
+    def test_discovery_priority_cli_over_env(self, tmp_path, monkeypatch):
+        """CLI path takes priority over TOOLS_CONFIG env var."""
+        cli_cfg = tmp_path / "cli.jsonc"
+        cli_cfg.write_text('{"disabled": ["fetch"]}')
+        env_cfg = tmp_path / "env.jsonc"
+        env_cfg.write_text('{"disabled": ["filesystem"]}')
+        monkeypatch.setenv("TOOLS_CONFIG", str(env_cfg))
+        result = load_tool_config(str(cli_cfg))
+        assert result is not None
+        assert result.disabled == ["fetch"]
+
+    def test_empty_config(self, tmp_path):
+        """Empty object is valid — no tools disabled."""
+        cfg = tmp_path / "config.jsonc"
+        cfg.write_text("{}")
+        result = load_tool_config(str(cfg))
+        assert result is not None
+        assert result.mode == "denylist"
+        assert result.disabled == []
+        assert result.enabled == []
+
+
+# ---------------------------------------------------------------------------
+# apply_tool_config
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_registry(namespaces):
+    """Create a mock ToolRegistry with tools in the given namespaces.
+
+    Each namespace gets one tool named ``{namespace}-method``.
+    """
+    registry = MagicMock()
+    tools = {}
+    for ns in namespaces:
+        tool = MagicMock()
+        tool.namespace = ns
+        tool.name = f"{ns}-method"
+        tools[f"{ns}-method"] = tool
+    registry._tools = tools
+    registry.is_enabled = MagicMock(return_value=True)
+    registry.disable = MagicMock()
+    return registry
+
+
+class TestApplyToolConfig:
+    """Tests for applying config to a registry."""
+
+    def test_denylist_disables_listed(self):
+        """Denylist mode disables tools in listed namespaces."""
+        registry = _make_mock_registry(
+            ["calculator", "datetime", "filesystem", "file_ops"]
+        )
+        config = ToolConfig(
+            mode="denylist",
+            disabled=["filesystem", "file_ops"],
+            source="test",
+        )
+        apply_tool_config(registry, config)
+
+        # Should have called disable for filesystem-method and file_ops-method
+        disabled_names = [call.args[0] for call in registry.disable.call_args_list]
+        assert "filesystem-method" in disabled_names
+        assert "file_ops-method" in disabled_names
+        assert "calculator-method" not in disabled_names
+        assert "datetime-method" not in disabled_names
+
+    def test_denylist_unknown_namespace_warns(self, caplog):
+        """Denylist with unknown namespace logs a warning."""
+        registry = _make_mock_registry(["calculator"])
+        config = ToolConfig(
+            mode="denylist",
+            disabled=["nonexistent"],
+            source="test",
+        )
+        apply_tool_config(registry, config)
+        # No disable calls for unknown namespace
+        assert registry.disable.call_count == 0
+
+    def test_allowlist_disables_unlisted(self):
+        """Allowlist mode disables tools NOT in the allow list."""
+        registry = _make_mock_registry(
+            ["calculator", "datetime", "filesystem", "fetch"]
+        )
+        config = ToolConfig(
+            mode="allowlist",
+            enabled=["calculator", "datetime"],
+            source="test",
+        )
+        apply_tool_config(registry, config)
+
+        disabled_names = [call.args[0] for call in registry.disable.call_args_list]
+        assert "filesystem-method" in disabled_names
+        assert "fetch-method" in disabled_names
+        assert "calculator-method" not in disabled_names
+        assert "datetime-method" not in disabled_names
+
+    def test_allowlist_unknown_namespace_warns(self, caplog):
+        """Allowlist with unknown namespace logs a warning."""
+        registry = _make_mock_registry(["calculator"])
+        config = ToolConfig(
+            mode="allowlist",
+            enabled=["calculator", "nonexistent"],
+            source="test",
+        )
+        apply_tool_config(registry, config)
+        # calculator should NOT be disabled
+        disabled_names = [call.args[0] for call in registry.disable.call_args_list]
+        assert "calculator-method" not in disabled_names
+
+    def test_empty_denylist_disables_nothing(self):
+        """Empty denylist leaves all tools enabled."""
+        registry = _make_mock_registry(["calculator", "datetime"])
+        config = ToolConfig(mode="denylist", disabled=[], source="test")
+        apply_tool_config(registry, config)
+        assert registry.disable.call_count == 0
+
+    def test_empty_allowlist_disables_everything(self):
+        """Empty allowlist disables all tools."""
+        registry = _make_mock_registry(["calculator", "datetime"])
+        config = ToolConfig(mode="allowlist", enabled=[], source="test")
+        apply_tool_config(registry, config)
+        assert registry.disable.call_count == 2
+
+    def test_denylist_multiple_tools_per_namespace(self):
+        """Denylist disables all tools in a namespace, not just one."""
+        registry = MagicMock()
+        tools = {}
+        for method in ["add", "subtract", "multiply"]:
+            tool = MagicMock()
+            tool.namespace = "calculator"
+            tool.name = f"calculator-{method}"
+            tools[f"calculator-{method}"] = tool
+        registry._tools = tools
+        registry.disable = MagicMock()
+
+        config = ToolConfig(
+            mode="denylist",
+            disabled=["calculator"],
+            source="test",
+        )
+        apply_tool_config(registry, config)
+
+        disabled_names = [call.args[0] for call in registry.disable.call_args_list]
+        assert "calculator-add" in disabled_names
+        assert "calculator-subtract" in disabled_names
+        assert "calculator-multiply" in disabled_names
+
+
+# ---------------------------------------------------------------------------
+# Integration: build_registry with config
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRegistryWithConfig:
+    """Integration tests for build_registry with tools_config_path."""
+
+    def test_build_registry_with_denylist(self, tmp_path):
+        """build_registry applies denylist config."""
+        cfg = tmp_path / "tools.jsonc"
+        cfg.write_text(
+            textwrap.dedent("""\
+            {
+                "mode": "denylist",
+                "disabled": ["calculator", "datetime"]
+            }""")
+        )
+
+        from toolregistry_hub.server.registry import build_registry
+
+        registry = build_registry(tools_config_path=str(cfg))
+
+        # calculator and datetime tools should be disabled
+        for tool_name, tool in registry._tools.items():
+            if tool.namespace in ("calculator", "datetime"):
+                assert not registry.is_enabled(tool_name), (
+                    f"{tool_name} should be disabled"
+                )
+
+    def test_build_registry_with_allowlist(self, tmp_path):
+        """build_registry applies allowlist config."""
+        cfg = tmp_path / "tools.jsonc"
+        cfg.write_text(
+            textwrap.dedent("""\
+            {
+                "mode": "allowlist",
+                "enabled": ["calculator"]
+            }""")
+        )
+
+        from toolregistry_hub.server.registry import build_registry
+
+        registry = build_registry(tools_config_path=str(cfg))
+
+        # Only calculator tools should be enabled
+        for tool_name, tool in registry._tools.items():
+            if tool.namespace == "calculator":
+                assert registry.is_enabled(tool_name), f"{tool_name} should be enabled"
+            elif tool.namespace is not None:
+                assert not registry.is_enabled(tool_name), (
+                    f"{tool_name} should be disabled (not in allowlist)"
+                )
+
+    def test_build_registry_no_config(self, tmp_path, monkeypatch):
+        """build_registry without config leaves all configured tools enabled."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("TOOLS_CONFIG", raising=False)
+
+        from toolregistry_hub.server.registry import build_registry
+
+        registry = build_registry()
+
+        # Static-method tools (calculator, datetime, etc.) should be enabled
+        for tool_name, tool in registry._tools.items():
+            if tool.namespace == "calculator":
+                assert registry.is_enabled(tool_name), (
+                    f"{tool_name} should be enabled without config"
+                )

--- a/tools.jsonc.example
+++ b/tools.jsonc.example
@@ -1,0 +1,35 @@
+{
+  // Startup tool configuration for ToolRegistry Hub.
+  //
+  // Copy this file to "tools.jsonc" and customize as needed.
+  // The server discovers this file automatically from the working directory,
+  // or you can specify a path via:
+  //   --tools-config path/to/tools.jsonc
+  //   TOOLS_CONFIG=path/to/tools.jsonc
+  //
+  // Mode: "denylist" (default) or "allowlist"
+  //   - denylist: all tools enabled except those listed in "disabled"
+  //   - allowlist: only tools listed in "enabled" are active
+
+  "mode": "denylist",
+
+  // --- Denylist mode ---
+  // List namespaces to disable at startup.
+  // Available namespaces:
+  //   calculator, datetime, fetch, filesystem, file_ops,
+  //   think, todolist, unit_converter,
+  //   brave_search, tavily_search, searxng_search,
+  //   brightdata_search, scrapeless_search
+  "disabled": [
+    "filesystem", // filesystem operations — security sensitive
+    "file_ops" // file editing — security sensitive
+  ]
+
+  // --- Allowlist mode ---
+  // Uncomment below and set mode to "allowlist" to enable only listed tools.
+  // "enabled": [
+  //     "calculator",
+  //     "datetime",
+  //     "unit_converter"
+  // ]
+}


### PR DESCRIPTION
## Summary

Add startup tool configuration support via JSONC (JSON with Comments) file, allowing users to declaratively specify which tools to load at server startup.

Closes #37

## Changes

- **New**: `src/toolregistry_hub/server/tool_config.py` - JSONC parser and tool configuration loader
- **New**: `tools.jsonc.example` - Example configuration file with documentation
- **New**: `tests/test_tool_config.py` - Comprehensive tests for tool config module
- **Modified**: `src/toolregistry_hub/server/registry.py` - Integrate tool config loading into registry
- **Modified**: `src/toolregistry_hub/server/cli.py` - Add `--tools-config` CLI option
- **Modified**: `.gitignore` - Ignore `tools.jsonc` (user config)
- **Modified**: `PLAN.md` - Implementation plan documentation

## Features

- JSONC format support (JSON with single-line and block comments)
- Selective tool loading via configuration file
- CLI option `--tools-config` to specify config file path
- Graceful fallback: loads all tools if no config file specified
- Comprehensive error handling and logging