### PR TITLE
feat(fetch): replace BS4 with readability + soup pipeline (#83)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
 dependencies = [
     "httpx>=0.28.1",
     "ua-generator>=1.0.6",
-    "beautifulsoup4>=4.13.4",
     "pydantic>=2.7.2,<3.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["src", "tests"]
+exclude = ["src/toolregistry_hub/_vendor"]
 
 [tool.ty.rules]
 unresolved-import = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ target-version = "py310"
 select = ["E", "F", "UP"]
 ignore = ["UP007", "E501"]
 
+[tool.ruff.lint.per-file-ignores]
+"src/toolregistry_hub/_vendor/**" = ["UP035"]
+
 [tool.ty.environment]
 python-version = "3.10"
 

--- a/src/toolregistry_hub/_vendor/readability/__init__.py
+++ b/src/toolregistry_hub/_vendor/readability/__init__.py
@@ -1,0 +1,1 @@
+from .readability import *  # noqa: F401,F403

--- a/src/toolregistry_hub/_vendor/readability/readability.py
+++ b/src/toolregistry_hub/_vendor/readability/readability.py
@@ -1,0 +1,1002 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = ["soup"]
+# tier = "medium"
+# category = "data"
+# note = "Install/update via `zerodep add readability`"
+# ///
+
+"""HTML readability content extractor — zero-dep, stdlib only, Python 3.10+.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Extracts the main article content from arbitrary web pages using a scoring
+algorithm inspired by Mozilla's Readability.js (Firefox Reader View).  Built
+on top of ``zerodep/soup`` for HTML parsing; no external dependencies.
+
+Algorithm overview:
+
+1. Pre-clean the DOM (remove scripts, styles, etc.)
+2. Extract metadata (JSON-LD, ``<meta>`` tags, ``<title>``)
+3. Remove unlikely candidate nodes (sidebars, footers, ads …)
+4. Transform mis-used ``<div>`` elements into ``<p>`` paragraphs
+5. Score every ``<p>``/``<pre>``/``<td>`` node based on comma count,
+   text length and class/id weight; propagate scores to parent &
+   grandparent
+6. Pick the highest-scoring container and include qualifying siblings
+7. Sanitize the extracted article (remove forms, low-quality headers …)
+8. If the result is too short, retry with relaxed heuristics
+
+Example::
+
+    from readability import extract, is_probably_readable
+
+    html = open("article.html").read()
+    if is_probably_readable(html):
+        result = extract(html)
+        print(result.title)
+        print(result.text[:200])
+
+References:
+    - Mozilla Readability.js: https://github.com/mozilla/readability
+    - python-readability: https://github.com/buriy/python-readability
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+import sys
+from dataclasses import dataclass
+from html import unescape
+from typing import Any
+
+__all__ = [
+    "ReadabilityResult",
+    "extract",
+    "is_probably_readable",
+]
+
+log = logging.getLogger(__name__)
+
+# ── Lazy soup import ─────────────────────────────────────────────────────────
+
+
+def _ensure_sibling_path(name: str) -> str:
+    """Add a sibling module directory to ``sys.path`` if not present."""
+    sibling_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", name))
+    if sibling_dir not in sys.path:
+        sys.path.insert(0, sibling_dir)
+    return sibling_dir
+
+
+def _load_soup():
+    _ensure_sibling_path("soup")
+    try:
+        from soup import Soup, Tag  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise NotImplementedError(
+            "readability requires the 'soup' zerodep module — "
+            "place soup/soup.py alongside readability/"
+        ) from exc
+    return Soup, Tag
+
+
+# ── Constants & regex patterns ───────────────────────────────────────────────
+
+MIN_PARAGRAPH_LENGTH = 25
+RETRY_LENGTH = 250
+DEFAULT_CHAR_THRESHOLD = 500
+
+UNLIKELY_CANDIDATES_RE = re.compile(
+    r"combx|comment|community|disqus|extra|foot|header|menu|remark|rss|"
+    r"shoutbox|sidebar|sponsor|ad-break|agegate|pagination|pager|popup|"
+    r"tweet|twitter|widget|breadcrumb|social|share|related|banner|"
+    r"cookie|consent|modal|overlay|nav\b",
+    re.I,
+)
+
+OK_MAYBE_CANDIDATE_RE = re.compile(
+    r"and|article|body|column|main|shadow|content",
+    re.I,
+)
+
+POSITIVE_RE = re.compile(
+    r"article|body|content|entry|hentry|h-entry|main|page|pagination|"
+    r"post|text|blog|story",
+    re.I,
+)
+
+NEGATIVE_RE = re.compile(
+    r"-ad-|hidden|^hid$| hid$| hid |^hid |banner|combx|comment|com-|"
+    r"contact|footer|gdpr|masthead|media|meta|outbrain|promo|related|"
+    r"scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|"
+    r"tool|widget",
+    re.I,
+)
+
+BLOCK_LEVEL_TAGS = frozenset(
+    {
+        "a",
+        "blockquote",
+        "dl",
+        "div",
+        "img",
+        "ol",
+        "p",
+        "pre",
+        "table",
+        "ul",
+        "section",
+        "figure",
+        "header",
+        "footer",
+        "nav",
+        "aside",
+        "details",
+        "fieldset",
+        "form",
+        "hr",
+        "noscript",
+        "video",
+        "audio",
+    }
+)
+
+TAGS_TO_SCORE = frozenset({"p", "pre", "td"})
+
+TAG_WEIGHTS: dict[str, int] = {
+    "div": 5,
+    "article": 5,
+    "pre": 3,
+    "td": 3,
+    "blockquote": 3,
+    "address": -3,
+    "ol": -3,
+    "ul": -3,
+    "dl": -3,
+    "dd": -3,
+    "dt": -3,
+    "li": -3,
+    "form": -3,
+    "aside": -3,
+    "h1": -5,
+    "h2": -5,
+    "h3": -5,
+    "h4": -5,
+    "h5": -5,
+    "h6": -5,
+    "th": -5,
+    "header": -5,
+    "footer": -5,
+    "nav": -5,
+}
+
+CLEAN_CONDITIONALLY_TAGS = frozenset(
+    {"table", "ul", "div", "aside", "header", "footer", "section"}
+)
+
+REMOVE_TAGS = frozenset({"form", "textarea", "input", "button", "select"})
+
+TITLE_SEPARATORS_RE = re.compile(r"\s+[\|\-–—\\/>»]\s+")
+
+# JSON-LD Article types (Schema.org)
+JSONLD_ARTICLE_TYPES = frozenset(
+    {
+        "Article",
+        "AdvertiserContentArticle",
+        "NewsArticle",
+        "AnalysisNewsArticle",
+        "AskPublicNewsArticle",
+        "BackgroundNewsArticle",
+        "OpinionNewsArticle",
+        "ReportageNewsArticle",
+        "ReviewNewsArticle",
+        "Report",
+        "SatiricalArticle",
+        "ScholarlyArticle",
+        "MedicalScholarlyArticle",
+        "SocialMediaPosting",
+        "BlogPosting",
+        "LiveBlogPosting",
+        "DiscussionForumPosting",
+        "TechArticle",
+        "APIReference",
+    }
+)
+
+# Multi-language commas for scoring
+COMMAS_RE = re.compile(r"[\u002C\u060C\uFE50\uFE10\uFE11\u2E41\u2E34\u2E32\uFF0C]")
+
+
+# ── Result dataclass ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ReadabilityResult:
+    """Container for extracted article data.
+
+    Attributes:
+        title: Article title (refined from ``<title>`` or headings).
+        content: Cleaned HTML of the main content.
+        text: Plain-text rendering of the main content.
+        author: Author name, or ``None``.
+        excerpt: Article excerpt / description, or ``None``.
+        site_name: Site name (e.g. from ``og:site_name``), or ``None``.
+        published_time: Publication timestamp string, or ``None``.
+        lang: Language code from ``<html lang="...">``, or ``None``.
+        dir: Text direction (``"ltr"`` / ``"rtl"``), or ``None``.
+        length: Character count of *text*.
+    """
+
+    title: str
+    content: str
+    text: str
+    author: str | None = None
+    excerpt: str | None = None
+    site_name: str | None = None
+    published_time: str | None = None
+    lang: str | None = None
+    dir: str | None = None
+    length: int = 0
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def extract(html: str, url: str | None = None) -> ReadabilityResult:
+    """Extract the main article content from an HTML string.
+
+    Args:
+        html: The full HTML document as a decoded string.
+        url: Optional base URL (currently unused; reserved for future
+            link absolutisation).
+
+    Returns:
+        A ``ReadabilityResult`` with the extracted content and metadata.
+    """
+    Soup, _Tag = _load_soup()
+    reader = _Readability(html, Soup, _Tag)
+    return reader.parse()
+
+
+def is_probably_readable(
+    html: str,
+    min_score: float = 20.0,
+    min_content_length: int = 140,
+) -> bool:
+    """Quick heuristic check whether *html* likely contains a readable article.
+
+    Uses the same approach as Mozilla's ``isProbablyReaderable``: accumulate
+    ``sqrt(textLen - threshold)`` over qualifying ``<p>``/``<pre>``/``<article>``
+    nodes and return ``True`` once the score exceeds *min_score*.
+
+    Args:
+        html: The HTML document string.
+        min_score: Minimum cumulative score to consider readable.
+        min_content_length: Minimum text length for a node to contribute.
+
+    Returns:
+        ``True`` if the page is probably an article.
+    """
+    Soup, _Tag = _load_soup()
+    soup = Soup(html)
+
+    score = 0.0
+    for tag in soup.find_all(["p", "pre", "article"]):
+        # Skip unlikely candidates
+        class_id = _get_class_id_string(tag)
+        if len(class_id) > 1:
+            is_unlikely = UNLIKELY_CANDIDATES_RE.search(class_id)
+            is_ok = OK_MAYBE_CANDIDATE_RE.search(class_id)
+            if is_unlikely and not is_ok:
+                continue
+
+        text = tag.get_text(strip=True)
+        text_len = len(text)
+        if text_len < min_content_length:
+            continue
+
+        score += math.sqrt(text_len - min_content_length)
+        if score >= min_score:
+            return True
+
+    return False
+
+
+# ── Internal helpers ─────────────────────────────────────────────────────────
+
+
+def _get_class_id_string(tag: Any) -> str:
+    """Return concatenated class and id for regex matching."""
+    cls = tag.get("class", [])
+    if isinstance(cls, list):
+        cls = " ".join(cls)
+    tag_id = tag.get("id", "")
+    return f"{cls} {tag_id}"
+
+
+def _normalize_spaces(s: str) -> str:
+    """Collapse all whitespace to single spaces and strip."""
+    return " ".join(s.split())
+
+
+def _text_length(tag: Any) -> int:
+    """Return the length of the whitespace-normalised text content."""
+    return len(_normalize_spaces(tag.get_text()))
+
+
+# ── Readability engine ───────────────────────────────────────────────────────
+
+
+class _Readability:
+    """Internal engine that implements the readability extraction algorithm."""
+
+    # Tags to discard during article-extraction parsing.  These are never
+    # part of the readable content and skipping them speeds up both tree
+    # construction and subsequent traversals.
+    _SKIP_TAGS = frozenset({"script", "style", "link", "noscript"})
+
+    def __init__(self, html: str, Soup: type, Tag: type) -> None:
+        self._raw_html = html
+        self._Soup = Soup
+        self._Tag = Tag
+        self._soup: Any = None
+
+    # ── Main entry point ─────────────────────────────────────────────────
+
+    def parse(self) -> ReadabilityResult:
+        """Run the full extraction pipeline and return a result."""
+        # Parse once: extract metadata from the fresh DOM before mutations.
+        self._soup = self._Soup(self._raw_html)
+        metadata = self._extract_metadata(self._soup)
+        lang = self._detect_lang(self._soup)
+        direction = self._detect_dir(self._soup)
+
+        # Grab article content.  The first iteration reuses self._soup
+        # (removing non-content tags in-place); retries use a faster
+        # parse that skips those tags during tree construction.
+        article_html, article_text = self._grab_article()
+
+        # If metadata title is empty, try to derive from article headings.
+        title = metadata.get("title", "")
+        if not title:
+            title = self._get_title_from_headings(self._soup) or ""
+
+        text = _normalize_spaces(article_text)
+        return ReadabilityResult(
+            title=title,
+            content=article_html,
+            text=text,
+            author=metadata.get("author"),
+            excerpt=metadata.get("excerpt"),
+            site_name=metadata.get("site_name"),
+            published_time=metadata.get("published_time"),
+            lang=lang,
+            dir=direction,
+            length=len(text),
+        )
+
+    # ── Article grabbing (with retry) ────────────────────────────────────
+
+    _PRE_CLEAN_TAGS = ["script", "style", "link", "noscript"]
+
+    def _grab_article(self) -> tuple[str, str]:
+        """Extract article content, retrying with relaxed rules if needed.
+
+        Returns:
+            ``(article_html, article_text)`` tuple.
+        """
+        ruthless = True
+
+        for _attempt in range(2):
+            if _attempt == 0:
+                # First attempt: reuse the DOM already parsed by parse()
+                # and strip non-content tags in-place.
+                self._pre_clean()
+            else:
+                # Retry: fast re-parse that skips non-content tags at the
+                # parser level (avoids building + decomposing subtrees).
+                self._soup = self._Soup(self._raw_html, skip_tags=self._SKIP_TAGS)
+
+            if ruthless:
+                self._remove_unlikely_candidates()
+
+            self._transform_divs_to_paragraphs()
+            candidates = self._score_paragraphs()
+
+            best = self._select_best_candidate(candidates)
+            if best is not None:
+                article_tag = self._get_article(best, candidates)
+                self._sanitize(article_tag)
+                article_html = article_tag.to_html()
+                article_text = article_tag.get_text(separator=" ", strip=True)
+
+                if len(article_text) >= RETRY_LENGTH or not ruthless:
+                    return article_html, article_text
+
+                # Too short — retry without ruthless filtering.
+                log.debug(
+                    "Article too short (%d chars), retrying without "
+                    "ruthless candidate removal",
+                    len(article_text),
+                )
+                ruthless = False
+                continue
+            else:
+                if ruthless:
+                    log.debug("No candidate found, retrying without ruthless")
+                    ruthless = False
+                    continue
+                # Fall back to body content.
+                break
+
+        # Final fallback: return body content as-is.
+        body = self._soup.find("body")
+        if body is not None:
+            return body.to_html(), body.get_text(separator=" ", strip=True)
+        return "", ""
+
+    # ── Pre-cleaning ─────────────────────────────────────────────────────
+
+    def _pre_clean(self) -> None:
+        """Remove script, style, link and other non-content tags."""
+        for tag in list(self._soup.find_all(self._PRE_CLEAN_TAGS)):
+            tag.decompose()
+
+    # ── Metadata extraction ──────────────────────────────────────────────
+
+    def _extract_metadata(self, soup: Any) -> dict[str, str | None]:
+        """Extract article metadata from JSON-LD and ``<meta>`` tags.
+
+        Args:
+            soup: A parsed ``Soup`` instance (unmutated).
+
+        Returns:
+            Dict with keys: title, author, excerpt, site_name, published_time.
+        """
+        meta: dict[str, str | None] = {
+            "title": None,
+            "author": None,
+            "excerpt": None,
+            "site_name": None,
+            "published_time": None,
+        }
+
+        # 1. Try JSON-LD first (highest priority).
+        self._parse_jsonld(soup, meta)
+
+        # 2. Parse <meta> tags.
+        self._parse_meta_tags(soup, meta)
+
+        # 3. Title from <title> element (if not yet found).
+        if not meta["title"]:
+            title_tag = soup.find("title")
+            if title_tag:
+                meta["title"] = _normalize_spaces(title_tag.get_text())
+
+        # 4. Refine title by removing site name suffixes.
+        if meta["title"]:
+            meta["title"] = self._shorten_title(meta["title"])
+
+        return meta
+
+    def _parse_jsonld(self, soup: Any, meta: dict[str, str | None]) -> None:
+        """Extract metadata from ``<script type="application/ld+json">``."""
+        for script in soup.find_all("script", attrs={"type": "application/ld+json"}):
+            text = script.get_text()
+            if not text:
+                continue
+            try:
+                data = json.loads(text)
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+            # Handle @graph arrays.
+            if isinstance(data, dict) and "@graph" in data:
+                graph = data["@graph"]
+                if isinstance(graph, list):
+                    for item in graph:
+                        if self._is_article_jsonld(item):
+                            data = item
+                            break
+                    else:
+                        continue
+
+            if not self._is_article_jsonld(data):
+                continue
+
+            if not meta["title"]:
+                meta["title"] = _str_or_none(data.get("headline")) or _str_or_none(
+                    data.get("name")
+                )
+            if not meta["author"]:
+                meta["author"] = self._extract_jsonld_author(data)
+            if not meta["excerpt"]:
+                meta["excerpt"] = _str_or_none(data.get("description"))
+            if not meta["published_time"]:
+                meta["published_time"] = _str_or_none(data.get("datePublished"))
+            if not meta["site_name"]:
+                publisher = data.get("publisher")
+                if isinstance(publisher, dict):
+                    meta["site_name"] = _str_or_none(publisher.get("name"))
+
+    @staticmethod
+    def _is_article_jsonld(data: Any) -> bool:
+        """Check if *data* is a Schema.org Article (or subtype)."""
+        if not isinstance(data, dict):
+            return False
+        schema_type = data.get("@type", "")
+        if isinstance(schema_type, list):
+            return any(t in JSONLD_ARTICLE_TYPES for t in schema_type)
+        return schema_type in JSONLD_ARTICLE_TYPES
+
+    @staticmethod
+    def _extract_jsonld_author(data: dict) -> str | None:
+        """Extract author name from JSON-LD, handling various formats."""
+        author = data.get("author")
+        if author is None:
+            return None
+        if isinstance(author, str):
+            return author
+        if isinstance(author, dict):
+            return _str_or_none(author.get("name"))
+        if isinstance(author, list):
+            names = []
+            for a in author:
+                if isinstance(a, str):
+                    names.append(a)
+                elif isinstance(a, dict) and "name" in a:
+                    names.append(a["name"])
+            return ", ".join(names) if names else None
+        return None
+
+    def _parse_meta_tags(self, soup: Any, meta: dict[str, str | None]) -> None:
+        """Extract metadata from ``<meta>`` tags (OpenGraph, DC, etc.)."""
+        # Mapping of meta property/name → target field + priority (lower wins).
+        property_map: dict[str, str] = {
+            "og:title": "title",
+            "og:description": "excerpt",
+            "og:site_name": "site_name",
+            "article:author": "author",
+            "article:published_time": "published_time",
+            "dc:title": "title",
+            "dc:creator": "author",
+            "dc:description": "excerpt",
+            "dcterm:title": "title",
+            "dcterm:creator": "author",
+            "dcterm:description": "excerpt",
+            "twitter:title": "title",
+            "twitter:description": "excerpt",
+        }
+        name_map: dict[str, str] = {
+            "author": "author",
+            "description": "excerpt",
+            "parsely-author": "author",
+            "parsely-pub-date": "published_time",
+            "parsely-title": "title",
+        }
+
+        for tag in soup.find_all("meta"):
+            content = tag.get("content", "")
+            if not content:
+                continue
+            content = _normalize_spaces(unescape(content))
+
+            prop = tag.get("property", "")
+            name = tag.get("name", "")
+
+            # Match by property attribute.
+            field = property_map.get(prop) or property_map.get(prop.lower())
+            if field and not meta[field]:
+                meta[field] = content
+                continue
+
+            # Match by name attribute.
+            field = name_map.get(name) or name_map.get(name.lower())
+            if field and not meta[field]:
+                meta[field] = content
+
+    @staticmethod
+    def _shorten_title(title: str) -> str:
+        """Remove site name suffixes/prefixes from *title*.
+
+        Handles patterns like ``"Article Title | Site Name"`` by
+        splitting on common separators and picking the most likely
+        article title part.
+        """
+        parts = TITLE_SEPARATORS_RE.split(title)
+        if len(parts) > 1:
+            # Heuristic: the longest part is usually the title, not
+            # the site name.  But if the longest part is very short
+            # (< 2 words) and it's not significantly longer than the
+            # second-longest, keep the original.
+            sorted_parts = sorted(parts, key=len, reverse=True)
+            best = sorted_parts[0]
+            second = sorted_parts[1] if len(sorted_parts) > 1 else ""
+            # Use the longest part if it's meaningfully longer than
+            # the second part, OR if the first/last part is clearly
+            # the title (common patterns).
+            if len(best) > len(second):
+                return best.strip()
+            # If parts are roughly equal length, use the first one
+            # (title typically comes first).
+            return parts[0].strip()
+
+        # Try colon separator.
+        if ": " in title:
+            colon_parts = title.split(": ")
+            # Use text after colon if before-colon is short.
+            if len(colon_parts[0].split()) <= 5:
+                return ": ".join(colon_parts[1:]).strip()
+
+        return title.strip()
+
+    # ── Language / direction detection ────────────────────────────────────
+
+    @staticmethod
+    def _detect_lang(soup: Any) -> str | None:
+        """Detect language from ``<html lang="...">``."""
+        html_tag = soup.find("html")
+        if html_tag is not None:
+            lang = html_tag.get("lang")
+            if lang:
+                return lang if isinstance(lang, str) else str(lang)
+        return None
+
+    @staticmethod
+    def _detect_dir(soup: Any) -> str | None:
+        """Detect text direction from ``dir`` attribute."""
+        for tag_name in ("html", "body"):
+            tag = soup.find(tag_name)
+            if tag is not None:
+                d = tag.get("dir")
+                if d and isinstance(d, str) and d.lower() in ("ltr", "rtl"):
+                    return d.lower()
+        return None
+
+    # ── Unlikely candidate removal ───────────────────────────────────────
+
+    def _remove_unlikely_candidates(self) -> None:
+        """Remove elements whose class/id suggests non-content."""
+        for tag in list(self._soup._all_descendants()):
+            if tag.name in ("html", "body"):
+                continue
+            class_id = _get_class_id_string(tag)
+            if len(class_id) <= 1:
+                continue
+            if UNLIKELY_CANDIDATES_RE.search(
+                class_id
+            ) and not OK_MAYBE_CANDIDATE_RE.search(class_id):
+                tag.decompose()
+
+    # ── Div-to-P transformation ──────────────────────────────────────────
+
+    def _transform_divs_to_paragraphs(self) -> None:
+        """Convert ``<div>`` elements without block children into ``<p>``."""
+        for div in list(self._soup.find_all("div")):
+            has_block = any(
+                isinstance(c, self._Tag) and c.name in BLOCK_LEVEL_TAGS
+                for c in div.children
+            )
+            if not has_block:
+                div.name = "p"
+
+    # ── Scoring ──────────────────────────────────────────────────────────
+
+    def _score_paragraphs(self) -> dict[int, dict[str, Any]]:
+        """Score paragraph-like nodes and propagate to ancestors.
+
+        Returns:
+            Dict mapping ``id(tag)`` → ``{"tag": tag, "score": float}``.
+        """
+        candidates: dict[int, dict[str, Any]] = {}
+
+        for tag in self._soup.find_all(list(TAGS_TO_SCORE)):
+            inner_text = _normalize_spaces(tag.get_text())
+            if len(inner_text) < MIN_PARAGRAPH_LENGTH:
+                continue
+
+            parent = tag.parent
+            grandparent = parent.parent if parent is not None else None
+
+            # Ensure parent is initialised.
+            if parent is not None and id(parent) not in candidates:
+                candidates[id(parent)] = {
+                    "tag": parent,
+                    "score": self._init_score(parent),
+                }
+            # Ensure grandparent is initialised.
+            if grandparent is not None and id(grandparent) not in candidates:
+                candidates[id(grandparent)] = {
+                    "tag": grandparent,
+                    "score": self._init_score(grandparent),
+                }
+
+            # Content score for this paragraph.
+            inner_len = len(inner_text)
+            content_score = 1.0
+            content_score += len(COMMAS_RE.findall(inner_text))
+            content_score += min(inner_len / 100.0, 3.0)
+
+            # Propagate to parent (full) and grandparent (half).
+            if parent is not None and id(parent) in candidates:
+                candidates[id(parent)]["score"] += content_score
+            if grandparent is not None and id(grandparent) in candidates:
+                candidates[id(grandparent)]["score"] += content_score / 2.0
+
+        # Scale scores by link density.
+        for entry in candidates.values():
+            ld = self._get_link_density(entry["tag"])
+            entry["score"] *= 1.0 - ld
+
+        return candidates
+
+    def _init_score(self, tag: Any) -> float:
+        """Compute initial score for a node based on tag name and class/id."""
+        score = float(TAG_WEIGHTS.get(tag.name, 0))
+        score += self._get_class_weight(tag)
+        return score
+
+    @staticmethod
+    def _get_class_weight(tag: Any) -> float:
+        """Return ±25 weight based on class and id attribute content."""
+        weight = 0.0
+        for attr in ("class", "id"):
+            value = tag.get(attr, "")
+            if isinstance(value, list):
+                value = " ".join(value)
+            if not value:
+                continue
+            if NEGATIVE_RE.search(value):
+                weight -= 25.0
+            if POSITIVE_RE.search(value):
+                weight += 25.0
+        return weight
+
+    @staticmethod
+    def _get_link_density(tag: Any) -> float:
+        """Ratio of link text length to total text length."""
+        total_len = _text_length(tag)
+        if total_len == 0:
+            return 0.0
+        link_len = sum(_text_length(a) for a in tag.find_all("a"))
+        return link_len / total_len
+
+    # ── Candidate selection ──────────────────────────────────────────────
+
+    @staticmethod
+    def _select_best_candidate(
+        candidates: dict[int, dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """Return the candidate with the highest score, or ``None``."""
+        if not candidates:
+            return None
+        return max(candidates.values(), key=lambda c: c["score"])
+
+    # ── Article assembly ─────────────────────────────────────────────────
+
+    def _get_article(
+        self, best: dict[str, Any], candidates: dict[int, dict[str, Any]]
+    ) -> Any:
+        """Build the article container from the best candidate + siblings.
+
+        Args:
+            best: The highest-scoring candidate dict.
+            candidates: All scored candidates.
+
+        Returns:
+            A new ``Tag`` containing the article content.
+        """
+        best_tag = best["tag"]
+        parent = best_tag.parent
+
+        # Create an article wrapper.
+        article = self._Tag("div")
+        sibling_threshold = max(10.0, best["score"] * 0.2)
+
+        # If there's no parent, use the candidate itself.
+        if parent is None:
+            article.append(best_tag.extract())
+            return article
+
+        for sibling in list(parent.children):
+            if isinstance(sibling, str):
+                if sibling.strip():
+                    article.append(sibling)
+                continue
+
+            should_include = False
+
+            if sibling is best_tag:
+                should_include = True
+            elif id(sibling) in candidates:
+                if candidates[id(sibling)]["score"] >= sibling_threshold:
+                    should_include = True
+            elif isinstance(sibling, self._Tag) and sibling.name == "p":
+                link_density = self._get_link_density(sibling)
+                text = _normalize_spaces(sibling.get_text())
+                text_len = len(text)
+                if text_len > 80 and link_density < 0.25:
+                    should_include = True
+                elif (
+                    text_len <= 80 and link_density == 0 and re.search(r"\.\s*$", text)
+                ):
+                    should_include = True
+
+            if should_include:
+                article.append(sibling.extract())
+
+        return article
+
+    # ── Sanitization ─────────────────────────────────────────────────────
+
+    _HEADING_TAGS_SET = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
+    # Combined list of form-related + heading tags for single find_all pass.
+    _REMOVE_AND_HEADING_TAGS = list(REMOVE_TAGS | _HEADING_TAGS_SET)
+
+    def _sanitize(self, article: Any) -> None:
+        """Clean the extracted article of low-quality elements."""
+        # 1+2. Remove form-related elements and low-quality headings in
+        # a single find_all pass instead of two separate traversals.
+        for tag in list(article.find_all(self._REMOVE_AND_HEADING_TAGS)):
+            if tag.name in REMOVE_TAGS:
+                tag.decompose()
+            else:
+                # Heading tag — check quality.
+                if self._get_class_weight(tag) < 0:
+                    tag.decompose()
+                elif self._get_link_density(tag) > 0.33:
+                    tag.decompose()
+
+        # 3. Conditional cleanup of tables, divs, lists, etc. — single
+        # find_all with all candidate tags instead of per-tag-name loops.
+        self._clean_conditionally_all(article)
+
+        # 4. Remove empty tags.
+        self._remove_empty_tags(article)
+
+    _EMBED_TAGS = frozenset({"embed", "object", "iframe"})
+
+    @staticmethod
+    def _count_child_tags(tag: Any, embed_tags: frozenset[str]) -> tuple:
+        """Count p, img, li, input, and embed descendant tags in one pass.
+
+        Args:
+            tag: The parent element to inspect.
+            embed_tags: Frozenset of tag names considered "embed-like".
+
+        Returns:
+            ``(p_count, img_count, li_count, input_count, embed_count)``.
+        """
+        p_count = img_count = li_count = input_count = embed_count = 0
+        for desc in tag._all_descendants():
+            dname = desc.name
+            if dname == "p":
+                p_count += 1
+            elif dname == "img":
+                img_count += 1
+            elif dname == "li":
+                li_count += 1
+            elif dname == "input":
+                input_count += 1
+            elif dname in embed_tags:
+                embed_count += 1
+        return p_count, img_count, li_count, input_count, embed_count
+
+    @staticmethod
+    def _should_remove_conditionally(
+        tag_name: str,
+        class_weight: float,
+        content_len: int,
+        link_density: float,
+        p_count: int,
+        img_count: int,
+        li_count: int,
+        input_count: int,
+        embed_count: int,
+    ) -> bool:
+        """Decide whether a conditionally-cleaned element should be removed.
+
+        Args:
+            tag_name: The tag name being evaluated.
+            class_weight: CSS class/id weight for the element.
+            content_len: Length of normalised inner text.
+            link_density: Ratio of link text to total text.
+            p_count: Number of ``<p>`` descendants.
+            img_count: Number of ``<img>`` descendants.
+            li_count: Number of ``<li>`` descendants.
+            input_count: Number of ``<input>`` descendants.
+            embed_count: Number of embed-like descendants.
+
+        Returns:
+            ``True`` if the element should be removed.
+        """
+        if img_count > 1 and p_count > 0 and (p_count / img_count) < 0.5:
+            return True
+        if li_count > p_count and tag_name not in ("ol", "ul"):
+            return True
+        if input_count > p_count / 3:
+            return True
+        if content_len < MIN_PARAGRAPH_LENGTH and (img_count == 0 or img_count > 2):
+            return True
+        if class_weight < 25 and link_density > 0.2:
+            return True
+        if class_weight >= 25 and link_density > 0.5:
+            return True
+        if (embed_count == 1 and content_len < 75) or (
+            embed_count > 1 and content_len < 200
+        ):
+            return True
+        return False
+
+    _CLEAN_COND_TAGS_LIST = list(CLEAN_CONDITIONALLY_TAGS)
+
+    def _clean_conditionally_all(self, article: Any) -> None:
+        """Remove conditionally-cleaned elements in a single find_all pass."""
+        for tag in list(article.find_all(self._CLEAN_COND_TAGS_LIST)):
+            class_weight = self._get_class_weight(tag)
+            # Quick reject: very negative weight.
+            if class_weight < -25:
+                tag.decompose()
+                continue
+
+            inner_text = _normalize_spaces(tag.get_text())
+            comma_count = len(COMMAS_RE.findall(inner_text))
+
+            # Commas indicate content-rich nodes; keep them.
+            if comma_count >= 10:
+                continue
+
+            counts = self._count_child_tags(tag, self._EMBED_TAGS)
+            content_len = len(inner_text)
+            link_density = self._get_link_density(tag)
+
+            if self._should_remove_conditionally(
+                tag.name, class_weight, content_len, link_density, *counts
+            ):
+                tag.decompose()
+
+    @staticmethod
+    def _remove_empty_tags(article: Any) -> None:
+        """Remove tags that have no text content and no images/embeds."""
+        keep_tags = frozenset(
+            {"img", "br", "hr", "embed", "object", "iframe", "video", "audio"}
+        )
+        # Process in reverse document order (children before parents) so
+        # that a single pass is sufficient.
+        for tag in reversed(article._all_descendants()):
+            if tag.name in keep_tags:
+                continue
+            if not tag.children:
+                tag.decompose()
+            elif not tag.get_text(strip=True) and not tag.find_all(list(keep_tags)):
+                tag.decompose()
+
+    # ── Title fallback from headings ─────────────────────────────────────
+
+    @staticmethod
+    def _get_title_from_headings(soup: Any) -> str | None:
+        """Try to find a title from ``<h1>`` or ``<h2>`` headings."""
+        for level in ("h1", "h2"):
+            heading = soup.find(level)
+            if heading is not None:
+                text = _normalize_spaces(heading.get_text())
+                if text:
+                    return text
+        return None
+
+
+# ── Module-level helpers ─────────────────────────────────────────────────────
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Return a non-empty stripped string or ``None``."""
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s if s else None

--- a/src/toolregistry_hub/_vendor/scheduler/__init__.py
+++ b/src/toolregistry_hub/_vendor/scheduler/__init__.py
@@ -1,0 +1,2 @@
+from .scheduler import *  # noqa: F401,F403
+from .scheduler import _cron_next_fire_time  # noqa: F401

--- a/src/toolregistry_hub/_vendor/scheduler/scheduler.py
+++ b/src/toolregistry_hub/_vendor/scheduler/scheduler.py
@@ -1,8 +1,9 @@
 # /// zerodep
-# version = "0.3.0"
+# version = "0.3.1"
 # deps = []
 # tier = "subsystem"
 # category = "process"
+# note = "Install/update via `zerodep add scheduler`"
 # ///
 
 """Zero-dependency in-process task scheduler with cron support.
@@ -55,8 +56,7 @@ import logging
 import threading
 import uuid
 from datetime import datetime, timedelta, timezone
-from collections.abc import Callable
-from typing import Any
+from typing import Any, Callable
 
 __all__ = [
     # Constants
@@ -180,6 +180,109 @@ _DOW_NAMES = {
 }
 
 
+def _resolve_name_or_int(token: str) -> int:
+    """Resolve a cron token to an integer.
+
+    Checks named month and day-of-week aliases first, then falls back
+    to ``int(token)``.
+
+    Args:
+        token: Raw token string (e.g. ``"jan"``, ``"5"``).
+
+    Returns:
+        The resolved integer value.
+
+    Raises:
+        ValueError: If the token is not a known name and not a valid integer.
+    """
+    lower = token.lower()
+    val = _MONTH_NAMES.get(lower)
+    if val is not None:
+        return val
+    val = _DOW_NAMES.get(lower)
+    if val is not None:
+        return val
+    return int(token)
+
+
+def _extract_step(part: str, field: str) -> tuple[str, int]:
+    """Split a cron part on ``/`` and return ``(base, step)``.
+
+    Args:
+        part: A single comma-separated cron part (e.g. ``"*/2"``).
+        field: The full field string, used in error messages.
+
+    Returns:
+        A tuple of ``(base_string, step_int)``.
+
+    Raises:
+        InvalidCronExpression: On invalid step value.
+    """
+    if "/" not in part:
+        return part, 1
+    base, step_str = part.split("/", 1)
+    try:
+        step = int(step_str)
+    except ValueError:
+        raise InvalidCronExpression(field, f"invalid step: {step_str!r}")
+    if step < 1:
+        raise InvalidCronExpression(field, f"step must be >= 1, got {step}")
+    return base, step
+
+
+def _parse_cron_range(part: str, step: int, lo: int, hi: int, field: str) -> set[int]:
+    """Parse a range expression like ``1-5`` with an optional step.
+
+    Args:
+        part: The range string (e.g. ``"1-5"``, ``"mon-fri"``).
+        step: Step value for the range.
+        lo: Minimum allowed value for the field.
+        hi: Maximum allowed value for the field.
+        field: The full field string, used in error messages.
+
+    Returns:
+        Set of integers in the range.
+
+    Raises:
+        InvalidCronExpression: On invalid range bounds.
+    """
+    rlo_str, rhi_str = part.split("-", 1)
+    try:
+        rlo = _resolve_name_or_int(rlo_str)
+        rhi = _resolve_name_or_int(rhi_str)
+    except ValueError:
+        raise InvalidCronExpression(field, f"invalid range: {part!r}")
+    if rlo < lo or rhi > hi or rlo > rhi:
+        raise InvalidCronExpression(
+            field, f"range {rlo}-{rhi} out of bounds [{lo}-{hi}]"
+        )
+    return set(range(rlo, rhi + 1, step))
+
+
+def _parse_cron_literal(part: str, lo: int, hi: int, field: str) -> int:
+    """Parse a single literal cron value.
+
+    Args:
+        part: The literal string (e.g. ``"5"``, ``"jan"``).
+        lo: Minimum allowed value for the field.
+        hi: Maximum allowed value for the field.
+        field: The full field string, used in error messages.
+
+    Returns:
+        The parsed integer value.
+
+    Raises:
+        InvalidCronExpression: On invalid or out-of-range values.
+    """
+    try:
+        val = _resolve_name_or_int(part)
+    except ValueError:
+        raise InvalidCronExpression(field, f"invalid value: {part!r}")
+    if val < lo or val > hi:
+        raise InvalidCronExpression(field, f"value {val} out of bounds [{lo}-{hi}]")
+    return val
+
+
 def _parse_cron_field(field: str, lo: int, hi: int) -> frozenset[int]:
     """Parse a single cron field into a set of allowed values.
 
@@ -204,65 +307,14 @@ def _parse_cron_field(field: str, lo: int, hi: int) -> frozenset[int]:
         if not part:
             raise InvalidCronExpression(field, "empty part in list")
 
-        # Handle step
-        step = 1
-        if "/" in part:
-            base, step_str = part.split("/", 1)
-            try:
-                step = int(step_str)
-            except ValueError:
-                raise InvalidCronExpression(field, f"invalid step: {step_str!r}")
-            if step < 1:
-                raise InvalidCronExpression(field, f"step must be >= 1, got {step}")
-            part = base
-
-        # Resolve named values
-        part_lower = part.lower()
-        if part_lower in _MONTH_NAMES:
-            val = _MONTH_NAMES[part_lower]
-            if lo <= val <= hi:
-                result.add(val)
-                continue
-        if part_lower in _DOW_NAMES:
-            val = _DOW_NAMES[part_lower]
-            if lo <= val <= hi:
-                result.add(val)
-                continue
+        part, step = _extract_step(part, field)
 
         if part == "*":
             result.update(range(lo, hi + 1, step))
         elif "-" in part:
-            range_parts = part.split("-", 1)
-            try:
-                rlo_str, rhi_str = range_parts
-                # Resolve names in ranges
-                rlo = (
-                    _MONTH_NAMES.get(rlo_str.lower())
-                    or _DOW_NAMES.get(rlo_str.lower())
-                    or int(rlo_str)
-                )
-                rhi = (
-                    _MONTH_NAMES.get(rhi_str.lower())
-                    or _DOW_NAMES.get(rhi_str.lower())
-                    or int(rhi_str)
-                )
-            except ValueError:
-                raise InvalidCronExpression(field, f"invalid range: {part!r}")
-            if rlo < lo or rhi > hi or rlo > rhi:
-                raise InvalidCronExpression(
-                    field, f"range {rlo}-{rhi} out of bounds [{lo}-{hi}]"
-                )
-            result.update(range(rlo, rhi + 1, step))
+            result.update(_parse_cron_range(part, step, lo, hi, field))
         else:
-            try:
-                val = int(part)
-            except ValueError:
-                raise InvalidCronExpression(field, f"invalid value: {part!r}")
-            if val < lo or val > hi:
-                raise InvalidCronExpression(
-                    field, f"value {val} out of bounds [{lo}-{hi}]"
-                )
-            result.add(val)
+            result.add(_parse_cron_literal(part, lo, hi, field))
 
     return frozenset(result)
 

--- a/src/toolregistry_hub/_vendor/soup/__init__.py
+++ b/src/toolregistry_hub/_vendor/soup/__init__.py
@@ -1,0 +1,1 @@
+from .soup import *  # noqa: F401,F403

--- a/src/toolregistry_hub/_vendor/soup/soup.py
+++ b/src/toolregistry_hub/_vendor/soup/soup.py
@@ -1,0 +1,998 @@
+# /// zerodep
+# version = "0.6.0"
+# deps = []
+# tier = "medium"
+# category = "data"
+# note = "Install/update via `zerodep add soup`"
+# ///
+
+"""HTML parser with BeautifulSoup-like API — zero-dep, stdlib only, Python 3.10+.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Provides a lightweight DOM tree built on top of ``html.parser.HTMLParser``.
+Supports ``find``, ``find_all``, ``select``, ``select_one``, ``get_text``,
+``decompose``, and ``find_parent`` — the subset of BeautifulSoup used by
+the vast majority of real-world scraping scripts.
+
+Supports CSS pseudo-selectors: ``:first-child``, ``:last-child``,
+``:only-child``, and ``:not(selector)``.
+
+Does NOT implement: ``.prettify()``, ``.stripped_strings``, ``.descendants``
+iterator, ``.next_sibling`` / ``.previous_sibling``, ``NavigableString`` class,
+multiple parser backends.
+
+Example::
+
+    soup = Soup("<html><body><p class='msg'>Hello</p></body></html>")
+    print(soup.find("p", class_="msg").text)
+    # Hello
+"""
+
+from __future__ import annotations
+
+import re
+from html.parser import HTMLParser
+from typing import Any
+
+__all__ = [
+    "SELF_CLOSING_TAGS",
+    "Tag",
+    "Soup",
+]
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+SELF_CLOSING_TAGS = frozenset(
+    {
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    }
+)
+
+# ── Tag ───────────────────────────────────────────────────────────────────────
+
+
+class Tag:
+    """A single HTML element node.
+
+    Attributes:
+        name: Tag name (e.g. ``"div"``).
+        attrs: Dictionary of attribute name to value.  The ``class`` attribute
+            is stored as a **list** of class names; all others as ``str``.
+        children: Ordered child nodes — either ``Tag`` or plain ``str``.
+        parent: Parent ``Tag``, or ``None`` for the root document.
+    """
+
+    __slots__ = ("name", "attrs", "children", "parent")
+
+    def __init__(
+        self,
+        name: str,
+        attrs: dict[str, str | list[str]] | None = None,
+        parent: Tag | None = None,
+    ) -> None:
+        self.name: str = name
+        self.attrs: dict[str, str | list[str]] = attrs if attrs is not None else {}
+        self.children: list[Tag | str] = []
+        self.parent: Tag | None = parent
+
+    # ── Attribute access ──────────────────────────────────────────────────
+
+    def get(self, attr: str, default: Any = None) -> Any:
+        """Return attribute value, or *default* if not present."""
+        return self.attrs.get(attr, default)
+
+    def __getitem__(self, attr: str) -> Any:
+        """Return attribute value; raise ``KeyError`` if missing."""
+        return self.attrs[attr]
+
+    def __contains__(self, attr: str) -> bool:
+        return attr in self.attrs
+
+    def __setitem__(self, attr: str, value: Any) -> None:
+        """Set an attribute value (e.g. ``tag['id'] = 'main'``)."""
+        self.attrs[attr] = value
+
+    def __delitem__(self, attr: str) -> None:
+        """Delete an attribute (e.g. ``del tag['id']``)."""
+        del self.attrs[attr]
+
+    # ── Text helpers ──────────────────────────────────────────────────────
+
+    @property
+    def text(self) -> str:
+        """Concatenated text content of this element and all descendants."""
+        return self.get_text()
+
+    @property
+    def string(self) -> str | None:
+        """If this element has exactly one text child (possibly nested), return it.
+
+        Returns ``None`` when the element has no children, multiple children,
+        or a mix of text and tags.
+        """
+        # Direct single-text child
+        if len(self.children) == 1:
+            child = self.children[0]
+            if isinstance(child, str):
+                return child
+            return child.string
+        # No children or multiple children -> None
+        return None
+
+    def get_text(self, separator: str = "", strip: bool = False) -> str:
+        """Return all text under this element concatenated.
+
+        Args:
+            separator: Inserted between text fragments.
+            strip: If ``True`` each fragment is whitespace-stripped and empty
+                fragments are dropped.
+
+        Returns:
+            The combined text.
+        """
+        parts: list[str] = []
+        self._collect_text(parts)
+        if strip:
+            parts = [p.strip() for p in parts]
+            parts = [p for p in parts if p]
+        return separator.join(parts)
+
+    def _collect_text(self, acc: list[str]) -> None:
+        for child in self.children:
+            if isinstance(child, str):
+                acc.append(child)
+            else:
+                child._collect_text(acc)
+
+    # ── Tree modification ─────────────────────────────────────────────────
+
+    def append(self, child: Tag | str) -> None:
+        """Append *child* to this element's children.
+
+        If *child* is a ``Tag`` already attached to a parent, it is first
+        detached from its old position.
+
+        Args:
+            child: A ``Tag`` or plain text string to append.
+        """
+        if isinstance(child, Tag):
+            if child.parent is not None:
+                try:
+                    child.parent.children.remove(child)
+                except ValueError:
+                    pass
+            child.parent = self
+        self.children.append(child)
+
+    def insert(self, index: int, child: Tag | str) -> None:
+        """Insert *child* at *index* in this element's children.
+
+        Args:
+            index: Position to insert at (same semantics as ``list.insert``).
+            child: A ``Tag`` or plain text string to insert.
+        """
+        if isinstance(child, Tag):
+            if child.parent is not None:
+                try:
+                    child.parent.children.remove(child)
+                except ValueError:
+                    pass
+            child.parent = self
+        self.children.insert(index, child)
+
+    def extract(self) -> Tag:
+        """Remove this element from its parent but keep its content intact.
+
+        Unlike ``decompose``, the element and its subtree remain usable
+        after extraction.
+
+        Returns:
+            This element (now detached).
+        """
+        if self.parent is not None:
+            try:
+                self.parent.children.remove(self)
+            except ValueError:
+                pass
+            self.parent = None
+        return self
+
+    def replace_with(self, new_node: Tag | str) -> Tag:
+        """Replace this element with *new_node* in the parent's children.
+
+        Args:
+            new_node: The replacement ``Tag`` or text string.
+
+        Returns:
+            This element (now detached).
+
+        Raises:
+            ValueError: If the element has no parent.
+        """
+        if self.parent is None:
+            raise ValueError("Cannot replace a detached element")
+        parent = self.parent
+        for i, child in enumerate(parent.children):
+            if child is self:
+                parent.children[i] = new_node
+                if isinstance(new_node, Tag):
+                    if new_node.parent is not None:
+                        try:
+                            new_node.parent.children.remove(new_node)
+                        except ValueError:
+                            pass
+                    new_node.parent = parent
+                self.parent = None
+                return self
+        raise ValueError("Element not found in parent's children")  # pragma: no cover
+
+    def unwrap(self) -> None:
+        """Remove this tag but keep its children (re-parent them).
+
+        The children are spliced into the parent's children list at the
+        position formerly occupied by this element.
+        """
+        if self.parent is None:
+            return
+        parent = self.parent
+        idx = next(i for i, c in enumerate(parent.children) if c is self)
+        # Splice children into parent at the position of this element.
+        for child in self.children:
+            if isinstance(child, Tag):
+                child.parent = parent
+        parent.children[idx : idx + 1] = self.children
+        self.children = []
+        self.parent = None
+
+    def decompose(self) -> None:
+        """Remove this element from its parent and discard its content."""
+        if self.parent is not None:
+            try:
+                self.parent.children.remove(self)
+            except ValueError:
+                pass
+            self.parent = None
+        self.children.clear()
+
+    # ── Searching ─────────────────────────────────────────────────────────
+
+    def find(
+        self,
+        name: str | list[str] | None = None,
+        attrs: dict[str, str | bool] | None = None,
+        *,
+        class_: str | None = None,
+        **kwargs: str | bool,
+    ) -> Tag | None:
+        """Return the first descendant matching the criteria, or ``None``.
+
+        Args:
+            name: Tag name(s) to match. ``None`` matches any tag.
+            attrs: Dict of attribute filters.
+            class_: Shorthand for ``attrs={"class": value}``.
+            **kwargs: Extra attribute filters (``href=True`` means *has* href).
+
+        Returns:
+            The first matching ``Tag``, or ``None``.
+        """
+        results = self.find_all(name, attrs, class_=class_, limit=1, **kwargs)
+        return results[0] if results else None
+
+    def find_all(
+        self,
+        name: str | list[str] | None = None,
+        attrs: dict[str, str | bool] | None = None,
+        *,
+        class_: str | None = None,
+        limit: int | None = None,
+        **kwargs: str | bool,
+    ) -> list[Tag]:
+        """Return all descendants matching the criteria.
+
+        Args:
+            name: Tag name(s) to match.
+            attrs: Dict of attribute filters.
+            class_: Shorthand for ``attrs={"class": value}``.
+            limit: Stop after finding this many results.
+            **kwargs: Extra attribute filters.
+
+        Returns:
+            A list of matching ``Tag`` objects.
+        """
+        merged = dict(attrs) if attrs else {}
+        if class_ is not None:
+            merged["class"] = class_
+        merged.update(kwargs)
+
+        # Fast path: name-only search with no attribute filters.
+        if not merged:
+            if isinstance(name, str):
+                results: list[Tag] = []
+                self._search_by_single_name(name, results, limit)
+                return results
+            if isinstance(name, list):
+                name_set: frozenset[str] = frozenset(name)
+                results = []
+                self._search_by_name_set(name_set, results, limit)
+                return results
+
+        if isinstance(name, list):
+            name_set = frozenset(name)
+        else:
+            name_set = None  # type: ignore[assignment]
+
+        results = []
+        self._search(name, name_set, merged, results, limit)
+        return results
+
+    def __call__(self, *args: Any, **kwargs: Any) -> list[Tag]:
+        """Calling a tag is equivalent to ``find_all``."""
+        return self.find_all(*args, **kwargs)
+
+    def _search(
+        self,
+        name: str | list[str] | None,
+        name_set: frozenset[str] | None,
+        attr_filters: dict[str, str | bool],
+        results: list[Tag],
+        limit: int | None,
+    ) -> None:
+        for child in self.children:
+            if limit is not None and len(results) >= limit:
+                return
+            if isinstance(child, Tag):
+                if _matches(child, name, name_set, attr_filters):
+                    results.append(child)
+                    if limit is not None and len(results) >= limit:
+                        return
+                child._search(name, name_set, attr_filters, results, limit)
+
+    def _search_by_name_set(
+        self,
+        name_set: frozenset[str],
+        results: list[Tag],
+        limit: int | None,
+    ) -> None:
+        """Fast path for searching by a set of tag names with no attr filters."""
+        for child in self.children:
+            if limit is not None and len(results) >= limit:
+                return
+            if isinstance(child, Tag):
+                if child.name in name_set:
+                    results.append(child)
+                    if limit is not None and len(results) >= limit:
+                        return
+                child._search_by_name_set(name_set, results, limit)
+
+    def _search_by_single_name(
+        self,
+        name: str,
+        results: list[Tag],
+        limit: int | None,
+    ) -> None:
+        """Fast path for searching by a single tag name with no attr filters."""
+        for child in self.children:
+            if limit is not None and len(results) >= limit:
+                return
+            if isinstance(child, Tag):
+                if child.name == name:
+                    results.append(child)
+                    if limit is not None and len(results) >= limit:
+                        return
+                child._search_by_single_name(name, results, limit)
+
+    # ── find_parent ───────────────────────────────────────────────────────
+
+    def find_parent(self, name: str | None = None) -> Tag | None:
+        """Walk up the tree and return the first ancestor matching *name*.
+
+        Args:
+            name: Tag name to match. ``None`` returns the immediate parent.
+
+        Returns:
+            The matching ancestor ``Tag``, or ``None``.
+        """
+        node = self.parent
+        if name is None:
+            return node
+        while node is not None:
+            if node.name == name:
+                return node
+            node = node.parent
+        return None
+
+    # ── CSS selectors ─────────────────────────────────────────────────────
+
+    def select(self, css_selector: str) -> list[Tag]:
+        """Return all descendants matching a CSS selector (simple subset).
+
+        Supported patterns: ``tag``, ``.class``, ``#id``, ``[attr]``,
+        ``[attr="value"]``, descendant (``a b``), child (``a > b``),
+        compound (``div.cls#id``), multiple classes (``div.a.b``).
+
+        Args:
+            css_selector: The CSS selector string.
+
+        Returns:
+            A list of matching ``Tag`` objects.
+        """
+        parts = _parse_selector(css_selector)
+        candidates: list[Tag] = self._all_descendants()
+        return [tag for tag in candidates if _selector_matches(tag, parts)]
+
+    def select_one(self, css_selector: str) -> Tag | None:
+        """Like ``select``, but return only the first match (or ``None``).
+
+        Args:
+            css_selector: The CSS selector string.
+
+        Returns:
+            The first matching ``Tag``, or ``None``.
+        """
+        parts = _parse_selector(css_selector)
+        for tag in self._all_descendants():
+            if _selector_matches(tag, parts):
+                return tag
+        return None
+
+    def _all_descendants(self) -> list[Tag]:
+        """Collect all descendant Tag nodes in document order."""
+        result: list[Tag] = []
+        self._collect_descendants(result)
+        return result
+
+    def _collect_descendants(self, acc: list[Tag]) -> None:
+        for child in self.children:
+            if isinstance(child, Tag):
+                acc.append(child)
+                child._collect_descendants(acc)
+
+    # ── Serialization ────────────────────────────────────────────────────
+
+    def to_html(self) -> str:
+        """Serialize this element and its descendants back to an HTML string.
+
+        Returns:
+            The HTML markup for this subtree.
+        """
+        parts: list[str] = []
+        self._serialize(parts)
+        return "".join(parts)
+
+    def _serialize(self, acc: list[str]) -> None:
+        """Recursively build HTML string pieces into *acc*."""
+        # Build opening tag
+        attr_parts: list[str] = []
+        for k, v in self.attrs.items():
+            if isinstance(v, list):
+                attr_parts.append(f'{k}="{" ".join(v)}"')
+            elif v == "":
+                attr_parts.append(k)
+            else:
+                attr_parts.append(f'{k}="{v}"')
+        attrs_str = (" " + " ".join(attr_parts)) if attr_parts else ""
+
+        if self.name.lower() in SELF_CLOSING_TAGS:
+            acc.append(f"<{self.name}{attrs_str}>")
+            return
+
+        acc.append(f"<{self.name}{attrs_str}>")
+        for child in self.children:
+            if isinstance(child, str):
+                acc.append(child)
+            else:
+                child._serialize(acc)
+        acc.append(f"</{self.name}>")
+
+    def __str__(self) -> str:
+        """Return the HTML serialization of this element."""
+        return self.to_html()
+
+    # ── Repr ──────────────────────────────────────────────────────────────
+
+    def __repr__(self) -> str:
+        attrs_str = ""
+        if self.attrs:
+            parts = []
+            for k, v in self.attrs.items():
+                if isinstance(v, list):
+                    parts.append(f'{k}="{" ".join(v)}"')
+                else:
+                    parts.append(f'{k}="{v}"')
+            attrs_str = " " + " ".join(parts)
+        return f"<{self.name}{attrs_str}>"
+
+
+# ── Match helpers ─────────────────────────────────────────────────────────────
+
+
+def _check_name_match(
+    tag: Tag,
+    name: str | list[str] | None,
+    name_set: frozenset[str] | None = None,
+) -> bool:
+    """Return True if *tag* satisfies the *name* filter."""
+    if name is None:
+        return True
+    if name_set is not None:
+        return tag.name in name_set
+    if isinstance(name, list):
+        return tag.name in name
+    return tag.name == name
+
+
+def _check_attr_filter(tag: Tag, key: str, expected: str | bool) -> bool:
+    """Return True if *tag* satisfies a single attribute filter."""
+    actual = tag.attrs.get(key)
+    if expected is True:
+        return actual is not None
+    if expected is False:
+        return actual is None
+    # Value comparison
+    if key == "class":
+        return _class_matches(actual, expected)
+    if actual is None:
+        return False
+    if isinstance(actual, list):
+        return expected in actual
+    return actual == expected
+
+
+def _matches(
+    tag: Tag,
+    name: str | list[str] | None,
+    name_set: frozenset[str] | None,
+    attr_filters: dict[str, str | bool],
+) -> bool:
+    """Check whether *tag* satisfies *name* and *attr_filters*."""
+    if not _check_name_match(tag, name, name_set):
+        return False
+    return all(_check_attr_filter(tag, k, v) for k, v in attr_filters.items())
+
+
+def _class_matches(actual: str | list[str] | None, expected: str) -> bool:
+    """Return True if *expected* class is present in *actual*.
+
+    *actual* may be a list (``["a", "b"]``) or ``None``.
+    *expected* is a single class name string.
+    """
+    if actual is None:
+        return False
+    if isinstance(actual, list):
+        return expected in actual
+    return actual == expected
+
+
+# ── CSS selector parser ───────────────────────────────────────────────────────
+
+# A parsed selector is a list of *steps*.  Each step is
+# ``(combinator, simple_selector_list)`` where combinator is one of
+# ``"descendant"`` or ``"child"`` (the first step has ``"descendant"`` as a
+# dummy).  A simple selector is a dict with optional keys ``tag``, ``id``,
+# ``classes``, ``attrs``.
+
+_SIMPLE_RE = re.compile(
+    r"""
+    (?P<tag>[a-zA-Z][a-zA-Z0-9-]*)     # tag name
+    |(?P<cls>\.[a-zA-Z_-][a-zA-Z0-9_-]*)  # .class
+    |(?P<id>\#[a-zA-Z_-][a-zA-Z0-9_-]*)   # #id
+    |(?P<attr>\[[^\]]+\])              # [attr] or [attr="val"]
+    |(?P<pseudo>:(?:first-child|last-child|only-child))  # structural pseudo
+    |(?P<not>:not\()                   # :not( — argument parsed separately
+    """,
+    re.VERBOSE,
+)
+
+_ATTR_RE = re.compile(
+    r"""
+    \[
+    \s*(?P<name>[a-zA-Z_-][a-zA-Z0-9_-]*)
+    (?:\s*=\s*["']?(?P<value>[^"'\]]*)["']?)?
+    \s*\]
+    """,
+    re.VERBOSE,
+)
+
+SelectorStep = tuple[str, dict[str, Any]]
+
+
+_WS = frozenset(" \t\n")
+
+
+def _skip_whitespace(selector: str, pos: int) -> int:
+    """Advance *pos* past any whitespace characters."""
+    while pos < len(selector) and selector[pos] in _WS:
+        pos += 1
+    return pos
+
+
+def _tokenize_whitespace(
+    selector: str, pos: int, tokens: list[str | dict[str, Any]]
+) -> int:
+    """Handle whitespace at *pos*, emitting a combinator token if needed.
+
+    Returns the updated position.
+    """
+    rest = selector[pos:].lstrip()
+    if rest.startswith(">"):
+        tokens.append(">")
+        pos = selector.index(">", pos) + 1
+        return _skip_whitespace(selector, pos)
+    # Space combinator only if the previous token is not already a combinator
+    if tokens and tokens[-1] not in (" ", ">"):
+        tokens.append(" ")
+    return pos + 1
+
+
+def _apply_regex_match(m: re.Match[str], compound: dict[str, Any]) -> None:
+    """Populate *compound* dict from a single ``_SIMPLE_RE`` match."""
+    if m.group("tag"):
+        compound["tag"] = m.group("tag")
+    elif m.group("cls"):
+        compound.setdefault("classes", []).append(m.group("cls")[1:])
+    elif m.group("id"):
+        compound["id"] = m.group("id")[1:]
+    elif m.group("attr"):
+        am = _ATTR_RE.match(m.group("attr"))
+        if am:
+            compound.setdefault("attrs", []).append(
+                (am.group("name"), am.group("value"))
+            )
+    elif m.group("pseudo"):
+        compound.setdefault("pseudos", []).append(m.group("pseudo")[1:])
+
+
+def _parse_not_argument(selector: str, pos: int) -> tuple[dict[str, Any], int]:
+    """Parse the simple selector inside ``:not(...)``, return (inner, new_pos).
+
+    *pos* should point right after the opening ``(``.  The closing ``)`` is
+    consumed and *new_pos* points past it.
+    """
+    inner, pos = _parse_compound(selector, pos)
+    if inner is None:
+        inner = {}
+    pos = _skip_whitespace(selector, pos)
+    if pos < len(selector) and selector[pos] == ")":
+        pos += 1
+    return inner, pos
+
+
+def _parse_compound(selector: str, pos: int) -> tuple[dict[str, Any] | None, int]:
+    """Parse a compound simple selector starting at *pos*.
+
+    Returns ``(compound_dict_or_None, new_pos)``.
+    """
+    compound: dict[str, Any] = {}
+    matched_any = False
+    while pos < len(selector):
+        m = _SIMPLE_RE.match(selector, pos)
+        if m is None:
+            break
+        matched_any = True
+        if m.group("not"):
+            # :not( matched — parse the inner selector and closing paren
+            pos = m.end()
+            inner, pos = _parse_not_argument(selector, pos)
+            compound.setdefault("nots", []).append(inner)
+        else:
+            _apply_regex_match(m, compound)
+            pos = m.end()
+    return (compound if matched_any else None), pos
+
+
+def _tokens_to_steps(tokens: list[str | dict[str, Any]]) -> list[SelectorStep]:
+    """Convert a flat token list into ``(combinator, simple)`` step list."""
+    steps: list[SelectorStep] = []
+    combinator = "descendant"
+    for tok in tokens:
+        if tok == " ":
+            combinator = "descendant"
+        elif tok == ">":
+            combinator = "child"
+        else:
+            assert isinstance(tok, dict)
+            steps.append((combinator, tok))
+            combinator = "descendant"
+    return steps
+
+
+def _parse_selector(selector: str) -> list[SelectorStep]:
+    """Parse a simple CSS selector string into step list.
+
+    Returns a list of ``(combinator, simple)`` tuples.
+    """
+    tokens: list[str | dict[str, Any]] = []
+    pos = 0
+    selector = selector.strip()
+
+    while pos < len(selector):
+        if selector[pos] in _WS:
+            pos = _tokenize_whitespace(selector, pos, tokens)
+            continue
+
+        if selector[pos] == ">":
+            tokens.append(">")
+            pos = _skip_whitespace(selector, pos + 1)
+            continue
+
+        compound, pos = _parse_compound(selector, pos)
+        if compound is not None:
+            tokens.append(compound)
+        else:
+            pos += 1  # skip unknown character to avoid infinite loop
+
+    return _tokens_to_steps(tokens)
+
+
+def _classes_match(tag: Tag, required_classes: list[str]) -> bool:
+    """Return True if *tag* has all *required_classes*."""
+    tag_classes = tag.attrs.get("class")
+    if tag_classes is None:
+        return False
+    if isinstance(tag_classes, str):
+        tag_classes = [tag_classes]
+    return all(cls in tag_classes for cls in required_classes)
+
+
+def _attr_value_matches(actual: str | list[str], expected: str) -> bool:
+    """Return True if *actual* attribute value equals *expected*."""
+    if isinstance(actual, list):
+        return expected in actual
+    return actual == expected
+
+
+def _selector_attrs_match(tag: Tag, attrs: list[tuple[str, str | None]]) -> bool:
+    """Return True if *tag* satisfies all attribute constraints from a selector."""
+    for attr_name, attr_val in attrs:
+        actual = tag.attrs.get(attr_name)
+        if actual is None:
+            return False
+        if attr_val is not None and not _attr_value_matches(actual, attr_val):
+            return False
+    return True
+
+
+def _element_siblings(tag: Tag) -> list[Tag]:
+    """Return element (non-text) children of *tag*'s parent."""
+    if tag.parent is None:
+        return [tag]
+    return [c for c in tag.parent.children if isinstance(c, Tag)]
+
+
+def _pseudo_matches(tag: Tag, pseudo: str) -> bool:
+    """Return True if *tag* satisfies the structural pseudo-class *pseudo*."""
+    siblings = _element_siblings(tag)
+    if pseudo == "first-child":
+        return siblings[0] is tag
+    if pseudo == "last-child":
+        return siblings[-1] is tag
+    if pseudo == "only-child":
+        return len(siblings) == 1
+    return False  # pragma: no cover
+
+
+def _simple_matches(tag: Tag, simple: dict[str, Any]) -> bool:
+    """Check if *tag* matches a single compound simple selector."""
+    if "tag" in simple and tag.name != simple["tag"]:
+        return False
+    if "id" in simple and tag.attrs.get("id") != simple["id"]:
+        return False
+    if "classes" in simple and not _classes_match(tag, simple["classes"]):
+        return False
+    if "attrs" in simple and not _selector_attrs_match(tag, simple["attrs"]):
+        return False
+    if "pseudos" in simple:
+        for pseudo in simple["pseudos"]:
+            if not _pseudo_matches(tag, pseudo):
+                return False
+    if "nots" in simple:
+        for inner in simple["nots"]:
+            if _simple_matches(tag, inner):
+                return False
+    return True
+
+
+def _selector_matches(tag: Tag, steps: list[SelectorStep]) -> bool:
+    """Return ``True`` if *tag* matches the full parsed selector."""
+    if not steps:
+        return True
+
+    # The last step must match the tag itself.
+    combinator, simple = steps[-1]
+    if not _simple_matches(tag, simple):
+        return False
+
+    if len(steps) == 1:
+        return True
+
+    # Walk remaining steps backwards up the tree.
+    remaining = steps[:-1]
+    return _ancestor_matches(tag, remaining)
+
+
+def _ancestor_matches(tag: Tag, steps: list[SelectorStep]) -> bool:
+    """Verify that ancestors of *tag* satisfy the remaining selector steps."""
+    if not steps:
+        return True
+
+    combinator, simple = steps[-1]
+    rest = steps[:-1]
+
+    if combinator == "child":
+        parent = tag.parent
+        if parent is None or not _simple_matches(parent, simple):
+            return False
+        return _ancestor_matches(parent, rest)
+    else:
+        # descendant — walk up until we find a match
+        node = tag.parent
+        while node is not None:
+            if _simple_matches(node, simple):
+                if _ancestor_matches(node, rest):
+                    return True
+            node = node.parent
+        return False
+
+
+# ── HTML parser ───────────────────────────────────────────────────────────────
+
+
+class _TreeBuilder(HTMLParser):
+    """Build a ``Tag`` tree from HTML markup.
+
+    Args:
+        skip_tags: Optional frozenset of tag names to omit from the tree.
+            When a skipped tag is encountered, it and all its descendants
+            (including text) are silently discarded.
+    """
+
+    def __init__(self, skip_tags: frozenset[str] | None = None) -> None:
+        super().__init__(convert_charrefs=True)
+        self.root = Tag("[document]")
+        self.current: Tag = self.root
+        self._skip_tags: frozenset[str] = skip_tags or frozenset()
+        # Depth counter for nested skipped tags (> 0 means discarding).
+        self._skip_depth: int = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # If we're inside a skipped subtree, track nesting depth only.
+        if self._skip_depth > 0:
+            if tag not in SELF_CLOSING_TAGS:
+                self._skip_depth += 1
+            return
+
+        # Check if this tag should be skipped.
+        if tag in self._skip_tags:
+            if tag not in SELF_CLOSING_TAGS:
+                self._skip_depth = 1
+            return
+
+        attr_dict: dict[str, str | list[str]] = {}
+        for key, value in attrs:
+            if value is None:
+                value = ""
+            if key == "class":
+                attr_dict["class"] = value.split()
+            else:
+                attr_dict[key] = value
+
+        node = Tag(tag, attr_dict, parent=self.current)
+        self.current.children.append(node)
+
+        if tag not in SELF_CLOSING_TAGS:
+            self.current = node
+
+    def handle_endtag(self, tag: str) -> None:
+        # If we're inside a skipped subtree, decrement depth.
+        if self._skip_depth > 0:
+            self._skip_depth -= 1
+            return
+
+        # Walk up to find the matching open tag (tolerates malformed HTML)
+        node = self.current
+        while node is not None and node.name != tag:
+            node = node.parent
+        if node is not None and node.parent is not None:
+            self.current = node.parent
+        # If no matching open tag found, do nothing (malformed HTML tolerance)
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # Explicit self-closing tag like <br/>
+        if self._skip_depth > 0 or tag in self._skip_tags:
+            return
+        self.handle_starttag(tag, attrs)
+        # Don't descend into it — it has no children.  If handle_starttag
+        # pushed current down, pop back up.
+        if self.current.name == tag:
+            if self.current.parent is not None:
+                self.current = self.current.parent
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth > 0:
+            return
+        self.current.children.append(data)
+
+    def handle_comment(self, data: str) -> None:
+        # Comments are silently dropped (matching BS4 default).
+        pass
+
+
+# ── Soup (document root) ─────────────────────────────────────────────────────
+
+
+class Soup(Tag):
+    """Parse an HTML document and provide a BeautifulSoup-like API.
+
+    Args:
+        markup: The HTML string to parse.
+        parser: Ignored (present only for API compatibility with BS4).
+            Only ``"html.parser"`` is supported.
+        skip_tags: Optional frozenset of tag names to omit during parsing.
+            Skipped tags and all their descendants are silently discarded,
+            which can significantly speed up parsing of pages with many
+            ``<script>`` or ``<style>`` blocks.
+
+    Example::
+
+        soup = Soup("<p>Hello <b>world</b></p>")
+        print(soup.find("b").text)
+        # world
+    """
+
+    def __init__(
+        self,
+        markup: str,
+        parser: str = "html.parser",
+        skip_tags: frozenset[str] | None = None,
+    ) -> None:
+        super().__init__("[document]")
+        builder = _TreeBuilder(skip_tags=skip_tags)
+        builder.feed(markup)
+        # Adopt the root's children as our own.
+        self.children = builder.root.children
+        for child in self.children:
+            if isinstance(child, Tag):
+                child.parent = self
+
+    def new_tag(
+        self, name: str, attrs: dict[str, str | list[str]] | None = None
+    ) -> Tag:
+        """Create a new detached ``Tag`` (not yet in the tree).
+
+        Args:
+            name: Tag name (e.g. ``"p"``).
+            attrs: Optional attribute dictionary.
+
+        Returns:
+            A new ``Tag`` instance with no parent.
+        """
+        return Tag(name, attrs)
+
+    def to_html(self) -> str:
+        """Serialize the entire document back to an HTML string.
+
+        Returns:
+            The HTML markup for the whole document.
+        """
+        parts: list[str] = []
+        for child in self.children:
+            if isinstance(child, str):
+                parts.append(child)
+            else:
+                child._serialize(parts)
+        return "".join(parts)

--- a/src/toolregistry_hub/_vendor/structlog/__init__.py
+++ b/src/toolregistry_hub/_vendor/structlog/__init__.py
@@ -1,0 +1,2 @@
+from .structlog import *  # noqa: F401,F403
+from .structlog import get_logger  # noqa: F401

--- a/src/toolregistry_hub/_vendor/structlog/structlog.py
+++ b/src/toolregistry_hub/_vendor/structlog/structlog.py
@@ -3,6 +3,7 @@
 # deps = []
 # tier = "medium"
 # category = "utility"
+# note = "Install/update via `zerodep add structlog`"
 # ///
 
 """Zero-dependency structured logging with pretty console output.
@@ -48,8 +49,7 @@ import logging
 import os
 import sys
 import traceback
-from typing import IO, Any
-from collections.abc import Callable
+from typing import IO, Any, Callable
 
 __all__ = [
     # Type aliases

--- a/src/toolregistry_hub/cron_tool.py
+++ b/src/toolregistry_hub/cron_tool.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from collections.abc import Callable
 
-from ._scheduler import (
+from ._vendor.scheduler import (
     CronTrigger,
     InvalidCronExpression,
     JobNotFound,
@@ -118,7 +118,7 @@ class CronTool:
             trigger = CronTrigger(cron)
         else:
             # One-shot: compute next fire time from cron, use OnceTrigger
-            from ._scheduler import _cron_next_fire_time
+            from ._vendor.scheduler import _cron_next_fire_time
 
             next_time = _cron_next_fire_time(spec, now)
             trigger = OnceTrigger(next_time)
@@ -317,7 +317,7 @@ class CronTool:
             if record.recurring:
                 trigger = CronTrigger(record.cron_expr)
             else:
-                from ._scheduler import _cron_next_fire_time
+                from ._vendor.scheduler import _cron_next_fire_time
 
                 try:
                     next_time = _cron_next_fire_time(spec, now)

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -5,15 +5,17 @@ from typing import Literal
 
 import httpx
 import ua_generator
-from bs4 import BeautifulSoup
+
+from ._vendor.readability import extract as readability_extract
+from ._vendor.soup import Soup
 from ._vendor.structlog import get_logger
 
 logger = get_logger()
 
 TIMEOUT_DEFAULT = 30.0
 
-# Minimum content length (in characters) to consider BS4 extraction sufficient.
-# Content shorter than this triggers Jina Reader fallback.
+# Minimum content length (in characters) to consider extraction sufficient.
+# Content shorter than this triggers the next fallback strategy.
 _MIN_CONTENT_LENGTH = 100
 
 # Common indicators of SPA shell pages that lack real content.
@@ -120,25 +122,23 @@ def _extract(
     timeout: float = TIMEOUT_DEFAULT,
     proxy: str | None = None,
 ) -> str:
-    """
-    Extract content from a given URL using available methods.
+    """Extract content from a given URL using available methods.
 
     Strategies are tried in order:
     1. Cloudflare Content Negotiation (zero-cost markdown attempt)
-    2. BeautifulSoup direct parsing (with content quality check)
-    3. Jina Reader (fallback for SPA shells or BS4 failures)
+    2. Readability extraction (intelligent article scoring, local)
+    3. Simple soup extraction (CSS selector fallback, local)
+    4. Jina Reader (external API fallback for SPA / JS-heavy pages)
 
-    If BS4 returns low-quality content (too short or SPA shell), Jina Reader
-    is attempted. If Jina also fails, the BS4 result is returned as a
-    low-quality fallback (better than nothing).
+    HTML is fetched once and reused by stages 2 and 3.
 
     Args:
-        url (str): The URL to extract content from.
-        timeout (float, optional): Request timeout in seconds. Defaults to TIMEOUT_DEFAULT (30). Usually not needed.
-        proxy (str, optional): Proxy to use for the request. Defaults to None.
+        url: The URL to extract content from.
+        timeout: Request timeout in seconds. Defaults to TIMEOUT_DEFAULT.
+        proxy: Proxy to use for the request. Defaults to None.
 
     Returns:
-        str: Extracted content from the URL, or "Unable to fetch content" if all strategies fail.
+        Extracted content, or ``"Unable to fetch content"`` if all strategies fail.
     """
     # 1. Try Cloudflare Content Negotiation (zero-cost, high quality if supported)
     content = _get_content_with_markdown_negotiation(
@@ -150,22 +150,45 @@ def _extract(
         logger.info(f"Successfully fetched {url} using strategy: markdown_negotiation")
         return _format_text(content)
 
-    # 2. Try BeautifulSoup direct parsing
-    bs4_content = _get_content_with_bs4(
-        url,
-        timeout=timeout,
-        proxy=proxy,
-    )
+    # Fetch HTML once for local extraction strategies
+    html = _fetch_html(url, timeout=timeout, proxy=proxy)
 
-    if bs4_content and _is_content_sufficient(bs4_content):
-        logger.info(f"Successfully fetched {url} using strategy: beautifulsoup")
-        return _format_text(bs4_content)
+    local_content = ""
+    if html:
+        # 2. Try Readability extraction (intelligent article detection)
+        readability_content = _extract_with_readability(html, url)
 
-    # 3. BS4 failed or content quality insufficient — try Jina Reader
-    reason = "low_quality_content" if bs4_content else "no_content"
+        # 3. Try simple soup extraction (CSS selector fallback)
+        soup_content = _extract_with_soup(html)
+
+        # Pick the best local result: prefer whichever is longer and sufficient.
+        # Readability produces cleaner article text; soup captures more structural
+        # content.  When readability returns only a short skeleton (e.g. SPA pages),
+        # soup's broader extraction is usually more useful.
+        for candidate, strategy in [
+            (readability_content, "readability"),
+            (soup_content, "soup"),
+        ]:
+            if candidate and _is_content_sufficient(candidate):
+                # Prefer readability if it extracted substantially more or equal
+                # content; otherwise fall through to soup.
+                if strategy == "readability" and soup_content and len(soup_content) > len(candidate) * 2:
+                    logger.debug(
+                        f"Readability result shorter than soup "
+                        f"({len(candidate)} vs {len(soup_content)}), trying soup"
+                    )
+                    continue
+                logger.info(f"Successfully fetched {url} using strategy: {strategy}")
+                return _format_text(candidate)
+
+        # Stash best local result for final fallback
+        local_content = readability_content or soup_content or ""
+
+    # 4. Local extraction insufficient — try Jina Reader
+    reason = "low_quality_content" if local_content else "no_content"
     logger.debug(
-        f"BS4 insufficient for {url} (reason: {reason}, "
-        f"length: {len(bs4_content) if bs4_content else 0}), trying Jina Reader"
+        f"Local extraction insufficient for {url} (reason: {reason}, "
+        f"length: {len(local_content)}), trying Jina Reader"
     )
 
     jina_content = _get_content_with_jina_reader(
@@ -177,17 +200,17 @@ def _extract(
     if jina_content and _is_content_sufficient(jina_content):
         logger.info(
             f"Successfully fetched {url} using strategy: jina_reader "
-            f"(bs4 reason: {reason})"
+            f"(local reason: {reason})"
         )
         return _format_text(jina_content)
 
-    # 4. Jina also failed — fall back to BS4 low-quality result if available
-    if bs4_content:
+    # 5. Fall back to best local result if available
+    if local_content:
         logger.info(
-            f"Successfully fetched {url} using strategy: beautifulsoup "
-            f"(low_quality_fallback, length: {len(bs4_content)})"
+            f"Successfully fetched {url} using strategy: local_fallback "
+            f"(low_quality, length: {len(local_content)})"
         )
-        return _format_text(bs4_content)
+        return _format_text(local_content)
 
     logger.warning(f"All extraction strategies failed for {url}")
     return "Unable to fetch content"
@@ -372,21 +395,20 @@ def _jina_reader_request(
         return ""
 
 
-def _get_content_with_bs4(
+def _fetch_html(
     url: str,
     timeout: float = TIMEOUT_DEFAULT,
     proxy: str | None = None,
 ) -> str:
-    """
-    Utilizes BeautifulSoup to fetch and parse the content of a webpage.
+    """Fetch raw HTML from a URL.
 
     Args:
-        url (str): The URL of the webpage.
-        timeout (float, Optional): Timeout for the HTTP request. Defaults to TIMEOUT_DEFAULT.
-        proxy (str, Optional): Proxy to use for the HTTP request. Defaults to None.
+        url: The URL to fetch.
+        timeout: Request timeout in seconds.
+        proxy: Optional proxy URL.
 
     Returns:
-        str: Parsed text content of the webpage.
+        HTML string, or empty string on failure.
     """
     try:
         ua = ua_generator.generate(browser=["chrome", "edge"])
@@ -399,23 +421,68 @@ def _get_content_with_bs4(
             proxy=proxy,
         )
         response.raise_for_status()
-        soup = BeautifulSoup(response.text, "html.parser")
-        for element in soup(["script", "style", "nav", "footer", "iframe", "noscript"]):
+        return response.text
+    except httpx.HTTPStatusError as e:
+        logger.debug(f"HTTP Error [{e.response.status_code}]: {e}")
+        return ""
+    except Exception as e:
+        logger.debug(f"Error fetching {url}: {e}")
+        return ""
+
+
+def _extract_with_readability(html: str, url: str) -> str:
+    """Extract content using the Readability algorithm.
+
+    Uses Mozilla Readability-style scoring to identify and extract the
+    main article content from arbitrary web pages.
+
+    Args:
+        html: Raw HTML string.
+        url: Original URL (passed to readability for link resolution).
+
+    Returns:
+        Plain text of the main article, or empty string on failure.
+    """
+    try:
+        result = readability_extract(html, url=url)
+        if result.length >= _MIN_CONTENT_LENGTH:
+            return result.text
+        logger.debug(f"Readability extraction too short ({result.length} chars)")
+        return ""
+    except Exception as e:
+        logger.debug(f"Readability extraction failed: {e}")
+        return ""
+
+
+def _extract_with_soup(html: str) -> str:
+    """Simple content extraction using zerodep soup.
+
+    Fallback for when readability fails. Decomposes non-content tags,
+    then looks for main/article/div.content landmarks.
+
+    Args:
+        html: Raw HTML string.
+
+    Returns:
+        Extracted text, or empty string.
+    """
+    try:
+        soup = Soup(html)
+        for element in soup.find_all(
+            ["script", "style", "nav", "footer", "iframe", "noscript"]
+        ):
             element.decompose()
         main_content = (
             soup.find("main")
             or soup.find("article")
             or soup.find("div", {"class": "content"})
         )
-        content_source = main_content if main_content else soup.body
+        content_source = main_content if main_content else soup.find("body")
         if not content_source:
             return ""
         return content_source.get_text(separator=" ", strip=True)
-    except httpx.HTTPStatusError as e:
-        logger.debug(f"HTTP Error [{e.response.status_code}]: {e}")
-        return ""
     except Exception as e:
-        logger.debug(f"Error parsing webpage content: {e}")
+        logger.debug(f"Soup extraction failed: {e}")
         return ""
 
 

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -6,7 +6,7 @@ from typing import Literal
 import httpx
 import ua_generator
 from bs4 import BeautifulSoup
-from ._structlog import get_logger
+from ._vendor.structlog import get_logger
 
 logger = get_logger()
 

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -172,7 +172,11 @@ def _extract(
             if candidate and _is_content_sufficient(candidate):
                 # Prefer readability if it extracted substantially more or equal
                 # content; otherwise fall through to soup.
-                if strategy == "readability" and soup_content and len(soup_content) > len(candidate) * 2:
+                if (
+                    strategy == "readability"
+                    and soup_content
+                    and len(soup_content) > len(candidate) * 2
+                ):
                     logger.debug(
                         f"Readability result shorter than soup "
                         f"({len(candidate)} vs {len(soup_content)}), trying soup"

--- a/src/toolregistry_hub/server/auth.py
+++ b/src/toolregistry_hub/server/auth.py
@@ -2,7 +2,7 @@
 
 import os
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 
 logger = get_logger()

--- a/src/toolregistry_hub/server/cli.py
+++ b/src/toolregistry_hub/server/cli.py
@@ -36,7 +36,7 @@ import sys
 from typing import TYPE_CHECKING, NoReturn
 
 from .. import __version__
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..version_check import check_for_updates
 from .banner import BANNER_ART
 

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -16,7 +16,7 @@ import importlib
 
 from toolregistry import ToolRegistry
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..utils.configurable import Configurable
 from ..utils.fn_namespace import _is_all_static_methods
 

--- a/src/toolregistry_hub/server/tool_config.py
+++ b/src/toolregistry_hub/server/tool_config.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from toolregistry import ToolRegistry
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 
 logger = get_logger()
 

--- a/src/toolregistry_hub/version_check.py
+++ b/src/toolregistry_hub/version_check.py
@@ -7,7 +7,7 @@ on PyPI and compare versions.
 import httpx
 
 from . import __version__
-from ._structlog import get_logger
+from ._vendor.structlog import get_logger
 
 logger = get_logger()
 

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..fetch import Fetch
 from .search_result import SearchResult
 

--- a/src/toolregistry_hub/websearch/google_parser.py
+++ b/src/toolregistry_hub/websearch/google_parser.py
@@ -20,7 +20,7 @@ Usage:
 from dataclasses import dataclass
 from typing import Any
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from .search_result import SearchResult
 
 logger = get_logger()

--- a/src/toolregistry_hub/websearch/websearch_brave.py
+++ b/src/toolregistry_hub/websearch/websearch_brave.py
@@ -27,7 +27,7 @@ API Documentation: https://api-dashboard.search.brave.com/app/documentation/web-
 
 import httpx
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
 from .base import TIMEOUT_DEFAULT, BaseSearch

--- a/src/toolregistry_hub/websearch/websearch_brightdata.py
+++ b/src/toolregistry_hub/websearch/websearch_brightdata.py
@@ -33,7 +33,7 @@ from urllib.parse import urlencode
 
 import httpx
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
 from .base import TIMEOUT_DEFAULT, BaseSearch

--- a/src/toolregistry_hub/websearch/websearch_scrapeless.py
+++ b/src/toolregistry_hub/websearch/websearch_scrapeless.py
@@ -34,7 +34,7 @@ from typing import Any
 
 import httpx
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
 from .base import TIMEOUT_DEFAULT, BaseSearch

--- a/src/toolregistry_hub/websearch/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch/websearch_searxng.py
@@ -33,7 +33,7 @@ import os
 
 import httpx
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..utils.requirements import requires_env
 from .base import TIMEOUT_DEFAULT, BaseSearch
 from .search_result import SearchResult

--- a/src/toolregistry_hub/websearch/websearch_serper.py
+++ b/src/toolregistry_hub/websearch/websearch_serper.py
@@ -31,7 +31,7 @@ from typing import Any
 
 import httpx
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
 from .base import TIMEOUT_DEFAULT, BaseSearch

--- a/src/toolregistry_hub/websearch/websearch_tavily.py
+++ b/src/toolregistry_hub/websearch/websearch_tavily.py
@@ -27,7 +27,7 @@ API Documentation: https://docs.tavily.com/documentation/api-reference/endpoint/
 
 import httpx
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
 from .base import TIMEOUT_DEFAULT, BaseSearch

--- a/src/toolregistry_hub/websearch_legacy/filter.py
+++ b/src/toolregistry_hub/websearch_legacy/filter.py
@@ -2,7 +2,7 @@ import os
 import time
 
 import httpx
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 
 logger = get_logger()
 

--- a/src/toolregistry_hub/websearch_legacy/websearch.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..fetch import Fetch
 
 logger = get_logger()

--- a/src/toolregistry_hub/websearch_legacy/websearch_bing.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_bing.py
@@ -10,7 +10,7 @@ import httpx
 import ua_generator
 from bs4 import BeautifulSoup, Tag
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from .filter import filter_search_results
 from .websearch import WebSearchGeneral
 

--- a/src/toolregistry_hub/websearch_legacy/websearch_bing.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_bing.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 import httpx
 import ua_generator
-from bs4 import BeautifulSoup, Tag
+from .._vendor.soup import Soup, Tag
 
 from .._vendor.structlog import get_logger
 from .filter import filter_search_results
@@ -238,7 +238,7 @@ class WebSearchBing(WebSearchGeneral):
         html: str, fetched_links: set[str], num_results: int
     ) -> Generator[_WebSearchEntryBing, None, None]:
         """Parse HTML content from Bing search results."""
-        soup = BeautifulSoup(html, "html.parser")
+        soup = Soup(html)
         result_block = soup.find_all("li", class_="b_algo")
         new_results = 0
 

--- a/src/toolregistry_hub/websearch_legacy/websearch_google.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_google.py
@@ -9,7 +9,7 @@ import httpx
 import ua_generator
 from bs4 import BeautifulSoup, Tag
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from .filter import filter_search_results
 from .websearch import WebSearchGeneral
 

--- a/src/toolregistry_hub/websearch_legacy/websearch_google.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_google.py
@@ -7,7 +7,7 @@ from urllib.parse import unquote  # to decode the url
 
 import httpx
 import ua_generator
-from bs4 import BeautifulSoup, Tag
+from .._vendor.soup import Soup, Tag
 
 from .._vendor.structlog import get_logger
 from .filter import filter_search_results
@@ -183,7 +183,7 @@ class WebSearchGoogle(WebSearchGeneral):
         html: str, fetched_links: set[str], num_results: int
     ) -> Generator[_WebSearchEntryGoogle, None, None]:
         """Parse HTML content from Google search results."""
-        soup = BeautifulSoup(html, "html.parser")
+        soup = Soup(html)
         result_block = soup.find_all("div", class_="ezO2md")
         new_results = 0
 

--- a/src/toolregistry_hub/websearch_legacy/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_searxng.py
@@ -5,7 +5,7 @@ from functools import partial
 import httpx
 import ua_generator
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from .filter import filter_search_results
 from .websearch import WebSearchGeneral
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -11,8 +11,10 @@ from toolregistry_hub.fetch import (
     _MIN_CONTENT_LENGTH,
     _SPA_SHELL_INDICATORS,
     _extract,
+    _extract_with_readability,
+    _extract_with_soup,
+    _fetch_html,
     _format_text,
-    _get_content_with_bs4,
     _get_content_with_jina_reader,
     _get_content_with_markdown_negotiation,
     _is_content_sufficient,
@@ -328,45 +330,22 @@ class TestJinaReader:
 
 
 # ============================================================
-# _get_content_with_bs4 tests
+# _fetch_html tests
 # ============================================================
 
 
-class TestBS4:
-    """Tests for the _get_content_with_bs4 function."""
+class TestFetchHtml:
+    """Tests for the _fetch_html function."""
 
     @patch("toolregistry_hub.fetch.httpx.get")
-    def test_extracts_main_content(self, mock_get):
-        html = """
-        <html><body>
-            <nav>Navigation</nav>
-            <main><p>Main content here with enough text to be meaningful.</p></main>
-            <footer>Footer</footer>
-        </body></html>
-        """
+    def test_success_returns_html(self, mock_get):
         mock_response = MagicMock()
-        mock_response.text = html
+        mock_response.text = "<html><body>Hello</body></html>"
         mock_response.raise_for_status = MagicMock()
         mock_get.return_value = mock_response
 
-        result = _get_content_with_bs4("https://example.com")
-        assert "Main content" in result
-        assert "Navigation" not in result
-
-    @patch("toolregistry_hub.fetch.httpx.get")
-    def test_extracts_article_content(self, mock_get):
-        html = """
-        <html><body>
-            <article><p>Article content here.</p></article>
-        </body></html>
-        """
-        mock_response = MagicMock()
-        mock_response.text = html
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
-
-        result = _get_content_with_bs4("https://example.com")
-        assert "Article content" in result
+        result = _fetch_html("https://example.com")
+        assert result == "<html><body>Hello</body></html>"
 
     @patch("toolregistry_hub.fetch.httpx.get")
     def test_http_error_returns_empty(self, mock_get):
@@ -379,19 +358,109 @@ class TestBS4:
         )
         mock_get.return_value = mock_response
 
-        result = _get_content_with_bs4("https://example.com")
+        result = _fetch_html("https://example.com")
         assert result == ""
 
     @patch("toolregistry_hub.fetch.httpx.get")
-    def test_no_body_returns_empty(self, mock_get):
-        html = "<html></html>"
+    def test_connection_error_returns_empty(self, mock_get):
+        mock_get.side_effect = httpx.ConnectError("Connection refused")
+
+        result = _fetch_html("https://example.com")
+        assert result == ""
+
+    @patch("toolregistry_hub.fetch.httpx.get")
+    def test_passes_proxy(self, mock_get):
         mock_response = MagicMock()
-        mock_response.text = html
+        mock_response.text = "<html></html>"
         mock_response.raise_for_status = MagicMock()
         mock_get.return_value = mock_response
 
-        result = _get_content_with_bs4("https://example.com")
+        _fetch_html("https://example.com", proxy="http://proxy:8080")
+
+        call_kwargs = mock_get.call_args
+        assert call_kwargs.kwargs.get("proxy") == "http://proxy:8080"
+
+
+# ============================================================
+# _extract_with_readability tests
+# ============================================================
+
+
+class TestReadabilityExtraction:
+    """Tests for the _extract_with_readability function."""
+
+    def test_extracts_article_content(self):
+        paragraphs = "<p>This is a test paragraph with enough content. </p>" * 20
+        html = f"""
+        <html><head><title>Test Article</title></head>
+        <body>
+            <nav>Navigation links</nav>
+            <article>{paragraphs}</article>
+            <footer>Footer content</footer>
+        </body></html>
+        """
+        result = _extract_with_readability(html, "https://example.com")
+        assert len(result) >= _MIN_CONTENT_LENGTH
+        assert "test paragraph" in result.lower()
+
+    def test_short_content_returns_empty(self):
+        html = "<html><body><p>Short.</p></body></html>"
+        result = _extract_with_readability(html, "https://example.com")
         assert result == ""
+
+    def test_returns_plain_text(self):
+        paragraphs = "<p>Some meaningful content for testing purposes. </p>" * 20
+        html = f"<html><body><article>{paragraphs}</article></body></html>"
+        result = _extract_with_readability(html, "https://example.com")
+        # Result should be plain text, not HTML
+        assert "<p>" not in result
+        assert "<article>" not in result
+
+    def test_exception_returns_empty(self):
+        # Invalid input that might cause parsing issues
+        result = _extract_with_readability("", "https://example.com")
+        assert result == ""
+
+
+# ============================================================
+# _extract_with_soup tests
+# ============================================================
+
+
+class TestSoupExtraction:
+    """Tests for the _extract_with_soup function."""
+
+    def test_extracts_main_content(self):
+        html = """
+        <html><body>
+            <nav>Navigation</nav>
+            <main><p>Main content here with enough text to be meaningful.</p></main>
+            <footer>Footer</footer>
+        </body></html>
+        """
+        result = _extract_with_soup(html)
+        assert "Main content" in result
+        assert "Navigation" not in result
+
+    def test_extracts_article_content(self):
+        html = """
+        <html><body>
+            <article><p>Article content here.</p></article>
+        </body></html>
+        """
+        result = _extract_with_soup(html)
+        assert "Article content" in result
+
+    def test_no_body_returns_empty(self):
+        html = "<html></html>"
+        result = _extract_with_soup(html)
+        assert result == ""
+
+    def test_malformed_html_no_crash(self):
+        html = "<div><p>Unclosed paragraph<div>Nested improperly"
+        result = _extract_with_soup(html)
+        # Should not raise, may return content or empty
+        assert isinstance(result, str)
 
 
 # ============================================================
@@ -403,31 +472,65 @@ class TestExtract:
     """Integration tests for the _extract function."""
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
-    @patch("toolregistry_hub.fetch._get_content_with_bs4")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_html")
     @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
-    def test_markdown_negotiation_success(self, mock_md, mock_bs4, mock_jina):
+    def test_markdown_negotiation_success(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_jina
+    ):
         mock_md.return_value = "# Markdown Content\nSome text here."
         result = _extract("https://example.com")
         assert "Markdown Content" in result
-        mock_bs4.assert_not_called()
+        mock_fetch.assert_not_called()
         mock_jina.assert_not_called()
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
-    @patch("toolregistry_hub.fetch._get_content_with_bs4")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_html")
     @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
-    def test_bs4_sufficient_content(self, mock_md, mock_bs4, mock_jina):
+    def test_readability_sufficient_content(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_jina
+    ):
         mock_md.return_value = ""
-        mock_bs4.return_value = "This is a long enough article. " * 10
+        mock_fetch.return_value = "<html>...</html>"
+        mock_readability.return_value = "This is a long enough article. " * 10
+        mock_soup.return_value = "Short soup."
         result = _extract("https://example.com")
         assert "long enough article" in result
         mock_jina.assert_not_called()
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
-    @patch("toolregistry_hub.fetch._get_content_with_bs4")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_html")
     @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
-    def test_bs4_spa_shell_triggers_jina(self, mock_md, mock_bs4, mock_jina):
+    def test_readability_fails_soup_sufficient(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_jina
+    ):
         mock_md.return_value = ""
-        mock_bs4.return_value = (
+        mock_fetch.return_value = "<html>...</html>"
+        mock_readability.return_value = ""
+        mock_soup.return_value = "Soup extracted content is good enough. " * 10
+        result = _extract("https://example.com")
+        assert "Soup extracted" in result
+        mock_jina.assert_not_called()
+
+    @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_html")
+    @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
+    def test_local_spa_shell_triggers_jina(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_jina
+    ):
+        mock_md.return_value = ""
+        mock_fetch.return_value = "<html>...</html>"
+        mock_readability.return_value = (
+            "Loading... Please enable JavaScript to continue." + "x" * 200
+        )
+        mock_soup.return_value = (
             "Loading... Please enable JavaScript to continue." + "x" * 200
         )
         mock_jina.return_value = "# Real Content\nActual article text here. " * 10
@@ -437,47 +540,49 @@ class TestExtract:
         mock_jina.assert_called_once()
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
-    @patch("toolregistry_hub.fetch._get_content_with_bs4")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_html")
     @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
-    def test_bs4_short_content_triggers_jina(self, mock_md, mock_bs4, mock_jina):
+    def test_no_html_triggers_jina(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_jina
+    ):
         mock_md.return_value = ""
-        mock_bs4.return_value = "Short"
-        mock_jina.return_value = "# Full Content\nComplete article. " * 10
-
-        result = _extract("https://example.com")
-        assert "Full Content" in result
-        mock_jina.assert_called_once()
-
-    @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
-    @patch("toolregistry_hub.fetch._get_content_with_bs4")
-    @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
-    def test_bs4_no_content_triggers_jina(self, mock_md, mock_bs4, mock_jina):
-        mock_md.return_value = ""
-        mock_bs4.return_value = ""
+        mock_fetch.return_value = ""
         mock_jina.return_value = "# Jina Content\nFetched via Jina. " * 10
 
         result = _extract("https://example.com")
         assert "Jina Content" in result
+        mock_readability.assert_not_called()
+        mock_soup.assert_not_called()
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
-    @patch("toolregistry_hub.fetch._get_content_with_bs4")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_html")
     @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
-    def test_jina_failure_falls_back_to_bs4_low_quality(
-        self, mock_md, mock_bs4, mock_jina
+    def test_jina_failure_falls_back_to_local(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_jina
     ):
         mock_md.return_value = ""
-        mock_bs4.return_value = "Short low quality"
+        mock_fetch.return_value = "<html>...</html>"
+        mock_readability.return_value = "Short low quality"
+        mock_soup.return_value = ""
         mock_jina.return_value = ""
 
         result = _extract("https://example.com")
         assert "Short low quality" in result
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
-    @patch("toolregistry_hub.fetch._get_content_with_bs4")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_html")
     @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
-    def test_all_strategies_fail(self, mock_md, mock_bs4, mock_jina):
+    def test_all_strategies_fail(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_jina
+    ):
         mock_md.return_value = ""
-        mock_bs4.return_value = ""
+        mock_fetch.return_value = ""
         mock_jina.return_value = ""
 
         result = _extract("https://example.com")

--- a/tests/websearch/test_debug_google_apis.py
+++ b/tests/websearch/test_debug_google_apis.py
@@ -21,7 +21,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
 import pytest
 from dotenv import load_dotenv
-from toolregistry_hub._structlog import setup_logging
+from toolregistry_hub._vendor.structlog import setup_logging
 from toolregistry_hub.websearch import websearch_brightdata, websearch_scrapeless
 
 # Configure logger for debugging

--- a/tests/websearch/test_serper_integration.py
+++ b/tests/websearch/test_serper_integration.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
 import pytest
 from dotenv import load_dotenv
-from toolregistry_hub._structlog import setup_logging
+from toolregistry_hub._vendor.structlog import setup_logging
 from toolregistry_hub.websearch.websearch_serper import SerperSearch
 
 logger = setup_logging(level="DEBUG", renderer="console")


### PR DESCRIPTION
## Summary

- Consolidate all zerodep modules (readability, soup, structlog, scheduler) into `_vendor/` with nested layout, update all import paths across 30+ files
- Replace simplistic BeautifulSoup CSS selector extraction in `fetch.py` with a multi-strategy pipeline: readability (intelligent article scoring) → soup (structural fallback) → Jina Reader (external API). HTML is fetched once and shared across local strategies
- Migrate `websearch_legacy` (bing, google) from BS4 to zerodep soup and remove `beautifulsoup4` from project dependencies

Closes #83

## Test plan

- [x] `pytest tests/test_fetch.py -v` — all 57 fetch tests pass
- [x] `pytest tests/ -v` — 603/605 pass (2 pre-existing API key integration test skips)
- [x] `grep -r "from bs4\|import BeautifulSoup" src/` — zero BS4 references
- [ ] Manual: verify `fetch_content` on URLs from #83 via MCP server