### PR TITLE
feat: add PathInfo tool for unified path metadata query

### DIFF
--- a/src/toolregistry_hub/__init__.py
+++ b/src/toolregistry_hub/__init__.py
@@ -25,6 +25,7 @@ from .datetime_utils import DateTime
 from .fetch import Fetch
 from .file_ops import FileOps
 from .filesystem import FileSystem
+from .path_info import PathInfo
 from .think_tool import ThinkTool
 from .todo_list import TodoList
 from .unit_converter import UnitConverter
@@ -48,6 +49,7 @@ __all__ = [
     "DateTime",
     "FileSystem",
     "FileOps",
+    "PathInfo",
     "ThinkTool",
     "UnitConverter",
     # WebSearch related tools

--- a/src/toolregistry_hub/path_info.py
+++ b/src/toolregistry_hub/path_info.py
@@ -1,0 +1,68 @@
+"""Unified file/directory metadata query.
+
+Provides a single-call interface to retrieve path metadata (existence, type,
+size, modification time, permissions), replacing the five separate query
+methods on the legacy FileSystem class.
+"""
+
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class PathInfo:
+    """File and directory metadata query."""
+
+    @staticmethod
+    def info(path: str) -> dict:
+        """Get metadata for a file or directory in a single call.
+
+        Args:
+            path: Absolute or relative path to query.
+
+        Returns:
+            A dict with keys:
+                - exists (bool)
+                - type ("file" | "directory" | "symlink" | "other")
+                - size (int, bytes) — for directories, total size of contents
+                - last_modified (str, ISO 8601 in UTC)
+                - permissions (str, e.g. "rwxr-xr-x")
+
+            If path does not exist, returns ``{"exists": False}``.
+        """
+        p = Path(path)
+
+        if not p.exists():
+            return {"exists": False}
+
+        st = p.stat()
+
+        # Determine type
+        if p.is_symlink():
+            path_type = "symlink"
+        elif p.is_file():
+            path_type = "file"
+        elif p.is_dir():
+            path_type = "directory"
+        else:
+            path_type = "other"
+
+        # Calculate size — recursive for directories
+        if p.is_dir():
+            size = sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+        else:
+            size = st.st_size
+
+        # ISO 8601 timestamp in UTC
+        last_modified = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc).isoformat()
+
+        # Human-readable permissions string (e.g. "rwxr-xr-x")
+        permissions = stat.filemode(st.st_mode)[1:]  # strip leading type char
+
+        return {
+            "exists": True,
+            "type": path_type,
+            "size": size,
+            "last_modified": last_modified,
+            "permissions": permissions,
+        }

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -26,6 +26,7 @@ _DEFAULT_TOOLS: list[dict[str, str]] = [
     {"class": "toolregistry_hub.fetch.Fetch", "namespace": "web/fetch"},
     {"class": "toolregistry_hub.filesystem.FileSystem", "namespace": "filesystem"},
     {"class": "toolregistry_hub.file_ops.FileOps", "namespace": "file_ops"},
+    {"class": "toolregistry_hub.path_info.PathInfo", "namespace": "fs/path_info"},
     {"class": "toolregistry_hub.think_tool.ThinkTool", "namespace": "think"},
     {"class": "toolregistry_hub.todo_list.TodoList", "namespace": "todolist"},
     {

--- a/tests/test_path_info.py
+++ b/tests/test_path_info.py
@@ -1,0 +1,99 @@
+"""Unit tests for PathInfo module."""
+
+import os
+import tempfile
+
+from toolregistry_hub.path_info import PathInfo
+
+
+class TestPathInfo:
+    """Test cases for PathInfo.info()."""
+
+    def setup_method(self):
+        """Set up test environment before each test."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.test_file = os.path.join(self.temp_dir, "test.txt")
+        self.test_subdir = os.path.join(self.temp_dir, "subdir")
+
+        with open(self.test_file, "w", encoding="utf-8") as f:
+            f.write("Hello, world!")  # 13 bytes
+
+        os.makedirs(self.test_subdir, exist_ok=True)
+
+    def teardown_method(self):
+        """Clean up test environment after each test."""
+        import shutil
+
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_nonexistent_path(self):
+        """Non-existent path returns {"exists": False} only."""
+        result = PathInfo.info(os.path.join(self.temp_dir, "no_such_file"))
+        assert result == {"exists": False}
+
+    def test_file_info(self):
+        """Regular file returns correct metadata."""
+        result = PathInfo.info(self.test_file)
+        assert result["exists"] is True
+        assert result["type"] == "file"
+        assert result["size"] == 13
+        assert isinstance(result["last_modified"], str)
+        assert "T" in result["last_modified"]  # ISO 8601
+        assert isinstance(result["permissions"], str)
+        assert len(result["permissions"]) == 9  # e.g. "rw-r--r--"
+
+    def test_directory_info(self):
+        """Directory returns correct metadata."""
+        result = PathInfo.info(self.test_subdir)
+        assert result["exists"] is True
+        assert result["type"] == "directory"
+        assert result["size"] == 0  # empty directory
+
+    def test_directory_size_recursive(self):
+        """Directory size is the sum of all contained file sizes."""
+        # Create files inside subdirectory
+        for name in ("a.txt", "b.txt"):
+            with open(os.path.join(self.test_subdir, name), "w") as f:
+                f.write("12345")  # 5 bytes each
+
+        result = PathInfo.info(self.test_subdir)
+        assert result["size"] == 10
+
+    def test_symlink(self):
+        """Symlink is reported as type 'symlink'."""
+        link_path = os.path.join(self.temp_dir, "link.txt")
+        os.symlink(self.test_file, link_path)
+        result = PathInfo.info(link_path)
+        assert result["exists"] is True
+        assert result["type"] == "symlink"
+        assert result["size"] == 13
+
+    def test_permissions_format(self):
+        """Permissions string is 9 characters like 'rwxr-xr-x'."""
+        result = PathInfo.info(self.test_file)
+        perms = result["permissions"]
+        assert len(perms) == 9
+        for ch in perms:
+            assert ch in "rwxsStT-"
+
+    def test_last_modified_iso8601(self):
+        """last_modified is a valid ISO 8601 string ending with UTC offset."""
+        from datetime import datetime
+
+        result = PathInfo.info(self.test_file)
+        ts = result["last_modified"]
+        # Should be parseable as ISO 8601
+        dt = datetime.fromisoformat(ts)
+        assert dt.tzinfo is not None  # has timezone info
+
+    def test_return_keys_for_existing_path(self):
+        """Existing path returns exactly the expected keys."""
+        result = PathInfo.info(self.test_file)
+        assert set(result.keys()) == {
+            "exists",
+            "type",
+            "size",
+            "last_modified",
+            "permissions",
+        }


### PR DESCRIPTION
## Summary
- Add `PathInfo.info(path)` static method that returns `exists`, `type`, `size`, `last_modified`, `permissions` in a single call
- Replaces 5 separate read-only query methods on the legacy `FileSystem` class (`exists`, `is_file`, `is_dir`, `get_size`, `get_last_modified_time`)
- Registered at namespace `fs/path_info` in the default tool list

Closes #63

## Test plan
- [x] Unit tests covering: file, directory, symlink, non-existent path, recursive dir size, permissions format, ISO 8601 timestamp, return keys
- [x] `ruff check` and `ty check` pass
- [x] `pytest tests/test_path_info.py` — 8/8 passed