### PR TITLE
feat!: replace diff-based editing with exact string replacement in FileOps

### DIFF
--- a/src/toolregistry_hub/file_ops.py
+++ b/src/toolregistry_hub/file_ops.py
@@ -5,8 +5,8 @@ Key features:
 - All methods are static for stateless usage
 - Atomic writes with automatic backups
 - Unified error handling
-- Diff/patch and git conflict support
-- Structured data parsing
+- Exact string replacement with disambiguation support
+- Encoding and line ending preservation
 """
 
 import difflib
@@ -18,73 +18,151 @@ import re
 class FileOps:
     """Core file operations toolkit designed for LLM agent integration.
 
-    Handles file reading, atomic writing, appending, searching, and diff-based modifications.
+    Handles file reading, atomic writing, appending, searching, and exact
+    string replacement for file editing.
     """
+
+    # ======================
+    #  Internal Helpers
+    # ======================
+
+    @staticmethod
+    def _detect_encoding(raw: bytes) -> tuple[str, bytes]:
+        """Detect file encoding from BOM bytes.
+
+        Args:
+            raw: Raw file bytes.
+
+        Returns:
+            Tuple of (encoding_name, bom_bytes). For utf-8-sig the codec
+            handles BOM transparently so bom is empty.
+        """
+        if raw.startswith(b"\xef\xbb\xbf"):
+            return ("utf-8-sig", b"")
+        if raw.startswith(b"\xff\xfe"):
+            return ("utf-16-le", b"\xff\xfe")
+        if raw.startswith(b"\xfe\xff"):
+            return ("utf-16-be", b"\xfe\xff")
+        return ("utf-8", b"")
+
+    @staticmethod
+    def _detect_line_ending(text: str) -> str:
+        """Detect dominant line ending in text.
+
+        Args:
+            text: Decoded file content.
+
+        Returns:
+            '\\r\\n' if CRLF is dominant, otherwise '\\n'.
+        """
+        crlf_count = text.count("\r\n")
+        lf_count = text.count("\n") - crlf_count
+        return "\r\n" if crlf_count > lf_count else "\n"
 
     # ======================
     #  Content Modification
     # ======================
 
     @staticmethod
-    def replace_by_diff(path: str, diff: str) -> None:
-        """Apply unified diff format changes atomically to a file.
+    def edit(
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+        start_line: int | None = None,
+    ) -> str:
+        """Replace exact string in file.
 
         Args:
-            path: The file path to modify.
-            diff: Unified diff text (must use standard format with ---/+++ headers and @@ hunk markers).
+            file_path: Absolute path to file.
+            old_string: Exact text to find. Must not be empty.
+            new_string: Replacement text (must differ from old_string).
+            replace_all: Replace all occurrences instead of just one.
+            start_line: Optional 1-based line number hint for disambiguation.
+                When multiple matches exist, selects the match whose start
+                line is closest to this value. Does not require exact precision.
 
-        Example diff text:
-            --- a/original_file
-            +++ b/modified_file
-            @@ -1,3 +1,3 @@
-            -line2
-            +line2 modified
+        Returns:
+            Unified diff showing what changed (for display purposes).
 
         Raises:
-            ValueError: On invalid diff format or patch failure
+            ValueError: If old_string is empty, identical to new_string,
+                not found, or ambiguous without start_line/replace_all.
+            FileNotFoundError: If file_path does not exist.
         """
-        original = FileOps.read_file(path)
-        original_lines = original.splitlines(keepends=True)
-        diff_lines = diff.splitlines(keepends=True)
-        patched_lines = []
-        orig_pos = 0
+        if not old_string:
+            raise ValueError("old_string must not be empty")
+        if old_string == new_string:
+            raise ValueError("old_string and new_string are identical")
 
-        hunk_regex = re.compile(r"@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@")
+        # Read file as bytes to preserve encoding
+        with open(file_path, "rb") as f:
+            raw = f.read()
 
-        i = 0
-        while i < len(diff_lines):
-            line = diff_lines[i]
-            if line.startswith("@@"):
-                m = hunk_regex.match(line)
-                if not m:
-                    raise ValueError("Invalid diff hunk header")
-                orig_start = int(m.group(1)) - 1
+        encoding, bom = FileOps._detect_encoding(raw)
+        if bom:
+            text = raw[len(bom) :].decode(encoding)
+        else:
+            text = raw.decode(encoding)
 
-                # Add unchanged lines before hunk
-                patched_lines.extend(original_lines[orig_pos:orig_start])
-                orig_pos = orig_start
+        line_ending = FileOps._detect_line_ending(text)
 
-                i += 1
-                while i < len(diff_lines) and not diff_lines[i].startswith("@@"):
-                    hline = diff_lines[i]
-                    if hline.startswith(" "):
-                        patched_lines.append(original_lines[orig_pos])
-                        orig_pos += 1
-                    elif hline.startswith("-"):
-                        orig_pos += 1
-                    elif hline.startswith("+"):
-                        patched_lines.append(hline[1:])
-                    else:
-                        raise ValueError(f"Invalid diff line: {hline}")
-                    i += 1
-            else:
-                i += 1
+        # Normalize to \n for matching
+        content = text.replace("\r\n", "\n")
+        old_str = old_string.replace("\r\n", "\n")
+        new_str = new_string.replace("\r\n", "\n")
 
-        # Add remaining lines after last hunk
-        patched_lines.extend(original_lines[orig_pos:])
+        # Find all non-overlapping occurrences
+        positions: list[int] = []
+        start = 0
+        while True:
+            idx = content.find(old_str, start)
+            if idx == -1:
+                break
+            positions.append(idx)
+            start = idx + len(old_str)
 
-        content = "".join(patched_lines)
-        FileOps.write_file(path, content)
+        n = len(positions)
+        if n == 0:
+            raise ValueError("old_string not found in file")
+
+        if n == 1:
+            pos = positions[0]
+            new_content = content[:pos] + new_str + content[pos + len(old_str) :]
+        elif replace_all:
+            new_content = content.replace(old_str, new_str)
+        elif start_line is not None:
+
+            def _pos_to_line(pos: int) -> int:
+                return content[:pos].count("\n") + 1
+
+            match_lines = [(pos, _pos_to_line(pos)) for pos in positions]
+            closest = min(match_lines, key=lambda x: abs(x[1] - start_line))
+            pos = closest[0]
+            new_content = content[:pos] + new_str + content[pos + len(old_str) :]
+        else:
+            raise ValueError(
+                f"old_string found {n} times in file. Use replace_all=True to "
+                f"replace all occurrences, or provide start_line to disambiguate."
+            )
+
+        # Generate diff for display (on normalized content)
+        diff_output = FileOps.make_diff(content, new_content)
+
+        # Restore line endings
+        if line_ending == "\r\n":
+            new_content = new_content.replace("\n", "\r\n")
+
+        # Encode back
+        encoded = bom + new_content.encode(encoding)
+
+        # Atomic write (binary)
+        tmp_path = f"{file_path}.tmp"
+        with open(tmp_path, "wb") as f:
+            f.write(encoded)
+        os.replace(tmp_path, file_path)
+
+        return diff_output
 
     @staticmethod
     def search_files(path: str, regex: str, file_pattern: str = "*") -> list[dict]:
@@ -136,69 +214,6 @@ class FileOps:
                             }
                         )
         return results
-
-    @staticmethod
-    def replace_by_git(path: str, diff: str) -> None:
-        """Apply git conflict style diff atomically to a file, replacing conflicted sections.
-
-        Args:
-            path: File path to modify.
-            diff: Git conflict style diff text (using <<<<<<< SEARCH, =======, >>>>>>> REPLACE markers).
-
-        Example diff text:
-            <<<<<<< SEARCH
-            line2
-            =======
-            line2 modified
-            >>>>>>> REPLACE
-
-        Raises:
-            ValueError: On invalid diff format or patch failure
-        """
-        original = FileOps.read_file(path)
-        original_lines = original.splitlines(keepends=True)
-        diff_lines = diff.splitlines(keepends=True)
-        patched_lines = []
-        orig_pos = 0
-
-        conflict_start_re = re.compile(r"<<<<<<<.*")
-        conflict_sep_re = re.compile(r"=======")
-        conflict_end_re = re.compile(r">>>>>>>.*")
-
-        i = 0
-        while i < len(diff_lines):
-            line = diff_lines[i]
-            if conflict_start_re.match(line):
-                # Add lines before conflict
-                patched_lines.extend(original_lines[orig_pos:orig_pos])
-                i += 1
-                # Count lines in original conflict block to skip
-                orig_conflict_lines = 0
-                # Skip lines until separator in diff
-                while i < len(diff_lines) and not conflict_sep_re.match(diff_lines[i]):
-                    i += 1
-                    orig_conflict_lines += 1
-                i += 1  # skip separator line
-                # Add lines after separator until conflict end
-                conflict_replacement_lines = []
-                while i < len(diff_lines) and not conflict_end_re.match(diff_lines[i]):
-                    conflict_replacement_lines.append(diff_lines[i])
-                    i += 1
-                i += 1  # skip conflict end line
-                patched_lines.extend(conflict_replacement_lines)
-                # Skip original conflicted lines
-                orig_pos += orig_conflict_lines
-            else:
-                if orig_pos < len(original_lines):
-                    patched_lines.append(original_lines[orig_pos])
-                    orig_pos += 1
-                i += 1
-
-        # Add remaining lines after last conflict
-        patched_lines.extend(original_lines[orig_pos:])
-
-        content = "".join(patched_lines)
-        FileOps.write_file(path, content)
 
     # ======================
     #  File I/O Operations

--- a/tests/test_file_ops.py
+++ b/tests/test_file_ops.py
@@ -164,75 +164,129 @@ class TestFileOps:
         assert len(results) == 1
         assert "script.py" in results[0]["file"]
 
-    def test_replace_by_git_simple(self):
-        """Test replacing content using git conflict style."""
-        original_content = "line1\nline2\nline3"
-        FileOps.write_file(self.test_file, original_content)
+    def test_edit_single_match(self):
+        """Test editing with a single match."""
+        content = "line1\nline2\nline3\n"
+        FileOps.write_file(self.test_file, content)
 
-        diff = """<<<<<<< SEARCH
-line2
-=======
-modified line2
->>>>>>> REPLACE"""
-
-        FileOps.replace_by_git(self.test_file, diff)
+        diff = FileOps.edit(self.test_file, "line2", "modified line2")
 
         result = FileOps.read_file(self.test_file)
-        # The implementation has a bug where it doesn't properly match and replace
-        # It adds the replacement but doesn't remove the original
-        expected = "modified line2\nline2\nline3"
-        assert result == expected
+        assert result == "line1\nmodified line2\nline3\n"
+        assert isinstance(diff, str)
+        assert len(diff) > 0
 
-    def test_replace_by_diff_simple(self):
-        """Test replacing content using unified diff."""
-        original_content = "line1\nline2\nline3\n"
-        FileOps.write_file(self.test_file, original_content)
+    def test_edit_no_match(self):
+        """Test editing with no match raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            FileOps.edit(self.test_file, "nonexistent", "replacement")
 
-        diff = """--- a/test.txt
-+++ b/test.txt
-@@ -1,3 +1,3 @@
- line1
--line2
-+modified line2
- line3"""
+    def test_edit_multiple_matches_replace_all(self):
+        """Test editing with replace_all=True replaces all occurrences."""
+        content = "TODO item1\nTODO item2\nTODO item3\n"
+        FileOps.write_file(self.test_file, content)
 
-        FileOps.replace_by_diff(self.test_file, diff)
+        FileOps.edit(self.test_file, "TODO", "DONE", replace_all=True)
 
         result = FileOps.read_file(self.test_file)
-        expected = "line1\nmodified line2\nline3\n"
-        assert result == expected
+        assert result == "DONE item1\nDONE item2\nDONE item3\n"
+        assert "TODO" not in result
 
-    def test_replace_by_diff_invalid_format(self):
-        """Test replacing content with invalid diff format."""
-        diff = "invalid diff format"
+    def test_edit_multiple_matches_start_line(self):
+        """Test editing with start_line disambiguation."""
+        lines = [
+            "line1\n",
+            "TODO first\n",
+            "line3\n",
+            "line4\n",
+            "TODO second\n",
+            "line6\n",
+        ]
+        content = "".join(lines)
+        FileOps.write_file(self.test_file, content)
 
-        # The implementation doesn't validate diff format strictly
-        # It just processes what it can, so no exception is raised
-        FileOps.replace_by_diff(self.test_file, diff)
-        # Should not raise an exception
-
-    def test_replace_by_git_multiple_blocks(self):
-        """Test replacing multiple blocks using git conflict style."""
-        original_content = "line1\nline2\nline3\nline4"
-        FileOps.write_file(self.test_file, original_content)
-
-        diff = """<<<<<<< SEARCH
-line2
-=======
-modified line2
->>>>>>> REPLACE
-<<<<<<< SEARCH
-line4
-=======
-modified line4
->>>>>>> REPLACE"""
-
-        FileOps.replace_by_git(self.test_file, diff)
+        FileOps.edit(self.test_file, "TODO", "DONE", start_line=5)
 
         result = FileOps.read_file(self.test_file)
-        # The implementation has issues with multiple blocks
-        expected = "modified line2\nmodified line4\nline3\nline4"
-        assert result == expected
+        assert "TODO first" in result
+        assert "DONE second" in result
+
+    def test_edit_multiple_matches_no_disambiguation(self):
+        """Test editing with multiple matches and no disambiguation raises ValueError."""
+        content = "dup\ndup\ndup\n"
+        FileOps.write_file(self.test_file, content)
+
+        with pytest.raises(ValueError, match="3 times"):
+            FileOps.edit(self.test_file, "dup", "unique")
+
+    def test_edit_identical_strings(self):
+        """Test editing with identical old and new strings raises ValueError."""
+        with pytest.raises(ValueError, match="identical"):
+            FileOps.edit(self.test_file, "same", "same")
+
+    def test_edit_empty_old_string(self):
+        """Test editing with empty old_string raises ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            FileOps.edit(self.test_file, "", "something")
+
+    def test_edit_preserves_crlf(self):
+        """Test that edit preserves CRLF line endings."""
+        with open(self.test_file, "wb") as f:
+            f.write(b"line1\r\nline2\r\nline3\r\n")
+
+        FileOps.edit(self.test_file, "line2", "modified")
+
+        with open(self.test_file, "rb") as f:
+            raw = f.read()
+        assert raw == b"line1\r\nmodified\r\nline3\r\n"
+
+    def test_edit_preserves_lf(self):
+        """Test that edit preserves LF line endings."""
+        with open(self.test_file, "wb") as f:
+            f.write(b"line1\nline2\nline3\n")
+
+        FileOps.edit(self.test_file, "line2", "modified")
+
+        with open(self.test_file, "rb") as f:
+            raw = f.read()
+        assert b"\r\n" not in raw
+        assert raw == b"line1\nmodified\nline3\n"
+
+    def test_edit_preserves_utf8_bom(self):
+        """Test that edit preserves UTF-8 BOM."""
+        bom = b"\xef\xbb\xbf"
+        with open(self.test_file, "wb") as f:
+            f.write(bom + b"line1\nline2\n")
+
+        FileOps.edit(self.test_file, "line1", "changed")
+
+        with open(self.test_file, "rb") as f:
+            raw = f.read()
+        assert raw.startswith(bom)
+        assert b"changed" in raw
+
+    def test_edit_returns_unified_diff(self):
+        """Test that edit returns a valid unified diff string."""
+        content = "aaa\nbbb\nccc\n"
+        FileOps.write_file(self.test_file, content)
+
+        diff = FileOps.edit(self.test_file, "bbb", "xxx")
+
+        assert "---" in diff
+        assert "+++" in diff
+        assert "@@" in diff
+        assert "-bbb" in diff
+        assert "+xxx" in diff
+
+    def test_edit_delete_string(self):
+        """Test editing with empty new_string deletes the old_string."""
+        content = "keep\nDELETE_ME\nkeep\n"
+        FileOps.write_file(self.test_file, content)
+
+        FileOps.edit(self.test_file, "DELETE_ME\n", "")
+
+        result = FileOps.read_file(self.test_file)
+        assert result == "keep\nkeep\n"
 
     def test_atomic_write_operation(self):
         """Test that write operations are atomic."""


### PR DESCRIPTION
## Summary

Closes #62

- Replace unreliable `replace_by_diff()` and `replace_by_git()` with a new `edit()` method using `old_string`/`new_string` exact matching — aligned with industry practice (Claude Code, OpenCode, Cline)
- Support `start_line` disambiguation when multiple matches exist (selects closest match)
- Preserve file encoding (UTF-8, UTF-8 BOM, UTF-16) and line endings (LF/CRLF) on write-back
- Return unified diff as output for display purposes

### Breaking Changes

- `replace_by_diff()` removed
- `replace_by_git()` removed

## Test plan

- [x] 26 tests pass (`pytest tests/test_file_ops.py -v`)
- [x] 12 new tests for `edit()`: single match, no match, replace_all, start_line, disambiguation error, identical strings, empty old_string, CRLF/LF preservation, UTF-8 BOM, diff output, delete string
- [x] 13 existing tests unchanged (read/write/append/search/validate/make_diff/make_git_conflict)
- [x] `ruff check` and `ruff format` clean
- [x] Docs updated (EN + ZH) on separate worktree branches