### PR TITLE
feat: API key failover with retry on auth/rate-limit errors

### DIFF
--- a/src/toolregistry_hub/utils/api_key_parser.py
+++ b/src/toolregistry_hub/utils/api_key_parser.py
@@ -6,6 +6,7 @@ different web search implementations.
 """
 
 import os
+import threading
 import time
 
 
@@ -50,6 +51,10 @@ class APIKeyParser:
         self.rate_limit_delay = rate_limit_delay
         # Track last request time for each API key individually
         self._last_request_times: dict[str, float] = {}
+        # Failed keys: key -> (reason, failure_time, ttl_seconds)
+        self._failed_keys: dict[str, tuple[str, float, float]] = {}
+        # Lock for thread-safe key rotation and failure tracking
+        self._lock = threading.Lock()
 
     def _parse_api_keys(self, api_keys_str: str, separator: str) -> list[str]:
         """Parse and validate API keys from string.
@@ -149,14 +154,42 @@ class APIKeyParser:
         """Get the next API key using round-robin selection.
 
         Returns:
-            The next API key in the rotation
+            The next API key in the rotation.
+
+        Raises:
+            ValueError: If no API keys are available.
         """
         if not self.api_keys:
             raise ValueError("No API keys available")
 
-        key = self.api_keys[self._current_key_index]
-        self._current_key_index = (self._current_key_index + 1) % len(self.api_keys)
+        with self._lock:
+            key = self.api_keys[self._current_key_index]
+            self._current_key_index = (self._current_key_index + 1) % len(self.api_keys)
         return key
+
+    def get_next_valid_key(self) -> str:
+        """Get the next non-failed API key using round-robin selection.
+
+        Skips keys that are currently marked as failed (whose TTL has not
+        expired). Expired failures are auto-recovered.
+
+        Returns:
+            The next valid API key.
+
+        Raises:
+            ValueError: If no API keys are available or all keys are failed.
+        """
+        if not self.api_keys:
+            raise ValueError("No API keys available")
+
+        with self._lock:
+            n = len(self.api_keys)
+            for _ in range(n):
+                key = self.api_keys[self._current_key_index]
+                self._current_key_index = (self._current_key_index + 1) % n
+                if self._is_key_available(key):
+                    return key
+            raise ValueError("All API keys are currently failed")
 
     @property
     def key_count(self) -> int:
@@ -184,37 +217,91 @@ class APIKeyParser:
             return self.api_keys[index]
         raise IndexError(f"Index {index} out of range for {len(self.api_keys)} keys")
 
+    def _is_key_available(self, key: str) -> bool:
+        """Check if a key is available (not failed or TTL expired).
+
+        If the key's TTL has expired, it is auto-recovered (removed from
+        ``_failed_keys``).
+
+        Note:
+            Caller must hold ``self._lock``.
+
+        Args:
+            key: The API key to check.
+
+        Returns:
+            True if the key is available for use.
+        """
+        if key not in self._failed_keys:
+            return True
+        reason, failure_time, ttl = self._failed_keys[key]
+        if time.time() - failure_time >= ttl:
+            del self._failed_keys[key]
+            return True
+        return False
+
+    def mark_key_failed(self, key: str, reason: str, ttl: float = 3600.0) -> None:
+        """Mark an API key as temporarily unavailable.
+
+        Args:
+            key: The API key to mark as failed.
+            reason: Human-readable reason (e.g. "HTTP 401", "rate limited").
+            ttl: Time-to-live in seconds before the key auto-recovers.
+                Defaults to 3600 (1 hour).
+        """
+        with self._lock:
+            self._failed_keys[key] = (reason, time.time(), ttl)
+
+    @property
+    def failed_keys(self) -> dict[str, str]:
+        """Return currently failed keys and their reasons.
+
+        Keys whose TTL has expired are auto-recovered and excluded.
+
+        Returns:
+            Mapping of failed key -> reason string.
+        """
+        with self._lock:
+            now = time.time()
+            # Auto-recover expired keys
+            expired = [
+                k
+                for k, (_, failure_time, ttl) in self._failed_keys.items()
+                if now - failure_time >= ttl
+            ]
+            for k in expired:
+                del self._failed_keys[k]
+            return {k: reason for k, (reason, _, _) in self._failed_keys.items()}
+
     def wait_for_rate_limit(self, api_key: str | None = None):
         """Ensure minimum delay between API requests to avoid rate limits for a specific key.
 
         Args:
-            api_key: The API key to check rate limit for. If None, uses the last used key.
+            api_key: The API key to check rate limit for. If None, uses the
+                previously selected key.
         """
         if api_key is None:
-            # Use the last used key (the one that was just selected)
-            if self._current_key_index == 0:
-                # If we're at the beginning, use the last key
-                api_key = self.api_keys[-1]
-            else:
-                api_key = self.api_keys[self._current_key_index - 1]
+            with self._lock:
+                if self._current_key_index == 0:
+                    api_key = self.api_keys[-1]
+                else:
+                    api_key = self.api_keys[self._current_key_index - 1]
 
-        current_time = time.time()
+        # Read last request time under lock, sleep outside lock
+        with self._lock:
+            current_time = time.time()
+            last_request_time = self._last_request_times.get(api_key, 0)
+            time_since_last_request = current_time - last_request_time
 
-        # Get the last request time for this specific API key
-        last_request_time = self._last_request_times.get(api_key, 0)
-        time_since_last_request = current_time - last_request_time
-
+        sleep_time = 0.0
         if time_since_last_request < self.rate_limit_delay:
             sleep_time = self.rate_limit_delay - time_since_last_request
-            import logging
 
-            logging.debug(
-                f"Rate limiting for key {api_key[:10]}...: sleeping for {sleep_time:.2f}s"
-            )
+        if sleep_time > 0:
             time.sleep(sleep_time)
 
-        # Update the last request time for this specific API key
-        self._last_request_times[api_key] = time.time()
+        with self._lock:
+            self._last_request_times[api_key] = time.time()
 
 
 def create_api_key_parser(

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -35,16 +35,19 @@ class BaseSearch(ABC):
             return bool(getattr(self, "api_key_parser").api_keys)
         return True
 
-    @property
     @abstractmethod
-    def _headers(self) -> dict:
-        """Generate headers necessary for making upstream query"""
-        # this method is for generating necessary headers used for upstream api call
-        # the content could be
-        # - BEARER authentication token
-        # - fake user agent from ua-generator
-        # - API key rotation
-        # - ...
+    def _build_headers(self, api_key: str | None = None) -> dict:
+        """Generate headers necessary for making upstream query.
+
+        Subclasses should build provider-specific headers using the given
+        ``api_key`` (if applicable). The key is obtained by the caller so
+        that rate-limiting, failover and the actual request all operate on
+        the *same* key — avoiding the double-consumption bug.
+
+        Args:
+            api_key: The API key to embed in the headers, or ``None`` for
+                providers that do not require one (e.g. SearXNG).
+        """
 
     @abstractmethod
     def search(

--- a/src/toolregistry_hub/websearch/websearch_brave.py
+++ b/src/toolregistry_hub/websearch/websearch_brave.py
@@ -54,13 +54,16 @@ class BraveSearch(BaseSearch):
 
         self.base_url = "https://api.search.brave.com/res/v1"
 
-    @property
-    def _headers(self) -> dict:
-        """Generate headers with the current API key."""
+    def _build_headers(self, api_key: str | None = None) -> dict:
+        """Generate headers with the given API key.
+
+        Args:
+            api_key: Brave API key to use for authentication.
+        """
         return {
             "Accept": "application/json",
             "Accept-Encoding": "gzip",
-            "X-Subscription-Token": self.api_key_parser.get_next_api_key(),
+            "X-Subscription-Token": api_key or "",
         }
 
     def search(
@@ -150,39 +153,60 @@ class BraveSearch(BaseSearch):
                 params[key] = value
 
         timeout = kwargs.get("timeout", TIMEOUT_DEFAULT)
-        try:
-            # Rate limiting: ensure minimum delay between requests
-            self._wait_for_rate_limit()
+        max_attempts = max(self.api_key_parser.key_count, 1)
 
-            with httpx.Client(timeout=timeout) as client:
-                response = client.get(
-                    f"{self.base_url}/web/search", headers=self._headers, params=params
-                )
-                response.raise_for_status()
+        for attempt in range(max_attempts):
+            try:
+                api_key = self.api_key_parser.get_next_valid_key()
+            except ValueError:
+                logger.error("All Brave API keys are currently unavailable")
+                break
 
-                data = response.json()
-                results = self._parse_results(data)
+            self.api_key_parser.wait_for_rate_limit(api_key=api_key)
 
-                logger.info(
-                    f"Brave search for '{query}' returned {len(results)} results"
-                )
-                return results
+            try:
+                with httpx.Client(timeout=timeout) as client:
+                    response = client.get(
+                        f"{self.base_url}/web/search",
+                        headers=self._build_headers(api_key),
+                        params=params,
+                    )
+                    response.raise_for_status()
 
-        except httpx.TimeoutException:
-            logger.error(f"Brave API request timed out after {timeout}s")
-            return []
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 429:
-                logger.warning(
-                    "Rate limit exceeded, consider increasing rate_limit_delay"
-                )
-            logger.error(
-                f"Brave API HTTP error {e.response.status_code}: {e.response.text}"
-            )
-            return []
-        except Exception as e:
-            logger.error(f"Brave API request failed: {e}")
-            return []
+                    data = response.json()
+                    results = self._parse_results(data)
+
+                    logger.info(
+                        f"Brave search for '{query}' returned {len(results)} results"
+                    )
+                    return results
+
+            except httpx.TimeoutException:
+                logger.error(f"Brave API request timed out after {timeout}s")
+                return []
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if status in (401, 403):
+                    self.api_key_parser.mark_key_failed(
+                        api_key, f"HTTP {status}", ttl=3600.0
+                    )
+                    logger.warning(
+                        f"Brave API key auth failed (HTTP {status}), trying next key"
+                    )
+                    continue
+                if status == 429:
+                    self.api_key_parser.mark_key_failed(
+                        api_key, "rate limited", ttl=300.0
+                    )
+                    logger.warning("Brave API rate limit exceeded, trying next key")
+                    continue
+                logger.error(f"Brave API HTTP error {status}: {e.response.text}")
+                return []
+            except Exception as e:
+                logger.error(f"Brave API request failed: {e}")
+                return []
+
+        return []
 
     def _parse_results(self, raw_results: dict) -> list[SearchResult]:
         """Parse Brave API response into standardized format.
@@ -207,12 +231,6 @@ class BraveSearch(BaseSearch):
             results.append(result)
 
         return results
-
-    def _wait_for_rate_limit(self):
-        """Ensure minimum delay between API requests to avoid rate limits."""
-        # Get the current API key and pass it to the rate limiter
-        current_key = self.api_key_parser.get_next_api_key()
-        self.api_key_parser.wait_for_rate_limit(api_key=current_key)
 
 
 def main():

--- a/src/toolregistry_hub/websearch/websearch_brightdata.py
+++ b/src/toolregistry_hub/websearch/websearch_brightdata.py
@@ -127,11 +127,14 @@ class BrightDataSearch(BaseSearch):
                     f"Proceeding anyway - zone might exist or will be created on first use."
                 )
 
-    @property
-    def _headers(self) -> dict:
-        """Generate headers for API requests."""
+    def _build_headers(self, api_key: str | None = None) -> dict:
+        """Generate headers with the given API key.
+
+        Args:
+            api_key: Bright Data API token to use for authentication.
+        """
         return {
-            "Authorization": f"Bearer {self.api_key_parser.get_next_api_key()}",
+            "Authorization": f"Bearer {api_key or ''}",
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
@@ -226,67 +229,71 @@ class BrightDataSearch(BaseSearch):
 
         timeout = kwargs.get("timeout", TIMEOUT_DEFAULT)
 
-        try:
-            with httpx.Client(timeout=timeout) as client:
-                response = client.post(
-                    self.base_url,
-                    headers=self._headers,
-                    json=payload,
-                )
-                response.raise_for_status()
+        max_attempts = max(self.api_key_parser.key_count, 1)
 
-                # Parse the response
-                # Bright Data returns the Google SERP data as text
-                raw_data = response.text
-                data = json.loads(raw_data)
+        for attempt in range(max_attempts):
+            try:
+                api_key = self.api_key_parser.get_next_valid_key()
+            except ValueError:
+                logger.error("All Bright Data API keys are currently unavailable")
+                break
 
-                # # Debug: Log the complete raw response structure
-                # logger.debug(f"Bright Data raw response keys: {list(data.keys())}")
-                # logger.debug(
-                #     f"Bright Data full response: {json.dumps(data, indent=2, ensure_ascii=False)}"
-                # )
+            self.api_key_parser.wait_for_rate_limit(api_key=api_key)
 
-                # # Debug: Log organic results structure if available
-                # if "organic" in data:
-                #     logger.debug(f"Number of organic results: {len(data['organic'])}")
-                #     if data["organic"]:
-                #         logger.debug(
-                #             f"First organic result structure: {json.dumps(data['organic'][0], indent=2, ensure_ascii=False)}"
-                #         )
+            try:
+                with httpx.Client(timeout=timeout) as client:
+                    response = client.post(
+                        self.base_url,
+                        headers=self._build_headers(api_key),
+                        json=payload,
+                    )
+                    response.raise_for_status()
 
-                # Use universal parser
-                results = self.parser.parse(data)
+                    raw_data = response.text
+                    data = json.loads(raw_data)
+                    results = self.parser.parse(data)
 
-                logger.info(
-                    f"Bright Data search for '{query}' (page {page_num}) returned {len(results)} results"
-                )
-                return results
+                    logger.info(
+                        f"Bright Data search for '{query}' (page {page_num}) returned {len(results)} results"
+                    )
+                    return results
 
-        except httpx.TimeoutException:
-            logger.error(f"Bright Data API request timed out after {timeout}s")
-            return []
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                logger.error("Authentication failed. Check your BRIGHTDATA_API_KEY")
-            elif e.response.status_code == 422:
-                logger.error(
-                    f"Zone '{self.zone}' does not exist. Check your BRIGHTDATA_ZONE configuration"
-                )
-            elif e.response.status_code == 429:
-                logger.warning(
-                    "Rate limit exceeded, consider increasing rate_limit_delay"
-                )
-            else:
-                logger.error(
-                    f"Bright Data API HTTP error {e.response.status_code}: {e.response.text}"
-                )
-            return []
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse Bright Data API response: {e}")
-            return []
-        except Exception as e:
-            logger.error(f"Bright Data API request failed: {e}")
-            return []
+            except httpx.TimeoutException:
+                logger.error(f"Bright Data API request timed out after {timeout}s")
+                return []
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if status in (401, 403):
+                    self.api_key_parser.mark_key_failed(
+                        api_key, f"HTTP {status}", ttl=3600.0
+                    )
+                    logger.warning(
+                        f"Bright Data API key auth failed (HTTP {status}), trying next key"
+                    )
+                    continue
+                if status == 429:
+                    self.api_key_parser.mark_key_failed(
+                        api_key, "rate limited", ttl=300.0
+                    )
+                    logger.warning(
+                        "Bright Data API rate limit exceeded, trying next key"
+                    )
+                    continue
+                if status == 422:
+                    logger.error(
+                        f"Zone '{self.zone}' does not exist. Check your BRIGHTDATA_ZONE configuration"
+                    )
+                    return []
+                logger.error(f"Bright Data API HTTP error {status}: {e.response.text}")
+                return []
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse Bright Data API response: {e}")
+                return []
+            except Exception as e:
+                logger.error(f"Bright Data API request failed: {e}")
+                return []
+
+        return []
 
     def _parse_results(self, raw_results: dict[str, Any]) -> list[SearchResult]:
         """Parse Bright Data API response into standardized format.
@@ -300,12 +307,6 @@ class BrightDataSearch(BaseSearch):
             List of parsed search results
         """
         return self.parser.parse(raw_results)
-
-    def _wait_for_rate_limit(self):
-        """Ensure minimum delay between API requests to avoid rate limits."""
-        # Get the current API key and pass it to the rate limiter
-        current_key = self.api_key_parser.get_next_api_key()
-        self.api_key_parser.wait_for_rate_limit(api_key=current_key)
 
 
 def main():

--- a/src/toolregistry_hub/websearch/websearch_scrapeless.py
+++ b/src/toolregistry_hub/websearch/websearch_scrapeless.py
@@ -74,11 +74,14 @@ class ScrapelessSearch(BaseSearch):
             f"Initialized ScrapelessSearch with {self.api_key_parser.key_count} API keys"
         )
 
-    @property
-    def _headers(self) -> dict:
-        """Generate headers with API key authentication."""
+    def _build_headers(self, api_key: str | None = None) -> dict:
+        """Generate headers with the given API key.
+
+        Args:
+            api_key: Scrapeless API key to use for authentication.
+        """
         return {
-            "X-API-Key": self.api_key_parser.get_next_api_key(),
+            "X-API-Key": api_key or "",
             "Content-Type": "application/json",
         }
 
@@ -192,51 +195,66 @@ class ScrapelessSearch(BaseSearch):
             "async": False,  # Wait for result synchronously
         }
 
-        try:
-            with httpx.Client(timeout=timeout) as client:
-                response = client.post(
-                    self.endpoint, headers=self._headers, json=payload
-                )
-                response.raise_for_status()
+        max_attempts = max(self.api_key_parser.key_count, 1)
 
-                # Parse JSON response from Scrapeless DeepSERP API
-                response_data = response.json()
+        for attempt in range(max_attempts):
+            try:
+                api_key = self.api_key_parser.get_next_valid_key()
+            except ValueError:
+                logger.error("All Scrapeless API keys are currently unavailable")
+                break
 
-                # # Debug: Log the complete raw response structure
-                # logger.debug(f"Scrapeless raw response keys: {list(response_data.keys())}")
-                # logger.debug(f"Scrapeless full response: {json.dumps(response_data, indent=2, ensure_ascii=False)}")
+            self.api_key_parser.wait_for_rate_limit(api_key=api_key)
 
-                # # Debug: Log organic results structure if available
-                # if "organic_results" in response_data:
-                #     logger.debug(f"Number of organic_results: {len(response_data['organic_results'])}")
-                #     if response_data['organic_results']:
-                #         logger.debug(f"First organic_result structure: {json.dumps(response_data['organic_results'][0], indent=2, ensure_ascii=False)}")
+            try:
+                with httpx.Client(timeout=timeout) as client:
+                    response = client.post(
+                        self.endpoint,
+                        headers=self._build_headers(api_key),
+                        json=payload,
+                    )
+                    response.raise_for_status()
 
-                # Use universal parser
-                results = self.parser.parse(response_data)
+                    response_data = response.json()
+                    results = self.parser.parse(response_data)
 
-                page_num = start // 10
-                logger.info(
-                    f"Scrapeless DeepSERP search for '{query}' (page {page_num}) returned {len(results)} results"
-                )
-                return results
+                    page_num = start // 10
+                    logger.info(
+                        f"Scrapeless DeepSERP search for '{query}' (page {page_num}) returned {len(results)} results"
+                    )
+                    return results
 
-        except httpx.TimeoutException:
-            logger.error(f"Scrapeless API request timed out after {timeout}s")
-            return []
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 429:
-                logger.warning("Rate limit exceeded")
-            logger.error(
-                f"Scrapeless API HTTP error {e.response.status_code}: {e.response.text}"
-            )
-            return []
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse Scrapeless API response: {e}")
-            return []
-        except Exception as e:
-            logger.error(f"Scrapeless API request failed: {e}")
-            return []
+            except httpx.TimeoutException:
+                logger.error(f"Scrapeless API request timed out after {timeout}s")
+                return []
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if status in (401, 403):
+                    self.api_key_parser.mark_key_failed(
+                        api_key, f"HTTP {status}", ttl=3600.0
+                    )
+                    logger.warning(
+                        f"Scrapeless API key auth failed (HTTP {status}), trying next key"
+                    )
+                    continue
+                if status == 429:
+                    self.api_key_parser.mark_key_failed(
+                        api_key, "rate limited", ttl=300.0
+                    )
+                    logger.warning(
+                        "Scrapeless API rate limit exceeded, trying next key"
+                    )
+                    continue
+                logger.error(f"Scrapeless API HTTP error {status}: {e.response.text}")
+                return []
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse Scrapeless API response: {e}")
+                return []
+            except Exception as e:
+                logger.error(f"Scrapeless API request failed: {e}")
+                return []
+
+        return []
 
     def _parse_results(self, raw_results: Any) -> list[SearchResult]:
         """Parse raw search results into standardized format.

--- a/src/toolregistry_hub/websearch/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch/websearch_searxng.py
@@ -66,9 +66,12 @@ class SearXNGSearch(BaseSearch):
         """Check if SearXNG URL is configured."""
         return self.search_url is not None
 
-    @property
-    def _headers(self) -> dict:
-        """Generate headers necessary for making upstream query."""
+    def _build_headers(self, api_key: str | None = None) -> dict:
+        """Generate headers for SearXNG requests.
+
+        Args:
+            api_key: Unused — SearXNG does not require API keys.
+        """
         return {
             "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
             "Accept": "application/json",
@@ -166,7 +169,7 @@ class SearXNGSearch(BaseSearch):
         try:
             with httpx.Client(timeout=timeout) as client:
                 response = client.get(
-                    self.search_url, headers=self._headers, params=params
+                    self.search_url, headers=self._build_headers(), params=params
                 )
                 response.raise_for_status()
 

--- a/src/toolregistry_hub/websearch/websearch_serper.py
+++ b/src/toolregistry_hub/websearch/websearch_serper.py
@@ -66,11 +66,14 @@ class SerperSearch(BaseSearch):
 
         self.base_url = "https://google.serper.dev"
 
-    @property
-    def _headers(self) -> dict:
-        """Generate headers with API key authentication."""
+    def _build_headers(self, api_key: str | None = None) -> dict:
+        """Generate headers with the given API key.
+
+        Args:
+            api_key: Serper API key to use for authentication.
+        """
         return {
-            "X-API-KEY": self.api_key_parser.get_next_api_key(),
+            "X-API-KEY": api_key or "",
             "Content-Type": "application/json",
         }
 
@@ -169,43 +172,63 @@ class SerperSearch(BaseSearch):
 
         timeout = kwargs.get("timeout", TIMEOUT_DEFAULT)
 
-        try:
-            self._wait_for_rate_limit()
+        max_attempts = max(self.api_key_parser.key_count, 1)
 
-            with httpx.Client(timeout=timeout) as client:
-                response = client.post(
-                    f"{self.base_url}/search",
-                    headers=self._headers,
-                    json=payload,
-                )
-                response.raise_for_status()
+        for attempt in range(max_attempts):
+            try:
+                api_key = self.api_key_parser.get_next_valid_key()
+            except ValueError:
+                logger.error("All Serper API keys are currently unavailable")
+                break
 
-                data = response.json()
-                results = self._parse_results(data)
+            self.api_key_parser.wait_for_rate_limit(api_key=api_key)
 
-                logger.info(
-                    f"Serper search for '{query}' returned {len(results)} results"
-                )
-                return results
+            try:
+                with httpx.Client(timeout=timeout) as client:
+                    response = client.post(
+                        f"{self.base_url}/search",
+                        headers=self._build_headers(api_key),
+                        json=payload,
+                    )
+                    response.raise_for_status()
 
-        except httpx.TimeoutException:
-            logger.error(f"Serper API request timed out after {timeout}s")
-            return []
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 429:
-                logger.warning(
-                    "Rate limit exceeded, consider increasing rate_limit_delay"
-                )
-            logger.error(
-                f"Serper API HTTP error {e.response.status_code}: {e.response.text}"
-            )
-            return []
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse Serper API response: {e}")
-            return []
-        except Exception as e:
-            logger.error(f"Serper API request failed: {e}")
-            return []
+                    data = response.json()
+                    results = self._parse_results(data)
+
+                    logger.info(
+                        f"Serper search for '{query}' returned {len(results)} results"
+                    )
+                    return results
+
+            except httpx.TimeoutException:
+                logger.error(f"Serper API request timed out after {timeout}s")
+                return []
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if status in (401, 403):
+                    self.api_key_parser.mark_key_failed(
+                        api_key, f"HTTP {status}", ttl=3600.0
+                    )
+                    logger.warning(
+                        f"Serper API key auth failed (HTTP {status}), trying next key"
+                    )
+                    continue
+                if status == 429:
+                    self.api_key_parser.mark_key_failed(
+                        api_key, "rate limited", ttl=300.0
+                    )
+                    logger.warning("Serper API rate limit exceeded, trying next key")
+                    continue
+                logger.error(f"Serper API HTTP error {status}: {e.response.text}")
+                return []
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse Serper API response: {e}")
+                return []
+            except Exception as e:
+                logger.error(f"Serper API request failed: {e}")
+                return []
+
+        return []
 
     def _parse_results(self, raw_results: Any) -> list[SearchResult]:
         """Parse Serper API response into standardized format.
@@ -230,11 +253,6 @@ class SerperSearch(BaseSearch):
             results.append(result)
 
         return results
-
-    def _wait_for_rate_limit(self):
-        """Ensure minimum delay between API requests to avoid rate limits."""
-        current_key = self.api_key_parser.get_next_api_key()
-        self.api_key_parser.wait_for_rate_limit(api_key=current_key)
 
 
 def main():

--- a/src/toolregistry_hub/websearch/websearch_tavily.py
+++ b/src/toolregistry_hub/websearch/websearch_tavily.py
@@ -54,11 +54,14 @@ class TavilySearch(BaseSearch):
 
         self.base_url = "https://api.tavily.com"
 
-    @property
-    def _headers(self) -> dict:
-        """Generate headers with the current API key."""
+    def _build_headers(self, api_key: str | None = None) -> dict:
+        """Generate headers with the given API key.
+
+        Args:
+            api_key: Tavily API key to use for authentication.
+        """
         return {
-            "Authorization": f"Bearer {self.api_key_parser.get_next_api_key()}",
+            "Authorization": f"Bearer {api_key or ''}",
             "Content-Type": "application/json",
         }
 
@@ -135,39 +138,60 @@ class TavilySearch(BaseSearch):
                 payload[param] = kwargs[param]
 
         timeout = kwargs.get("timeout", TIMEOUT_DEFAULT)
-        try:
-            # Rate limiting: ensure minimum delay between requests
-            self._wait_for_rate_limit()
+        max_attempts = max(self.api_key_parser.key_count, 1)
 
-            with httpx.Client(timeout=timeout) as client:
-                response = client.post(
-                    f"{self.base_url}/search", headers=self._headers, json=payload
-                )
-                response.raise_for_status()
+        for attempt in range(max_attempts):
+            try:
+                api_key = self.api_key_parser.get_next_valid_key()
+            except ValueError:
+                logger.error("All Tavily API keys are currently unavailable")
+                break
 
-                data = response.json()
-                results = self._parse_results(data)
+            self.api_key_parser.wait_for_rate_limit(api_key=api_key)
 
-                logger.info(
-                    f"Tavily search for '{query}' returned {len(results)} results"
-                )
-                return results
+            try:
+                with httpx.Client(timeout=timeout) as client:
+                    response = client.post(
+                        f"{self.base_url}/search",
+                        headers=self._build_headers(api_key),
+                        json=payload,
+                    )
+                    response.raise_for_status()
 
-        except httpx.TimeoutException:
-            logger.error(f"Tavily API request timed out after {timeout}s")
-            return []
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 429:
-                logger.warning(
-                    "Rate limit exceeded, consider increasing rate_limit_delay"
-                )
-            logger.error(
-                f"Tavily API HTTP error {e.response.status_code}: {e.response.text}"
-            )
-            return []
-        except Exception as e:
-            logger.error(f"Tavily API request failed: {e}")
-            return []
+                    data = response.json()
+                    results = self._parse_results(data)
+
+                    logger.info(
+                        f"Tavily search for '{query}' returned {len(results)} results"
+                    )
+                    return results
+
+            except httpx.TimeoutException:
+                logger.error(f"Tavily API request timed out after {timeout}s")
+                return []
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if status in (401, 403):
+                    self.api_key_parser.mark_key_failed(
+                        api_key, f"HTTP {status}", ttl=3600.0
+                    )
+                    logger.warning(
+                        f"Tavily API key auth failed (HTTP {status}), trying next key"
+                    )
+                    continue
+                if status == 429:
+                    self.api_key_parser.mark_key_failed(
+                        api_key, "rate limited", ttl=300.0
+                    )
+                    logger.warning("Tavily API rate limit exceeded, trying next key")
+                    continue
+                logger.error(f"Tavily API HTTP error {status}: {e.response.text}")
+                return []
+            except Exception as e:
+                logger.error(f"Tavily API request failed: {e}")
+                return []
+
+        return []
 
     def _parse_results(self, raw_results: dict) -> list[SearchResult]:
         """Parse Tavily API response into standardized format.
@@ -201,12 +225,6 @@ class TavilySearch(BaseSearch):
             results.append(result)
 
         return results
-
-    def _wait_for_rate_limit(self):
-        """Ensure minimum delay between API requests to avoid rate limits."""
-        # Get the current API key and pass it to the rate limiter
-        current_key = self.api_key_parser.get_next_api_key()
-        self.api_key_parser.wait_for_rate_limit(api_key=current_key)
 
 
 def main():

--- a/tests/test_api_key_parser.py
+++ b/tests/test_api_key_parser.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import threading
 import time
 import unittest
 from unittest.mock import patch
@@ -157,6 +158,106 @@ class TestAPIKeyParser(unittest.TestCase):
         self.assertGreaterEqual(
             elapsed3, 0.05
         )  # Should have slept for at least some time
+
+
+class TestAPIKeyFailover(unittest.TestCase):
+    """Test cases for API key failover functionality."""
+
+    def test_mark_key_failed(self):
+        """Test marking a key as failed."""
+        parser = APIKeyParser(api_keys="key1,key2,key3")
+        parser.mark_key_failed("key1", "HTTP 401", ttl=3600)
+
+        failed = parser.failed_keys
+        self.assertIn("key1", failed)
+        self.assertEqual(failed["key1"], "HTTP 401")
+
+    def test_get_next_valid_key_skips_failed(self):
+        """Test that get_next_valid_key skips failed keys."""
+        parser = APIKeyParser(api_keys="key1,key2,key3")
+        parser.mark_key_failed("key1", "HTTP 401", ttl=3600)
+
+        # Should skip key1 and return key2
+        key = parser.get_next_valid_key()
+        self.assertNotEqual(key, "key1")
+
+    def test_get_next_valid_key_round_robin(self):
+        """Test round-robin with one failed key."""
+        parser = APIKeyParser(api_keys="key1,key2,key3")
+        parser.mark_key_failed("key2", "HTTP 403", ttl=3600)
+
+        keys = []
+        for _ in range(4):
+            keys.append(parser.get_next_valid_key())
+
+        # key2 should never appear
+        self.assertNotIn("key2", keys)
+        # key1 and key3 should appear
+        self.assertIn("key1", keys)
+        self.assertIn("key3", keys)
+
+    def test_all_keys_failed_raises(self):
+        """Test that ValueError is raised when all keys are failed."""
+        parser = APIKeyParser(api_keys="key1,key2")
+        parser.mark_key_failed("key1", "HTTP 401", ttl=3600)
+        parser.mark_key_failed("key2", "HTTP 403", ttl=3600)
+
+        with self.assertRaises(ValueError, msg="All API keys are currently failed"):
+            parser.get_next_valid_key()
+
+    def test_ttl_auto_recovery(self):
+        """Test that failed keys auto-recover after TTL expires."""
+        parser = APIKeyParser(api_keys="key1,key2")
+        parser.mark_key_failed("key1", "rate limited", ttl=0.1)
+
+        # Initially key1 should be failed
+        self.assertIn("key1", parser.failed_keys)
+
+        # Wait for TTL to expire
+        time.sleep(0.15)
+
+        # key1 should be auto-recovered
+        self.assertNotIn("key1", parser.failed_keys)
+
+        # get_next_valid_key should now return key1
+        key = parser.get_next_valid_key()
+        self.assertEqual(key, "key1")
+
+    def test_failed_keys_property(self):
+        """Test failed_keys property returns correct state."""
+        parser = APIKeyParser(api_keys="key1,key2,key3")
+        parser.mark_key_failed("key1", "HTTP 401", ttl=3600)
+        parser.mark_key_failed("key3", "rate limited", ttl=300)
+
+        failed = parser.failed_keys
+        self.assertEqual(len(failed), 2)
+        self.assertEqual(failed["key1"], "HTTP 401")
+        self.assertEqual(failed["key3"], "rate limited")
+
+    def test_thread_safety(self):
+        """Test that concurrent access to key rotation is thread-safe."""
+        parser = APIKeyParser(api_keys="key1,key2,key3", rate_limit_delay=0)
+        results = []
+        errors = []
+
+        def get_keys(n):
+            try:
+                for _ in range(n):
+                    results.append(parser.get_next_valid_key())
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=get_keys, args=(100,)) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(errors), 0)
+        self.assertEqual(len(results), 500)
+        # All results should be valid keys
+        for key in results:
+            self.assertIn(key, ["key1", "key2", "key3"])
 
 
 if __name__ == "__main__":

--- a/tests/websearch/test_websearch.py
+++ b/tests/websearch/test_websearch.py
@@ -64,8 +64,7 @@ class TestSearchResult:
 class ConcreteSearch(BaseSearch):
     """Concrete implementation for testing abstract base class."""
 
-    @property
-    def _headers(self) -> dict:
+    def _build_headers(self, api_key: str | None = None) -> dict:
         return {"User-Agent": "test"}
 
     def search(
@@ -229,10 +228,10 @@ class TestWebSearchIntegration:
         assert isinstance(results, list)
         assert len(results) == 2
 
-    def test_headers_property(self):
-        """Test that headers property works."""
+    def test_build_headers(self):
+        """Test that _build_headers method works."""
         searcher = ConcreteSearch()
-        headers = searcher._headers
+        headers = searcher._build_headers()
 
         assert isinstance(headers, dict)
         assert "User-Agent" in headers

--- a/tests/websearch/test_websearch_brightdata.py
+++ b/tests/websearch/test_websearch_brightdata.py
@@ -60,10 +60,10 @@ class TestBrightDataSearch:
     @patch(
         "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
     )
-    def test_headers_property(self, mock_ensure):
-        """Test headers property."""
+    def test_build_headers(self, mock_ensure):
+        """Test _build_headers method."""
         search = BrightDataSearch(api_keys="test_token")
-        headers = search._headers
+        headers = search._build_headers("test_token")
 
         assert headers["Authorization"] == "Bearer test_token"
         assert headers["Content-Type"] == "application/json"

--- a/tests/websearch/test_websearch_failover.py
+++ b/tests/websearch/test_websearch_failover.py
@@ -1,0 +1,160 @@
+"""Integration tests for API key failover across websearch implementations."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from toolregistry_hub.websearch.websearch_brave import BraveSearch
+
+
+class TestWebSearchFailover:
+    """Test API key failover behavior using BraveSearch as representative."""
+
+    def _make_search(self, num_keys=3):
+        keys = ",".join(f"key{i}" for i in range(1, num_keys + 1))
+        return BraveSearch(api_keys=keys, rate_limit_delay=0)
+
+    @patch("httpx.Client")
+    def test_retry_on_401(self, mock_client_cls):
+        """First key returns 401, second key succeeds."""
+        search = self._make_search(2)
+
+        response_401 = MagicMock()
+        response_401.status_code = 401
+        response_401.text = "Unauthorized"
+        response_401.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401", request=MagicMock(), response=response_401
+        )
+
+        response_ok = MagicMock()
+        response_ok.status_code = 200
+        response_ok.raise_for_status.return_value = None
+        response_ok.json.return_value = {
+            "web": {
+                "results": [
+                    {
+                        "title": "Result",
+                        "url": "https://example.com",
+                        "description": "desc",
+                    }
+                ]
+            }
+        }
+
+        client_instance = MagicMock()
+        client_instance.__enter__ = MagicMock(return_value=client_instance)
+        client_instance.__exit__ = MagicMock(return_value=False)
+        client_instance.get.side_effect = [response_401, response_ok]
+        mock_client_cls.return_value = client_instance
+
+        results = search.search("test query", max_results=5)
+
+        assert len(results) == 1
+        assert results[0].title == "Result"
+        # First key should be marked as failed
+        assert "key1" in search.api_key_parser.failed_keys
+
+    @patch("httpx.Client")
+    def test_retry_on_429(self, mock_client_cls):
+        """Rate-limited key is marked failed with shorter TTL."""
+        search = self._make_search(2)
+
+        response_429 = MagicMock()
+        response_429.status_code = 429
+        response_429.text = "Too Many Requests"
+        response_429.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "429", request=MagicMock(), response=response_429
+        )
+
+        response_ok = MagicMock()
+        response_ok.status_code = 200
+        response_ok.raise_for_status.return_value = None
+        response_ok.json.return_value = {
+            "web": {
+                "results": [
+                    {"title": "OK", "url": "https://ok.com", "description": "ok"}
+                ]
+            }
+        }
+
+        client_instance = MagicMock()
+        client_instance.__enter__ = MagicMock(return_value=client_instance)
+        client_instance.__exit__ = MagicMock(return_value=False)
+        client_instance.get.side_effect = [response_429, response_ok]
+        mock_client_cls.return_value = client_instance
+
+        results = search.search("test query", max_results=5)
+
+        assert len(results) == 1
+        failed = search.api_key_parser.failed_keys
+        assert "key1" in failed
+        assert failed["key1"] == "rate limited"
+
+    @patch("httpx.Client")
+    def test_all_keys_fail(self, mock_client_cls):
+        """All keys return 401 -> empty results."""
+        search = self._make_search(2)
+
+        response_401 = MagicMock()
+        response_401.status_code = 401
+        response_401.text = "Unauthorized"
+        response_401.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401", request=MagicMock(), response=response_401
+        )
+
+        client_instance = MagicMock()
+        client_instance.__enter__ = MagicMock(return_value=client_instance)
+        client_instance.__exit__ = MagicMock(return_value=False)
+        client_instance.get.side_effect = [response_401, response_401]
+        mock_client_cls.return_value = client_instance
+
+        results = search.search("test query", max_results=5)
+
+        assert results == []
+        assert len(search.api_key_parser.failed_keys) == 2
+
+    @patch("httpx.Client")
+    def test_failed_key_skipped_on_subsequent_call(self, mock_client_cls):
+        """A key marked failed is skipped in subsequent search calls."""
+        search = self._make_search(2)
+
+        # First call: key1 fails with 401, key2 succeeds
+        response_401 = MagicMock()
+        response_401.status_code = 401
+        response_401.text = "Unauthorized"
+        response_401.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401", request=MagicMock(), response=response_401
+        )
+
+        def make_ok_response():
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {
+                "web": {
+                    "results": [
+                        {"title": "R", "url": "https://r.com", "description": "d"}
+                    ]
+                }
+            }
+            return resp
+
+        client_instance = MagicMock()
+        client_instance.__enter__ = MagicMock(return_value=client_instance)
+        client_instance.__exit__ = MagicMock(return_value=False)
+        client_instance.get.side_effect = [
+            response_401,
+            make_ok_response(),
+            make_ok_response(),
+        ]
+        mock_client_cls.return_value = client_instance
+
+        # First search: triggers failover
+        search.search("test1", max_results=5)
+        assert "key1" in search.api_key_parser.failed_keys
+
+        # Second search: should only try key2 (key1 is still failed)
+        results = search.search("test2", max_results=5)
+        assert len(results) == 1
+        # Total get calls: 2 from first search (401 + ok) + 1 from second (ok)
+        assert client_instance.get.call_count == 3

--- a/tests/websearch/test_websearch_scrapeless.py
+++ b/tests/websearch/test_websearch_scrapeless.py
@@ -38,10 +38,10 @@ class TestScrapelessSearch:
             assert search.api_key_parser.key_count == 0
             assert not search._is_configured()
 
-    def test_headers_property(self):
-        """Test headers property."""
+    def test_build_headers(self):
+        """Test _build_headers method."""
         search = ScrapelessSearch(api_keys="test_key")
-        headers = search._headers
+        headers = search._build_headers("test_key")
 
         assert headers["Content-Type"] == "application/json"
         assert headers["X-API-Key"] == "test_key"

--- a/tests/websearch/test_websearch_searxng.py
+++ b/tests/websearch/test_websearch_searxng.py
@@ -45,10 +45,10 @@ class TestSearXNGSearch:
             assert searcher.search_url is None
             assert not searcher._is_configured()
 
-    def test_headers_property(self):
-        """Test headers property."""
+    def test_build_headers(self):
+        """Test _build_headers method."""
         searcher = SearXNGSearch("http://localhost:8080")
-        headers = searcher._headers
+        headers = searcher._build_headers()
 
         assert "User-Agent" in headers
         assert headers["Accept"] == "application/json"

--- a/tests/websearch/test_websearch_serper.py
+++ b/tests/websearch/test_websearch_serper.py
@@ -30,10 +30,10 @@ class TestSerperSearch:
             assert search.api_key_parser.key_count == 0
             assert not search._is_configured()
 
-    def test_headers_property(self):
-        """Test headers property."""
+    def test_build_headers(self):
+        """Test _build_headers method."""
         search = SerperSearch(api_keys="test_key")
-        headers = search._headers
+        headers = search._build_headers("test_key")
 
         assert headers["Content-Type"] == "application/json"
         assert headers["X-API-KEY"] == "test_key"


### PR DESCRIPTION
## Summary
- Add thread-safe failed key tracking to `APIKeyParser` with TTL-based auto-recovery (1h for 401/403, 5min for 429)
- Fix double key consumption bug: `_headers` property and `_wait_for_rate_limit()` both called `get_next_api_key()`, using two different keys per request. Replaced with `_build_headers(api_key)` method so the same key is used throughout
- Add retry loop in all API-key-based websearch implementations (Brave, Tavily, Serper, Scrapeless, BrightData) that automatically tries the next valid key on 401/403/429 errors
- SearXNG unchanged (no API keys)

Closes #53

## Test plan
- [x] 7 new unit tests for `APIKeyParser` failover (`mark_key_failed`, `get_next_valid_key`, TTL recovery, thread safety)
- [x] 4 new integration tests for websearch failover (401 retry, 429 retry, all-keys-fail, subsequent-call skip)
- [x] All 564 existing tests pass
- [x] ruff check/format clean
- [x] ty check passes