### PR TITLE
Replace pyright with ty for type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "ty>=0.0.21",
     "python-dotenv>=1.0.1",
-    "pyright>=1.1.402",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
     "pytest>=7.0.0",
@@ -67,3 +67,9 @@ version = { attr = "toolregistry_hub.__version__" }
 
 [project.scripts]
 toolregistry-server = "toolregistry_hub.server.cli:main"
+
+[tool.ty.environment]
+python-version = "3.12"
+
+[tool.ty.src]
+include = ["src", "tests"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,8 +1,0 @@
-{
-  "reportMissingImports": false,
-  "reportMissingTypeStubs": false,
-  "reportAttributeAccessIssue": false,
-  "pythonVersion": "3.12",
-  "include": ["src", "tests"],
-  "typeCheckingMode": "basic"
-}

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -213,7 +213,7 @@ def _get_content_with_markdown_negotiation(
         str: Markdown content if the server supports it, otherwise empty string.
     """
     try:
-        ua = ua_generator.generate(browser=["chrome", "edge"])  # type: ignore
+        ua = ua_generator.generate(browser=["chrome", "edge"])
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         headers = ua.headers.get()
         headers["Accept"] = "text/markdown"
@@ -387,7 +387,7 @@ def _get_content_with_bs4(
         str: Parsed text content of the webpage.
     """
     try:
-        ua = ua_generator.generate(browser=["chrome", "edge"])  # type: ignore
+        ua = ua_generator.generate(browser=["chrome", "edge"])
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         response = httpx.get(
             url,

--- a/src/toolregistry_hub/filesystem.py
+++ b/src/toolregistry_hub/filesystem.py
@@ -88,8 +88,8 @@ class FileSystem:
         # On Windows, also check the hidden attribute
         if os.name == "nt":
             try:
-                attrs = path_obj.stat().st_file_attributes  # type: ignore
-                if attrs & stat.FILE_ATTRIBUTE_HIDDEN:  # type: ignore
+                attrs = path_obj.stat().st_file_attributes
+                if attrs & stat.FILE_ATTRIBUTE_HIDDEN:
                     return True
             except OSError:  # Handle potential errors like permission denied
                 return True  # Treat as hidden if attributes can't be read

--- a/src/toolregistry_hub/server/autoroute.py
+++ b/src/toolregistry_hub/server/autoroute.py
@@ -53,7 +53,7 @@ def _resolve_type(field_schema: Dict[str, Any]) -> Type:
         from typing import Literal  # noqa: UP035 – needed at runtime
 
         values = tuple(field_schema["enum"])
-        return Literal[values]  # type: ignore[valid-type]
+        return Literal[values]  # ty: ignore[invalid-type-form]
 
     json_type = field_schema.get("type")
 
@@ -61,7 +61,7 @@ def _resolve_type(field_schema: Dict[str, Any]) -> Type:
         items_schema = field_schema.get("items")
         if items_schema:
             inner = _resolve_type(items_schema)
-            return List[inner]  # type: ignore[valid-type]
+            return List[inner]  # ty: ignore[invalid-type-form]
         return list
 
     if json_type == "object" and "properties" in field_schema:
@@ -69,7 +69,7 @@ def _resolve_type(field_schema: Dict[str, Any]) -> Type:
         return _schema_to_pydantic("NestedModel", field_schema)
 
     if json_type is not None:
-        return _JSON_TYPE_MAP.get(json_type, Any)  # type: ignore[return-value]
+        return _JSON_TYPE_MAP.get(json_type, Any)
 
     # anyOf / oneOf patterns (e.g. Optional fields from toolregistry)
     any_of = field_schema.get("anyOf") or field_schema.get("oneOf")
@@ -78,7 +78,7 @@ def _resolve_type(field_schema: Dict[str, Any]) -> Type:
         if len(non_null) == 1:
             return _resolve_type(non_null[0])
 
-    return Any  # type: ignore[return-value]
+    return Any
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +101,7 @@ def _schema_to_pydantic(name: str, schema: Dict[str, Any]) -> Type[BaseModel]:
     properties: Dict[str, Any] = schema.get("properties", {})
     if not properties:
         # Return an empty model when there are no properties
-        return create_model(name)  # type: ignore[call-overload]
+        return create_model(name)
 
     required_fields: List[str] = schema.get("required", [])
     field_definitions: Dict[str, Tuple[Type, Any]] = {}
@@ -125,7 +125,7 @@ def _schema_to_pydantic(name: str, schema: Dict[str, Any]) -> Type[BaseModel]:
                 Field(default=default_value, **field_kwargs),
             )
 
-    return create_model(name, **field_definitions)  # type: ignore[call-overload]
+    return create_model(name, **field_definitions)  # ty: ignore[no-matching-overload]
 
 
 # ---------------------------------------------------------------------------
@@ -198,11 +198,11 @@ def _add_route(router: APIRouter, tool: Tool, registry: ToolRegistry) -> None:
 
         def _make_async_endpoint(
             t: Tool = tool,
-            M: Type[BaseModel] = request_model,  # type: ignore[assignment]
+            M: Type[BaseModel] = request_model,
             reg: ToolRegistry = registry,
             tname: str = tool_name,
         ):
-            async def _endpoint(data: M) -> Any:  # type: ignore[valid-type]
+            async def _endpoint(data: M) -> Any:  # ty: ignore[invalid-type-form]
                 if not reg.is_enabled(tname):
                     raise HTTPException(
                         status_code=503,
@@ -218,17 +218,17 @@ def _add_route(router: APIRouter, tool: Tool, registry: ToolRegistry) -> None:
             methods=["POST"],
             operation_id=tool.name,
             summary=summary,
-            tags=tags,
+            tags=tags,  # ty: ignore[invalid-argument-type]
         )
     else:
 
         def _make_sync_endpoint(
             t: Tool = tool,
-            M: Type[BaseModel] = request_model,  # type: ignore[assignment]
+            M: Type[BaseModel] = request_model,
             reg: ToolRegistry = registry,
             tname: str = tool_name,
         ):
-            def _endpoint(data: M) -> Any:  # type: ignore[valid-type]
+            def _endpoint(data: M) -> Any:  # ty: ignore[invalid-type-form]
                 if not reg.is_enabled(tname):
                     raise HTTPException(
                         status_code=503,
@@ -244,7 +244,7 @@ def _add_route(router: APIRouter, tool: Tool, registry: ToolRegistry) -> None:
             methods=["POST"],
             operation_id=tool.name,
             summary=summary,
-            tags=tags,
+            tags=tags,  # ty: ignore[invalid-argument-type]
         )
 
     logger.debug(f"Auto-route registered: POST {router.prefix}{path} → {tool.name}")
@@ -335,4 +335,4 @@ def setup_dynamic_openapi(app: FastAPI, registry: ToolRegistry) -> None:
         # is regenerated on every request, reflecting runtime changes.
         return openapi_schema
 
-    app.openapi = custom_openapi  # type: ignore[method-assign]
+    app.openapi = custom_openapi  # ty: ignore[invalid-assignment]

--- a/src/toolregistry_hub/utils/requirements.py
+++ b/src/toolregistry_hub/utils/requirements.py
@@ -30,7 +30,7 @@ def requires_env(*envs: str):
     """
 
     def decorator(cls: Type) -> Type:
-        cls._required_envs = list(envs)
+        setattr(cls, "_required_envs", list(envs))
         return cls
 
     return decorator

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -28,7 +28,7 @@ class BaseSearch(ABC):
             True if the instance is properly configured, False otherwise.
         """
         if hasattr(self, "api_key_parser"):
-            return bool(self.api_key_parser.api_keys)
+            return bool(getattr(self, "api_key_parser").api_keys)
         return True
 
     @property

--- a/src/toolregistry_hub/websearch/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch/websearch_searxng.py
@@ -163,6 +163,7 @@ class SearXNGSearch(BaseSearch):
                 params[param] = kwargs[param]
 
         timeout = kwargs.get("timeout", TIMEOUT_DEFAULT)
+        assert self.search_url is not None  # validated in search()
         try:
             with httpx.Client(timeout=timeout) as client:
                 response = client.get(

--- a/src/toolregistry_hub/websearch_legacy/websearch_bing.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_bing.py
@@ -189,7 +189,7 @@ class WebSearchBing(WebSearchGeneral):
         fetched_links: Set[str] = set()
 
         # Create a persistent client with connection pooling
-        ua = ua_generator.generate(browser=["chrome", "edge"])  # type: ignore
+        ua = ua_generator.generate(browser=["chrome", "edge"])
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         with httpx.Client(
             proxy=proxy,

--- a/src/toolregistry_hub/websearch_legacy/websearch_google.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_google.py
@@ -134,7 +134,7 @@ class WebSearchGoogle(WebSearchGeneral):
         fetched_links: Set[str] = set()
 
         # Create a persistent client with connection pooling
-        ua = ua_generator.generate(device="mobile")  # type: ignore
+        ua = ua_generator.generate(device="mobile")
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         with httpx.Client(
             proxy=proxy,

--- a/src/toolregistry_hub/websearch_legacy/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_searxng.py
@@ -141,7 +141,7 @@ class WebSearchSearXNG(WebSearchGeneral):
         """
         Perform a search using SearXNG and return the results.
         """
-        ua = ua_generator.generate(browser=["chrome", "edge"])  # type: ignore
+        ua = ua_generator.generate(browser=["chrome", "edge"])
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         response = httpx.get(
             searxng_base_url,

--- a/tests/test_autoroute.py
+++ b/tests/test_autoroute.py
@@ -103,8 +103,8 @@ class TestSchemaToPydantic:
 
         # Instantiate with defaults
         instance = Model()
-        assert instance.count == 10
-        assert instance.label == "hello"
+        assert instance.count == 10  # ty: ignore[unresolved-attribute]
+        assert instance.label == "hello"  # ty: ignore[unresolved-attribute]
 
     def test_array_type(self):
         """Array with items should map to List[inner_type]."""
@@ -299,7 +299,7 @@ class TestRegistryToRouter:
         registry = _make_simple_registry()
         router = registry_to_router(registry, prefix="/tools")
 
-        paths = [route.path for route in router.routes]
+        paths = [route.path for route in router.routes]  # ty: ignore[unresolved-attribute]
         # The tool registered with namespace="test" and function name "greet"
         # should produce path /test/greet
         assert any("/test/greet" in p for p in paths)
@@ -330,7 +330,7 @@ class TestAddRoute:
         assert len(router.routes) == 1
         route = router.routes[0]
         # The endpoint should NOT be a coroutine function for sync tools
-        assert not asyncio.iscoroutinefunction(route.endpoint)
+        assert not asyncio.iscoroutinefunction(route.endpoint)  # ty: ignore[unresolved-attribute]
 
     def test_async_endpoint(self):
         """Async tool should generate an async endpoint."""
@@ -349,7 +349,7 @@ class TestAddRoute:
         assert len(router.routes) == 1
         route = router.routes[0]
         # The endpoint SHOULD be a coroutine function for async tools
-        assert asyncio.iscoroutinefunction(route.endpoint)
+        assert asyncio.iscoroutinefunction(route.endpoint)  # ty: ignore[unresolved-attribute]
 
 
 # =========================================================================
@@ -375,7 +375,7 @@ class TestIntegration:
         from toolregistry_hub.server.server_core import create_core_app
 
         app = create_core_app()
-        paths = [route.path for route in app.routes]
+        paths = [route.path for route in app.routes]  # ty: ignore[unresolved-attribute]
         tools_paths = [p for p in paths if p.startswith("/tools/")]
         assert len(tools_paths) > 0, f"Expected /tools/ routes, got paths: {paths}"
 
@@ -384,7 +384,7 @@ class TestIntegration:
         from toolregistry_hub.server.server_core import create_core_app
 
         app = create_core_app()
-        paths = [route.path for route in app.routes]
+        paths = [route.path for route in app.routes]  # ty: ignore[unresolved-attribute]
         has_version = any(p.startswith("/version") for p in paths)
         assert has_version, f"Expected /version routes, got paths: {paths}"
 

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -142,8 +142,8 @@ class TestDateTime:
         result = DateTime.convert_timezone("12:00", "UTC", "UTC")
 
         # Times should be identical (or very close due to processing time)
-        source_dt = datetime.fromisoformat(result["source_time"])
-        target_dt = datetime.fromisoformat(result["target_time"])
+        _ = datetime.fromisoformat(result["source_time"])
+        _ = datetime.fromisoformat(result["target_time"])
 
         # Time difference should be 0 hours
         assert (

--- a/tests/test_requires_env.py
+++ b/tests/test_requires_env.py
@@ -22,7 +22,7 @@ class TestRequiresEnv(unittest.TestCase):
             pass
 
         self.assertTrue(hasattr(MyTool, "_required_envs"))
-        self.assertEqual(MyTool._required_envs, ["MY_API_KEY"])
+        self.assertEqual(MyTool._required_envs, ["MY_API_KEY"])  # ty: ignore[unresolved-attribute]
 
     def test_decorator_multiple_envs(self):
         """Test that requires_env supports multiple environment variables."""
@@ -31,7 +31,7 @@ class TestRequiresEnv(unittest.TestCase):
         class MultiEnvTool:
             pass
 
-        self.assertEqual(MultiEnvTool._required_envs, ["KEY_A", "KEY_B", "KEY_C"])
+        self.assertEqual(MultiEnvTool._required_envs, ["KEY_A", "KEY_B", "KEY_C"])  # ty: ignore[unresolved-attribute]
 
     def test_undecorated_class_has_no_required_envs(self):
         """Test that undecorated classes do not have _required_envs attribute."""
@@ -77,11 +77,11 @@ class TestRequiresEnv(unittest.TestCase):
             TavilySearch,
         )
 
-        self.assertEqual(BraveSearch._required_envs, ["BRAVE_API_KEY"])
-        self.assertEqual(TavilySearch._required_envs, ["TAVILY_API_KEY"])
-        self.assertEqual(SearXNGSearch._required_envs, ["SEARXNG_URL"])
-        self.assertEqual(BrightDataSearch._required_envs, ["BRIGHTDATA_API_KEY"])
-        self.assertEqual(ScrapelessSearch._required_envs, ["SCRAPELESS_API_KEY"])
+        self.assertEqual(BraveSearch._required_envs, ["BRAVE_API_KEY"])  # ty: ignore[unresolved-attribute]
+        self.assertEqual(TavilySearch._required_envs, ["TAVILY_API_KEY"])  # ty: ignore[unresolved-attribute]
+        self.assertEqual(SearXNGSearch._required_envs, ["SEARXNG_URL"])  # ty: ignore[unresolved-attribute]
+        self.assertEqual(BrightDataSearch._required_envs, ["BRIGHTDATA_API_KEY"])  # ty: ignore[unresolved-attribute]
+        self.assertEqual(ScrapelessSearch._required_envs, ["SCRAPELESS_API_KEY"])  # ty: ignore[unresolved-attribute]
 
 
 class TestConfigurableProtocol(unittest.TestCase):

--- a/tests/test_todo_list_objects.py
+++ b/tests/test_todo_list_objects.py
@@ -93,7 +93,7 @@ def test_todolist_update_non_string_input():
     """Test update with non-string todo items."""
     todos = [123, "[task1] Task one (planned)"]
     with pytest.raises(TypeError, match="must be a string"):
-        TodoList.update(todos)
+        TodoList.update(todos)  # ty: ignore[invalid-argument-type]
 
 
 def test_escape_pipe_in_content():

--- a/tests/websearch/test_brightdata_engines.py
+++ b/tests/websearch/test_brightdata_engines.py
@@ -35,9 +35,7 @@ def build_search_url(engine: str, query: str, page: int = 0) -> str:
         return f"https://www.google.com/search?q={q}&start={start}"
 
 
-def run_engine_format(
-    engine: str, data_format: str, query: str = "python programming"
-):
+def run_engine_format(engine: str, data_format: str, query: str = "python programming"):
     """Run a specific engine with a specific data format (manual test helper)."""
     api_token = os.getenv("BRIGHTDATA_API_KEY")
     if not api_token:

--- a/tests/websearch/test_websearch_brightdata.py
+++ b/tests/websearch/test_websearch_brightdata.py
@@ -4,7 +4,6 @@ import json
 from unittest.mock import MagicMock, patch
 
 import httpx
-import pytest
 
 from toolregistry_hub.websearch.search_result import SearchResult
 from toolregistry_hub.websearch.websearch_brightdata import BrightDataSearch

--- a/tests/websearch/test_websearch_scrapeless.py
+++ b/tests/websearch/test_websearch_scrapeless.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock, patch
 
 import httpx
-import pytest
 
 from toolregistry_hub.websearch.search_result import SearchResult
 from toolregistry_hub.websearch.websearch_scrapeless import ScrapelessSearch

--- a/tests/websearch/test_websearch_searxng.py
+++ b/tests/websearch/test_websearch_searxng.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock, patch
 
 import httpx
-import pytest
 
 from toolregistry_hub.websearch.search_result import SearchResult
 from toolregistry_hub.websearch.websearch_searxng import SearXNGSearch


### PR DESCRIPTION
## Summary

Replace pyright with ty (Astral's Python type checker) as the project's type checking tool.

### Changes:
- Replace `pyright>=1.1.402` with `ty>=0.0.21` in dev dependencies
- Delete `pyrightconfig.json`, add `[tool.ty]` configuration in `pyproject.toml`
- Fix type errors detected by ty in source code:
  - Use `setattr()` / `getattr()` for dynamically added attributes
  - Add assertions for None checks
  - Remove unused `# type: ignore` comments
- Add `# ty: ignore` for legitimate dynamic type patterns (autoroute.py metaprogramming, test files)
- Run `ruff check --fix` and `ruff format` on all modified files

Closes #45