### PR TITLE
feat: add FileSearch tool with glob, grep, and tree

### DIFF
--- a/src/toolregistry_hub/__init__.py
+++ b/src/toolregistry_hub/__init__.py
@@ -24,6 +24,7 @@ from .calculator import BaseCalculator, Calculator
 from .datetime_utils import DateTime
 from .fetch import Fetch
 from .file_ops import FileOps
+from .file_search import FileSearch
 from .filesystem import FileSystem
 from .path_info import PathInfo
 from .think_tool import ThinkTool
@@ -49,6 +50,7 @@ __all__ = [
     "DateTime",
     "FileSystem",
     "FileOps",
+    "FileSearch",
     "PathInfo",
     "ThinkTool",
     "UnitConverter",

--- a/src/toolregistry_hub/file_search.py
+++ b/src/toolregistry_hub/file_search.py
@@ -1,0 +1,263 @@
+"""File and content search tools.
+
+Provides glob-based file finding, regex content search (grep), and directory
+tree display — the three most common file-discovery operations in agent
+workflows.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path
+
+# Hard caps to prevent oversized returns
+_MAX_GLOB_RESULTS = 1000
+_MAX_GREP_RESULTS = 200
+_MAX_TREE_ENTRIES = 2000
+
+
+class FileSearch:
+    """File and content search tools."""
+
+    @staticmethod
+    def glob(
+        pattern: str,
+        root: str = ".",
+        recursive: bool = True,
+    ) -> list[str]:
+        """Find files matching a glob pattern.
+
+        Args:
+            pattern: Glob pattern (e.g. ``"**/*.py"``, ``"src/**/*.ts"``).
+            root: Root directory to search from. Defaults to current directory.
+            recursive: Whether ``**`` matches subdirectories. Defaults to True.
+
+        Returns:
+            List of matching file paths relative to *root*, sorted by
+            modification time (most recent first).  Capped at 1000 results.
+
+        Raises:
+            FileNotFoundError: If *root* does not exist or is not a directory.
+        """
+        root_path = Path(root).resolve()
+        if not root_path.is_dir():
+            raise FileNotFoundError(
+                f"Root is not a directory or does not exist: {root}"
+            )
+
+        if recursive:
+            matches = list(root_path.glob(pattern))
+        else:
+            # Non-recursive: only match in the root directory itself
+            matches = [p for p in root_path.glob(pattern) if p.parent == root_path]
+
+        # Sort by modification time, most recent first
+        matches.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+
+        # Cap results
+        matches = matches[:_MAX_GLOB_RESULTS]
+
+        return [str(p.relative_to(root_path)) for p in matches]
+
+    @staticmethod
+    def grep(
+        pattern: str,
+        path: str = ".",
+        recursive: bool = True,
+        file_pattern: str | None = None,
+        max_results: int = 50,
+    ) -> list[dict]:
+        """Search file contents using regex.
+
+        Args:
+            pattern: Regex pattern to search for.
+            path: File or directory to search in. Defaults to current directory.
+            recursive: Whether to search subdirectories. Defaults to True.
+            file_pattern: Optional glob to filter files (e.g. ``"*.py"``).
+            max_results: Maximum number of match results to return.
+                Clamped to an internal cap of 200.
+
+        Returns:
+            List of dicts, each with keys:
+
+            - ``file`` (str): path relative to search root
+            - ``line_number`` (int): 1-based line number
+            - ``content`` (str): the matching line (stripped)
+
+        Raises:
+            FileNotFoundError: If *path* does not exist.
+            re.error: If *pattern* is not a valid regex.
+        """
+        target = Path(path).resolve()
+        if not target.exists():
+            raise FileNotFoundError(f"Path does not exist: {path}")
+
+        regex = re.compile(pattern)
+        effective_max = min(max_results, _MAX_GREP_RESULTS)
+        results: list[dict] = []
+
+        if target.is_file():
+            FileSearch._grep_file(target, regex, target.parent, results, effective_max)
+            return results
+
+        # Directory search
+        if recursive:
+            files = target.rglob("*")
+        else:
+            files = target.iterdir()
+
+        for filepath in sorted(files):
+            if len(results) >= effective_max:
+                break
+            if not filepath.is_file():
+                continue
+            if file_pattern and not fnmatch.fnmatch(filepath.name, file_pattern):
+                continue
+            FileSearch._grep_file(filepath, regex, target, results, effective_max)
+
+        return results
+
+    @staticmethod
+    def _grep_file(
+        filepath: Path,
+        regex: re.Pattern,
+        base: Path,
+        results: list[dict],
+        max_results: int,
+    ) -> None:
+        """Search a single file for regex matches.
+
+        Args:
+            filepath: File to search.
+            regex: Compiled regex pattern.
+            base: Base directory for relative path calculation.
+            results: Accumulator list to append matches to.
+            max_results: Stop after this many total results.
+        """
+        try:
+            text = filepath.read_text(errors="replace")
+        except (OSError, PermissionError):
+            return
+
+        for line_num, line in enumerate(text.splitlines(), start=1):
+            if len(results) >= max_results:
+                return
+            if regex.search(line):
+                results.append(
+                    {
+                        "file": str(filepath.relative_to(base)),
+                        "line_number": line_num,
+                        "content": line.strip(),
+                    }
+                )
+
+    @staticmethod
+    def tree(
+        path: str = ".",
+        max_depth: int = 3,
+        show_hidden: bool = False,
+        file_pattern: str | None = None,
+    ) -> str:
+        """Display directory tree structure.
+
+        Args:
+            path: Root directory. Defaults to current directory.
+            max_depth: Maximum depth to display. Defaults to 3.
+            show_hidden: Whether to show hidden files/directories.
+            file_pattern: Optional glob to filter displayed files.
+
+        Returns:
+            Tree-formatted string representation of the directory.
+
+        Raises:
+            FileNotFoundError: If *path* does not exist or is not a directory.
+            ValueError: If *max_depth* is less than 1.
+        """
+        root = Path(path).resolve()
+        if not root.is_dir():
+            raise FileNotFoundError(
+                f"Path is not a directory or does not exist: {path}"
+            )
+        if max_depth < 1:
+            raise ValueError("max_depth must be 1 or greater.")
+
+        lines: list[str] = [root.name + "/"]
+        count = [0]  # mutable counter for the nested function
+
+        FileSearch._build_tree(
+            root, "", max_depth, 1, show_hidden, file_pattern, lines, count
+        )
+
+        if count[0] >= _MAX_TREE_ENTRIES:
+            lines.append(f"\n... truncated at {_MAX_TREE_ENTRIES} entries")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _build_tree(
+        directory: Path,
+        prefix: str,
+        max_depth: int,
+        current_depth: int,
+        show_hidden: bool,
+        file_pattern: str | None,
+        lines: list[str],
+        count: list[int],
+    ) -> None:
+        """Recursively build tree lines.
+
+        Args:
+            directory: Current directory to list.
+            prefix: Indentation prefix for the current level.
+            max_depth: Maximum depth to display.
+            current_depth: Current recursion depth.
+            show_hidden: Whether to show hidden entries.
+            file_pattern: Optional glob to filter files.
+            lines: Accumulator for output lines.
+            count: Single-element list used as a mutable counter.
+        """
+        if current_depth > max_depth:
+            return
+
+        try:
+            entries = sorted(
+                directory.iterdir(), key=lambda e: (not e.is_dir(), e.name)
+            )
+        except PermissionError:
+            return
+
+        # Filter hidden
+        if not show_hidden:
+            entries = [e for e in entries if not e.name.startswith(".")]
+
+        # Filter files by pattern (directories always shown so tree structure is intact)
+        if file_pattern:
+            entries = [
+                e
+                for e in entries
+                if e.is_dir() or fnmatch.fnmatch(e.name, file_pattern)
+            ]
+
+        for i, entry in enumerate(entries):
+            if count[0] >= _MAX_TREE_ENTRIES:
+                return
+
+            is_last = i == len(entries) - 1
+            connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
+            suffix = "/" if entry.is_dir() else ""
+            lines.append(f"{prefix}{connector}{entry.name}{suffix}")
+            count[0] += 1
+
+            if entry.is_dir() and current_depth < max_depth:
+                extension = "    " if is_last else "\u2502   "
+                FileSearch._build_tree(
+                    entry,
+                    prefix + extension,
+                    max_depth,
+                    current_depth + 1,
+                    show_hidden,
+                    file_pattern,
+                    lines,
+                    count,
+                )

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -26,6 +26,7 @@ _DEFAULT_TOOLS: list[dict[str, str]] = [
     {"class": "toolregistry_hub.fetch.Fetch", "namespace": "web/fetch"},
     {"class": "toolregistry_hub.filesystem.FileSystem", "namespace": "filesystem"},
     {"class": "toolregistry_hub.file_ops.FileOps", "namespace": "file_ops"},
+    {"class": "toolregistry_hub.file_search.FileSearch", "namespace": "fs/file_search"},
     {"class": "toolregistry_hub.path_info.PathInfo", "namespace": "fs/path_info"},
     {"class": "toolregistry_hub.think_tool.ThinkTool", "namespace": "think"},
     {"class": "toolregistry_hub.todo_list.TodoList", "namespace": "todolist"},

--- a/tests/test_file_search.py
+++ b/tests/test_file_search.py
@@ -1,0 +1,184 @@
+"""Unit tests for FileSearch module."""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from toolregistry_hub.file_search import FileSearch
+
+
+class TestFileSearchGlob:
+    """Test cases for FileSearch.glob()."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        # Create a small file tree:
+        #   root/
+        #     a.py
+        #     b.txt
+        #     sub/
+        #       c.py
+        #       d.txt
+        #       deep/
+        #         e.py
+        self.sub = os.path.join(self.temp_dir, "sub")
+        self.deep = os.path.join(self.sub, "deep")
+        os.makedirs(self.deep)
+
+        for name in ("a.py", "b.txt"):
+            Path = os.path.join(self.temp_dir, name)
+            with open(Path, "w") as f:
+                f.write(name)
+
+        for name in ("c.py", "d.txt"):
+            with open(os.path.join(self.sub, name), "w") as f:
+                f.write(name)
+
+        with open(os.path.join(self.deep, "e.py"), "w") as f:
+            f.write("e.py")
+
+    def teardown_method(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_recursive_glob(self):
+        result = FileSearch.glob("**/*.py", root=self.temp_dir)
+        names = sorted(os.path.basename(p) for p in result)
+        assert names == ["a.py", "c.py", "e.py"]
+
+    def test_non_recursive_glob(self):
+        result = FileSearch.glob("*.py", root=self.temp_dir, recursive=False)
+        names = [os.path.basename(p) for p in result]
+        assert names == ["a.py"]
+
+    def test_glob_no_match(self):
+        result = FileSearch.glob("*.rs", root=self.temp_dir)
+        assert result == []
+
+    def test_glob_invalid_root(self):
+        with pytest.raises(FileNotFoundError):
+            FileSearch.glob("*", root=os.path.join(self.temp_dir, "nope"))
+
+    def test_glob_returns_relative_paths(self):
+        result = FileSearch.glob("**/*.py", root=self.temp_dir)
+        for p in result:
+            assert not os.path.isabs(p)
+
+
+class TestFileSearchGrep:
+    """Test cases for FileSearch.grep()."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.file_a = os.path.join(self.temp_dir, "a.py")
+        self.file_b = os.path.join(self.temp_dir, "b.txt")
+
+        with open(self.file_a, "w") as f:
+            f.write("import os\nimport sys\nprint('hello')\n")
+
+        with open(self.file_b, "w") as f:
+            f.write("no matches here\njust text\n")
+
+    def teardown_method(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_grep_finds_matches(self):
+        results = FileSearch.grep("import", path=self.temp_dir)
+        assert len(results) == 2
+        assert all(r["content"].startswith("import") for r in results)
+
+    def test_grep_line_numbers(self):
+        results = FileSearch.grep("print", path=self.temp_dir)
+        assert len(results) == 1
+        assert results[0]["line_number"] == 3
+
+    def test_grep_single_file(self):
+        results = FileSearch.grep("import", path=self.file_a)
+        assert len(results) == 2
+
+    def test_grep_file_pattern(self):
+        results = FileSearch.grep(".", path=self.temp_dir, file_pattern="*.py")
+        files = {r["file"] for r in results}
+        assert all(f.endswith(".py") for f in files)
+
+    def test_grep_no_match(self):
+        results = FileSearch.grep("zzzzz_no_match", path=self.temp_dir)
+        assert results == []
+
+    def test_grep_max_results(self):
+        results = FileSearch.grep(".", path=self.temp_dir, max_results=2)
+        assert len(results) <= 2
+
+    def test_grep_invalid_path(self):
+        with pytest.raises(FileNotFoundError):
+            FileSearch.grep("x", path=os.path.join(self.temp_dir, "nope"))
+
+    def test_grep_invalid_regex(self):
+        with pytest.raises(Exception):
+            FileSearch.grep("[invalid", path=self.temp_dir)
+
+    def test_grep_returns_relative_paths(self):
+        results = FileSearch.grep("import", path=self.temp_dir)
+        for r in results:
+            assert not os.path.isabs(r["file"])
+
+
+class TestFileSearchTree:
+    """Test cases for FileSearch.tree()."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.sub = os.path.join(self.temp_dir, "sub")
+        self.deep = os.path.join(self.sub, "deep")
+        os.makedirs(self.deep)
+
+        with open(os.path.join(self.temp_dir, "file.txt"), "w") as f:
+            f.write("x")
+        with open(os.path.join(self.sub, "code.py"), "w") as f:
+            f.write("x")
+        with open(os.path.join(self.deep, "inner.py"), "w") as f:
+            f.write("x")
+
+        # Hidden file
+        with open(os.path.join(self.temp_dir, ".hidden"), "w") as f:
+            f.write("x")
+
+    def teardown_method(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_tree_basic(self):
+        output = FileSearch.tree(self.temp_dir)
+        assert "sub/" in output
+        assert "file.txt" in output
+
+    def test_tree_hidden_excluded_by_default(self):
+        output = FileSearch.tree(self.temp_dir)
+        assert ".hidden" not in output
+
+    def test_tree_hidden_included(self):
+        output = FileSearch.tree(self.temp_dir, show_hidden=True)
+        assert ".hidden" in output
+
+    def test_tree_max_depth(self):
+        output = FileSearch.tree(self.temp_dir, max_depth=1)
+        assert "sub/" in output
+        # deep/ should not appear at depth 1
+        assert "deep/" not in output
+
+    def test_tree_file_pattern(self):
+        output = FileSearch.tree(self.temp_dir, file_pattern="*.py")
+        assert "code.py" in output
+        assert "file.txt" not in output
+
+    def test_tree_invalid_path(self):
+        with pytest.raises(FileNotFoundError):
+            FileSearch.tree(os.path.join(self.temp_dir, "nope"))
+
+    def test_tree_invalid_depth(self):
+        with pytest.raises(ValueError):
+            FileSearch.tree(self.temp_dir, max_depth=0)
+
+    def test_tree_uses_connectors(self):
+        output = FileSearch.tree(self.temp_dir)
+        assert "├" in output or "└" in output


### PR DESCRIPTION
## Summary
- Add `FileSearch` class with three static methods: `glob`, `grep`, `tree`
- `glob`: find files by pattern, sorted by modification time (cap: 1000 results)
- `grep`: regex content search with file filtering and max_results (cap: 200)
- `tree`: directory tree display with depth/hidden/pattern controls (cap: 2000 entries)
- Registered at namespace `fs/file_search` in the default tool list

Closes #64

## Test plan
- [x] 22 unit tests covering all three methods, edge cases, error handling
- [x] `ruff check` + `ruff format` pass
- [x] `ty check` pass
- [x] `pytest tests/test_file_search.py` — 22/22 passed