### PR TITLE
fix(searxng): support optional X-API-Key header

### DIFF
--- a/src/toolregistry_hub/websearch/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch/websearch_searxng.py
@@ -45,13 +45,16 @@ logger = get_logger()
 class SearXNGSearch(BaseSearch):
     """Simple SearXNG API client for web search functionality."""
 
-    def __init__(self, base_url: str | None = None):
+    def __init__(self, base_url: str | None = None, api_key: str | None = None):
         """Initialize SearXNG search client.
 
         Args:
             base_url: SearXNG instance URL. If not provided, will try to get from SEARXNG_URL env var.
+            api_key: Optional API key for instances that protect the JSON API.
+                If not provided, will try to get from SEARXNG_API_KEY env var.
         """
         self.base_url = base_url or os.getenv("SEARXNG_URL")
+        self.api_key = api_key or os.getenv("SEARXNG_API_KEY") or None
         if not self.base_url:
             # Deferred validation: allow empty initialization
             self.search_url = None
@@ -72,13 +75,18 @@ class SearXNGSearch(BaseSearch):
         """Generate headers for SearXNG requests.
 
         Args:
-            api_key: Unused — SearXNG does not require API keys.
+            api_key: Optional API key. Falls back to ``self.api_key`` when
+                not provided explicitly.
         """
-        return {
+        headers = {
             "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
             "Accept": "application/json",
             "Accept-Language": "en-US,en;q=0.9",
         }
+        key = api_key or self.api_key
+        if key:
+            headers["X-API-Key"] = key
+        return headers
 
     def search(
         self,

--- a/tests/websearch/test_websearch_searxng.py
+++ b/tests/websearch/test_websearch_searxng.py
@@ -38,6 +38,35 @@ class TestSearXNGSearch:
 
         assert searcher.base_url == "http://env-searxng:8080"
 
+    def test_init_with_api_key(self):
+        """Test initialization with explicit API key."""
+        searcher = SearXNGSearch("http://localhost:8080", api_key="my-secret-key")
+
+        assert searcher.api_key == "my-secret-key"
+
+    @patch.dict("os.environ", {"SEARXNG_API_KEY": "env-key"})
+    def test_init_api_key_from_env(self):
+        """Test initialization reads API key from environment variable."""
+        searcher = SearXNGSearch("http://localhost:8080")
+
+        assert searcher.api_key == "env-key"
+
+    @patch.dict(
+        "os.environ",
+        {"SEARXNG_URL": "http://env:8080", "SEARXNG_API_KEY": "env-key"},
+    )
+    def test_init_explicit_api_key_overrides_env(self):
+        """Test that explicit API key takes precedence over env var."""
+        searcher = SearXNGSearch(api_key="explicit-key")
+
+        assert searcher.api_key == "explicit-key"
+
+    def test_init_no_api_key(self):
+        """Test initialization without API key sets None."""
+        with patch.dict("os.environ", {}, clear=True):
+            searcher = SearXNGSearch("http://localhost:8080")
+            assert searcher.api_key is None
+
     def test_init_without_url_creates_unconfigured_instance(self):
         """Test that initialization without URL creates an unconfigured instance."""
         with patch.dict("os.environ", {}, clear=True):
@@ -45,13 +74,28 @@ class TestSearXNGSearch:
             assert searcher.search_url is None
             assert not searcher._is_configured()
 
-    def test_build_headers(self):
-        """Test _build_headers method."""
+    def test_build_headers_without_api_key(self):
+        """Test _build_headers without API key."""
         searcher = SearXNGSearch("http://localhost:8080")
         headers = searcher._build_headers()
 
         assert "User-Agent" in headers
         assert headers["Accept"] == "application/json"
+        assert "X-API-Key" not in headers
+
+    def test_build_headers_with_instance_api_key(self):
+        """Test _build_headers includes X-API-Key from instance."""
+        searcher = SearXNGSearch("http://localhost:8080", api_key="my-key")
+        headers = searcher._build_headers()
+
+        assert headers["X-API-Key"] == "my-key"
+
+    def test_build_headers_with_explicit_api_key(self):
+        """Test _build_headers with explicitly passed API key."""
+        searcher = SearXNGSearch("http://localhost:8080")
+        headers = searcher._build_headers(api_key="override-key")
+
+        assert headers["X-API-Key"] == "override-key"
 
     @patch("httpx.Client")
     def test_search_success(self, mock_client):


### PR DESCRIPTION
## Summary

- Add optional `api_key` parameter to `SearXNGSearch.__init__()`, with fallback to `SEARXNG_API_KEY` env var
- When set, sends `X-API-Key` header with requests; omitted when unset (fully backwards compatible)
- Add 6 new unit tests covering key init, env var fallback, priority, and header generation
- Update docs_en and docs_zh with env var table, parameter docs, and usage example

## Test plan

- [x] All 24 existing + new tests pass
- [x] `ruff check` and `ruff format` clean
- [ ] CI passes