### PR TITLE
feat: implement FileReader.read_image()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dev = [
 reader = [
     "pypdf>=4.0.0",
 ]
+reader_image = [
+    "Pillow>=10.0.0",
+]
 reader_plus = [
     "pdfplumber>=0.10.0",
 ]

--- a/src/toolregistry_hub/file_reader.py
+++ b/src/toolregistry_hub/file_reader.py
@@ -1,19 +1,35 @@
 """Multi-format file reader with line numbers and pagination.
 
 Supports plain text (with line-numbered output and offset/limit),
-Jupyter notebooks (stdlib ``json``), and PDF files (optional dependency).
-Image reading is planned but blocked on upstream multimodal support.
+Jupyter notebooks (stdlib ``json``), PDF files (optional dependency),
+and image files (returned as multimodal content blocks).
 """
 
 from __future__ import annotations
 
+import base64
+import io
 import json
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Safety caps
 _MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB for text files
 _MAX_LINES_DEFAULT = 2000
 _MAX_PDF_PAGES = 20
+
+# Image constants
+_SUPPORTED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+_EXTENSION_TO_MIME = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+_MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB base64 budget
 
 
 class FileReader:
@@ -185,26 +201,151 @@ class FileReader:
         return "\n".join(lines)
 
     @staticmethod
-    def read_image(path: str) -> str:
-        """Read an image file and return as multimodal content block.
+    def read_image(
+        path: str,
+        max_size: int = _MAX_IMAGE_SIZE_BYTES,
+    ) -> list:
+        """Read an image file and return as multimodal content blocks.
 
-        .. note::
-            Not yet implemented. Blocked on upstream ``toolregistry`` support
-            for multimodal return types (image content blocks).
-            See: https://github.com/Oaklight/ToolRegistry/issues/101
-            Tracking: https://github.com/Oaklight/toolregistry-hub/issues/74
+        Returns a list of content blocks (TextBlock + ImageBlock) that the
+        toolregistry pipeline can expand into format-specific multimodal
+        messages via ``expand_content_blocks()``.
+
+        If the base64-encoded image exceeds ``max_size``, Pillow is used to
+        downsample it. If Pillow is not installed, the original image is
+        returned with a warning.
 
         Args:
-            path: Path to image file.
+            path: Path to image file (.png, .jpg, .jpeg, .gif, .webp).
+            max_size: Maximum base64-encoded size in bytes. Defaults to 5 MB.
+
+        Returns:
+            A list of two content blocks::
+
+                [
+                    {"type": "text", "text": "[Image: name (mime, size)]"},
+                    {"type": "image", "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "iVBOR..."
+                    }}
+                ]
 
         Raises:
-            NotImplementedError: Always. Pending upstream multimodal support.
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file extension is not supported.
         """
-        raise NotImplementedError(
-            "Image reading requires multimodal return type support from "
-            "upstream toolregistry. "
-            "See https://github.com/Oaklight/ToolRegistry/issues/101"
-        )
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+
+        ext = p.suffix.lower()
+        if ext not in _SUPPORTED_IMAGE_EXTENSIONS:
+            raise ValueError(
+                f"Unsupported image format: '{ext}'. "
+                f"Supported: {', '.join(sorted(_SUPPORTED_IMAGE_EXTENSIONS))}"
+            )
+
+        media_type = _EXTENSION_TO_MIME[ext]
+        img_data = p.read_bytes()
+        raw_size = len(img_data)
+
+        b64_data = base64.b64encode(img_data).decode("ascii")
+
+        if len(b64_data) > max_size:
+            img_data, media_type = FileReader._downsample_image(
+                img_data, media_type, max_size
+            )
+            b64_data = base64.b64encode(img_data).decode("ascii")
+
+        return [
+            {
+                "type": "text",
+                "text": f"[Image: {p.name} ({media_type}, {raw_size} bytes)]",
+            },
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": media_type,
+                    "data": b64_data,
+                },
+            },
+        ]
+
+    @staticmethod
+    def _downsample_image(
+        img_data: bytes,
+        media_type: str,
+        max_size: int,
+    ) -> tuple[bytes, str]:
+        """Downsample an image to fit within the base64 size budget.
+
+        Uses adaptive quality reduction based on ``target_ratio``. Strategy
+        inspired by payload-size-based compression (similar to argo-proxy).
+
+        If Pillow is not available, returns the original data with a warning
+        logged.
+
+        Args:
+            img_data: Raw image bytes.
+            media_type: MIME type of the image.
+            max_size: Target maximum base64-encoded size in bytes.
+
+        Returns:
+            Tuple of (compressed_bytes, output_media_type).
+        """
+        try:
+            from PIL import Image
+        except ImportError:
+            logger.warning(
+                "Pillow not installed; returning original image without "
+                "compression. Install with: pip install Pillow"
+            )
+            return img_data, media_type
+
+        current_b64_size = len(base64.b64encode(img_data))
+        target_ratio = max_size / current_b64_size
+
+        img = Image.open(io.BytesIO(img_data))
+
+        buf = io.BytesIO()
+
+        if media_type == "image/jpeg":
+            quality = max(int(85 * target_ratio), 20)
+            img = img.convert("RGB") if img.mode != "RGB" else img
+            img.save(buf, format="JPEG", quality=quality)
+            return buf.getvalue(), "image/jpeg"
+
+        if media_type == "image/png":
+            # Convert to JPEG for better compression; handle transparency
+            quality = max(int(75 * target_ratio), 15)
+            if img.mode in ("RGBA", "LA", "P"):
+                background = Image.new("RGB", img.size, (255, 255, 255))
+                if img.mode == "P":
+                    img = img.convert("RGBA")
+                background.paste(img, mask=img.split()[-1])
+                img = background
+            else:
+                img = img.convert("RGB")
+            img.save(buf, format="JPEG", quality=quality)
+            return buf.getvalue(), "image/jpeg"
+
+        if media_type == "image/webp":
+            quality = max(int(80 * target_ratio), 15)
+            img = img.convert("RGB") if img.mode not in ("RGB", "RGBA") else img
+            img.save(buf, format="WEBP", quality=quality)
+            return buf.getvalue(), "image/webp"
+
+        if media_type == "image/gif":
+            # Extract first frame and convert to JPEG
+            quality = max(int(70 * target_ratio), 15)
+            img = img.convert("RGB")
+            img.save(buf, format="JPEG", quality=quality)
+            return buf.getvalue(), "image/jpeg"
+
+        # Fallback: return as-is
+        return img_data, media_type
 
     # --- Private helpers ---
 

--- a/tests/test_file_reader.py
+++ b/tests/test_file_reader.py
@@ -1,11 +1,14 @@
 """Unit tests for FileReader module."""
 
+import base64
 import json
 import os
 import shutil
+import struct
 import tempfile
-
+import zlib
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -279,9 +282,129 @@ class TestFileReaderPdf:
         assert end - start + 1 == 20
 
 
+def _make_minimal_png(width: int = 1, height: int = 1) -> bytes:
+    """Generate a minimal valid PNG file in pure Python."""
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        c = chunk_type + data
+        return (
+            struct.pack(">I", len(data))
+            + c
+            + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+        )
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    ihdr = _chunk(b"IHDR", ihdr_data)
+    # Row data: filter byte + RGB pixels
+    raw = b""
+    for _ in range(height):
+        raw += b"\x00" + b"\xff\x00\x00" * width  # red pixels
+    idat = _chunk(b"IDAT", zlib.compress(raw))
+    iend = _chunk(b"IEND", b"")
+    return sig + ihdr + idat + iend
+
+
+def _make_minimal_jpeg() -> bytes:
+    """Generate a minimal valid JPEG using Pillow, or return a stub."""
+    try:
+        import io
+
+        from PIL import Image
+
+        img = Image.new("RGB", (2, 2), color=(255, 0, 0))
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        return buf.getvalue()
+    except ImportError:
+        pytest.skip("Pillow required to generate JPEG test data")
+
+
 class TestFileReaderImage:
     """Test cases for FileReader.read_image()."""
 
-    def test_raises_not_implemented(self):
-        with pytest.raises(NotImplementedError, match="multimodal"):
-            FileReader.read_image("/any/image.png")
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        shutil.rmtree(self.temp_dir)
+
+    def _write_image(self, name: str, data: bytes) -> str:
+        path = os.path.join(self.temp_dir, name)
+        with open(path, "wb") as f:
+            f.write(data)
+        return path
+
+    def test_read_image_png(self):
+        """PNG returns [TextBlock, ImageBlock]."""
+        png_data = _make_minimal_png()
+        path = self._write_image("test.png", png_data)
+        result = FileReader.read_image(path)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["type"] == "text"
+        assert result[1]["type"] == "image"
+        assert result[1]["source"]["media_type"] == "image/png"
+        assert result[1]["source"]["type"] == "base64"
+        # Verify round-trip
+        decoded = base64.b64decode(result[1]["source"]["data"])
+        assert decoded == png_data
+
+    def test_read_image_jpeg(self):
+        """JPEG returns correct content blocks."""
+        jpeg_data = _make_minimal_jpeg()
+        path = self._write_image("photo.jpg", jpeg_data)
+        result = FileReader.read_image(path)
+
+        assert len(result) == 2
+        assert result[1]["source"]["media_type"] == "image/jpeg"
+
+    def test_read_image_metadata_text_block(self):
+        """TextBlock contains filename, MIME type, and byte size."""
+        png_data = _make_minimal_png()
+        path = self._write_image("chart.png", png_data)
+        result = FileReader.read_image(path)
+
+        text = result[0]["text"]
+        assert "chart.png" in text
+        assert "image/png" in text
+        assert str(len(png_data)) in text
+
+    def test_read_image_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            FileReader.read_image(os.path.join(self.temp_dir, "nope.png"))
+
+    def test_read_image_unsupported_format(self):
+        path = self._write_image("photo.bmp", b"BM fake bmp data")
+        with pytest.raises(ValueError, match="Unsupported image format"):
+            FileReader.read_image(path)
+
+    def test_read_image_downsample(self):
+        """Large image is downsampled when Pillow is available."""
+        PIL = pytest.importorskip("PIL")  # noqa: F841
+        # Create a large PNG (100x100 = decent size after encoding)
+        png_data = _make_minimal_png(width=100, height=100)
+        path = self._write_image("big.png", png_data)
+
+        # Use a very small max_size to force downsampling
+        result = FileReader.read_image(path, max_size=100)
+
+        assert len(result) == 2
+        assert result[1]["type"] == "image"
+        # After downsampling PNG → JPEG
+        assert result[1]["source"]["media_type"] == "image/jpeg"
+
+    def test_read_image_no_pillow_fallback(self):
+        """Without Pillow, large image is returned as-is with warning."""
+        png_data = _make_minimal_png(width=50, height=50)
+        path = self._write_image("big.png", png_data)
+
+        with mock.patch.dict("sys.modules", {"PIL": None, "PIL.Image": None}):
+            result = FileReader.read_image(path, max_size=10)
+
+        assert len(result) == 2
+        # Original PNG data returned unchanged
+        decoded = base64.b64decode(result[1]["source"]["data"])
+        assert decoded == png_data
+        assert result[1]["source"]["media_type"] == "image/png"


### PR DESCRIPTION
## Summary

- Implement `read_image()` returning `[TextBlock, ImageBlock]` content blocks for downstream multimodal expansion via `expand_content_blocks()`
- Add `_downsample_image()` with adaptive quality reduction (Pillow optional dep) — format-specific quality floors for JPEG/PNG/WebP/GIF
- Add `reader_image` optional dependency group in pyproject.toml

## Test plan

- [x] `test_read_image_png` — PNG returns correct [TextBlock, ImageBlock], base64 round-trips
- [x] `test_read_image_jpeg` — JPEG with correct media type
- [x] `test_read_image_metadata_text_block` — TextBlock contains filename, MIME, size
- [x] `test_read_image_file_not_found` — FileNotFoundError
- [x] `test_read_image_unsupported_format` — .bmp raises ValueError
- [x] `test_read_image_downsample` — large image compressed via Pillow (PNG→JPEG)
- [x] `test_read_image_no_pillow_fallback` — without Pillow, returns original + warning

Closes #74