### PR TITLE
feat(websearch): add unified WebSearch entry point with engine selector

### DIFF
--- a/src/toolregistry_hub/websearch/__init__.py
+++ b/src/toolregistry_hub/websearch/__init__.py
@@ -5,6 +5,7 @@ from .websearch_scrapeless import ScrapelessSearch
 from .websearch_searxng import SearXNGSearch
 from .websearch_serper import SerperSearch
 from .websearch_tavily import TavilySearch
+from .websearch_unified import WebSearch
 
 __all__ = [
     "BraveSearch",
@@ -14,4 +15,5 @@ __all__ = [
     "SearXNGSearch",
     "SerperSearch",
     "TavilySearch",
+    "WebSearch",
 ]

--- a/src/toolregistry_hub/websearch/websearch_unified.py
+++ b/src/toolregistry_hub/websearch/websearch_unified.py
@@ -1,0 +1,419 @@
+"""Unified WebSearch entry point.
+
+Wraps all available search providers behind a single ``search()`` method with an
+``engine`` selector. Engines are instantiated lazily and skipped when their API
+keys are missing. Supports an ``"auto"`` mode that picks the first configured
+engine from a configurable priority list, plus an explicit ``fallback`` flag for
+graceful degradation when a chosen engine is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+import types
+from typing import Literal
+
+from .._vendor.structlog import get_logger
+from .base import TIMEOUT_DEFAULT, BaseSearch
+from .search_result import SearchResult
+
+logger = get_logger()
+
+
+# Static type for the ``engine`` parameter. Always exposed in source-level
+# tooling and IDE introspection. At instance construction time this may be
+# narrowed dynamically to only the actually-configured engines (see
+# ``WebSearch.__init__``), so the schema seen by an LLM client reflects the
+# real runtime availability.
+EngineName = Literal[
+    "auto",
+    "brave",
+    "tavily",
+    "searxng",
+    "brightdata",
+    "scrapeless",
+    "serper",
+]
+
+
+# Default engine priority for the "auto" mode. Paid / higher-quality providers
+# come first so that "auto" yields the best results when keys are available.
+# Override at runtime via the ``WEBSEARCH_PRIORITY`` environment variable
+# (comma-separated names, e.g. ``"searxng,brave,tavily"``).
+_DEFAULT_PRIORITY: tuple[str, ...] = (
+    "tavily",
+    "brave",
+    "serper",
+    "brightdata",
+    "scrapeless",
+    "searxng",
+)
+
+
+# Maps engine name → (module path, class name). Lazily imported so unused
+# providers don't pay the import cost.
+_ENGINE_REGISTRY: dict[str, tuple[str, str]] = {
+    "brave": ("toolregistry_hub.websearch.websearch_brave", "BraveSearch"),
+    "tavily": ("toolregistry_hub.websearch.websearch_tavily", "TavilySearch"),
+    "searxng": ("toolregistry_hub.websearch.websearch_searxng", "SearXNGSearch"),
+    "brightdata": (
+        "toolregistry_hub.websearch.websearch_brightdata",
+        "BrightDataSearch",
+    ),
+    "scrapeless": (
+        "toolregistry_hub.websearch.websearch_scrapeless",
+        "ScrapelessSearch",
+    ),
+    "serper": ("toolregistry_hub.websearch.websearch_serper", "SerperSearch"),
+}
+
+
+def _load_engine_class(name: str) -> type[BaseSearch]:
+    """Import and return the engine class for ``name``.
+
+    Args:
+        name: Engine identifier (e.g. ``"brave"``).
+
+    Returns:
+        The provider class.
+
+    Raises:
+        ValueError: If ``name`` is not a known engine.
+        ImportError: If the engine module cannot be imported.
+    """
+    if name not in _ENGINE_REGISTRY:
+        raise ValueError(
+            f"Unknown websearch engine: {name!r}. Available: {sorted(_ENGINE_REGISTRY)}"
+        )
+    module_path, class_name = _ENGINE_REGISTRY[name]
+    import importlib
+
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+
+def _resolve_priority(priority: str | None = None) -> list[str]:
+    """Resolve the engine priority order.
+
+    Lookup order:
+        1. Explicit ``priority`` argument (comma-separated string)
+        2. ``WEBSEARCH_PRIORITY`` environment variable
+        3. ``_DEFAULT_PRIORITY``
+
+    Unknown engine names are silently dropped with a warning.
+
+    Args:
+        priority: Optional comma-separated engine names.
+
+    Returns:
+        Ordered list of valid engine names.
+    """
+    raw = priority or os.getenv("WEBSEARCH_PRIORITY")
+    if not raw:
+        return list(_DEFAULT_PRIORITY)
+
+    names = [p.strip().lower() for p in raw.split(",") if p.strip()]
+    valid: list[str] = []
+    for n in names:
+        if n in _ENGINE_REGISTRY:
+            valid.append(n)
+        else:
+            logger.warning(
+                f"Ignoring unknown engine in WEBSEARCH_PRIORITY: {n!r}. "
+                f"Available: {sorted(_ENGINE_REGISTRY)}"
+            )
+    return valid or list(_DEFAULT_PRIORITY)
+
+
+class WebSearch:
+    """Unified web search entry point that dispatches to multiple providers.
+
+    Users can either let the wrapper auto-select the best configured provider
+    (``engine="auto"``) or pin a specific engine. Unconfigured engines (missing
+    API keys) are skipped automatically. When a specific engine is requested
+    but unavailable, the call fails by default — set ``fallback=True`` on a
+    per-call basis to fall through to the auto chain instead.
+
+    Example:
+        >>> ws = WebSearch()
+        >>> ws.search("latest python release", max_results=5)  # auto
+        >>> ws.search("latest python release", engine="tavily")  # strict
+        >>> ws.search("latest python release", engine="tavily", fallback=True)
+
+    The priority order for ``engine="auto"`` defaults to paid-provider-first
+    and can be overridden via the ``WEBSEARCH_PRIORITY`` environment variable
+    (comma-separated engine names).
+    """
+
+    def __init__(self, priority: str | None = None):
+        """Initialize the unified WebSearch wrapper.
+
+        Args:
+            priority: Optional comma-separated engine priority. Falls back to
+                ``WEBSEARCH_PRIORITY`` env var, then ``_DEFAULT_PRIORITY``.
+        """
+        self._priority: list[str] = _resolve_priority(priority)
+        # Cache instantiated engines (configured ones only)
+        self._engine_cache: dict[str, BaseSearch] = {}
+        # Narrow the ``engine`` parameter type to only the configured engines
+        # so that the JSON schema seen by LLM clients reflects real runtime
+        # availability. The class-level full Literal remains intact for IDE /
+        # static analysis use.
+        self._narrow_engine_annotation()
+
+    def _narrow_engine_annotation(self) -> None:
+        """Replace ``self.search`` with a per-instance copy whose ``engine``
+        annotation is narrowed to ``Literal["auto", *configured]``.
+
+        Called from ``__init__``. No-op when no engines are configured (the
+        unified tool will then be auto-disabled by ``build_registry`` via the
+        :class:`Configurable` protocol, so the schema is irrelevant).
+
+        Implementation notes:
+            - We construct a fresh ``FunctionType`` from the class method's
+              code so that mutating ``__annotations__`` on this copy does not
+              affect other instances.
+            - The new function is then re-bound to ``self`` as a regular method.
+            - ``get_type_hints()`` (used by toolregistry / pydantic for schema
+              generation) will see the dynamically-built ``Literal`` instead
+              of the deferred string annotation from ``from __future__ import
+              annotations``.
+        """
+        configured = self._configured_engine_names()
+        if not configured:
+            return  # Nothing to narrow; tool will be auto-disabled anyway
+
+        original = type(self).search
+        # Build a fresh function with the same code but isolated annotations.
+        new_func = types.FunctionType(
+            original.__code__,
+            original.__globals__,
+            name=original.__name__,
+            argdefs=original.__defaults__,
+            closure=original.__closure__,
+        )
+        new_func.__doc__ = original.__doc__
+        new_func.__qualname__ = original.__qualname__
+        new_func.__kwdefaults__ = original.__kwdefaults__
+        # Copy then override the engine annotation with the narrowed Literal.
+        new_func.__annotations__ = dict(original.__annotations__)
+        narrowed_literal = Literal.__getitem__(("auto", *configured))  # type: ignore[arg-type]
+        new_func.__annotations__["engine"] = narrowed_literal
+        # Bind as method so ``self.search(query, ...)`` works normally.
+        self.search = types.MethodType(new_func, self)  # type: ignore[method-assign]
+
+    def _configured_engine_names(self) -> list[str]:
+        """Return the priority-ordered list of engine names that are currently configured.
+
+        Returns:
+            List of engine names with valid API keys, in priority order.
+        """
+        return [n for n in self._priority if self._get_engine(n) is not None]
+
+    def _is_configured(self) -> bool:
+        """Configured iff at least one underlying engine is configured.
+
+        Used by :func:`build_registry` via the ``Configurable`` protocol to
+        auto-disable the unified tool when no providers have keys set.
+        """
+        return bool(self._configured_engine_names())
+
+    def _get_engine(self, name: str) -> BaseSearch | None:
+        """Return a configured engine instance for ``name``, or ``None``.
+
+        Lazily instantiates and caches the engine. Returns ``None`` when the
+        engine cannot be constructed or reports itself as unconfigured.
+
+        Args:
+            name: Engine identifier.
+
+        Returns:
+            Configured ``BaseSearch`` instance, or ``None``.
+        """
+        if name in self._engine_cache:
+            return self._engine_cache[name]
+
+        try:
+            cls = _load_engine_class(name)
+            instance = cls()
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Failed to construct engine {name!r}: {e}")
+            return None
+
+        if not instance._is_configured():
+            logger.debug(f"Engine {name!r} is not configured (missing API key)")
+            return None
+
+        self._engine_cache[name] = instance
+        return instance
+
+    def list_engines(self) -> dict[str, bool]:
+        """List all known engines and whether each is currently configured.
+
+        Returns:
+            Mapping of engine name → configured status.
+        """
+        result: dict[str, bool] = {}
+        for name in _ENGINE_REGISTRY:
+            result[name] = self._get_engine(name) is not None
+        return result
+
+    def search(
+        self,
+        query: str,
+        *,
+        engine: EngineName = "auto",
+        fallback: bool = False,
+        max_results: int = 5,
+        timeout: float = TIMEOUT_DEFAULT,
+        **kwargs,
+    ) -> list[SearchResult]:
+        """Perform a web search via the selected engine.
+
+        IMPORTANT: For time-sensitive queries (e.g., "recent news", "latest updates",
+        "today's events"), you MUST first obtain the current date/time using an
+        available time/datetime tool before constructing your search query. As an
+        LLM, you have no inherent sense of current time — your training data may
+        be outdated. Always verify the current date when temporal context matters.
+
+        Args:
+            query: The search query string.
+            engine: Provider to use. Either ``"auto"`` (try configured engines
+                in priority order) or a specific name from
+                ``["brave", "tavily", "searxng", "brightdata", "scrapeless", "serper"]``.
+                Note: at runtime this parameter's accepted values are narrowed
+                to only the engines whose API keys are configured on this
+                instance. Call ``list_engines()`` to inspect availability.
+            fallback: When ``engine`` is a specific provider, controls behavior
+                if that provider is unavailable or raises. ``False`` (default)
+                propagates the error; ``True`` falls back to the auto chain
+                excluding the originally-requested engine.
+            max_results: Maximum number of results to return (1-20 recommended).
+            timeout: Per-request timeout in seconds.
+            **kwargs: Provider-specific extra parameters (forwarded as-is).
+
+        Returns:
+            List of search results.
+
+        Raises:
+            ValueError: If ``engine`` is not a recognized name, or if the query
+                is empty.
+            RuntimeError: If no engine is available (auto mode), or if the
+                requested engine is unavailable and ``fallback=False``.
+        """
+        if not query or not query.strip():
+            return []
+
+        engine = engine.lower().strip()
+
+        if engine == "auto":
+            return self._search_auto(
+                query,
+                exclude=None,
+                max_results=max_results,
+                timeout=timeout,
+                **kwargs,
+            )
+
+        if engine not in _ENGINE_REGISTRY:
+            raise ValueError(
+                f"Unknown websearch engine: {engine!r}. "
+                f"Available: {sorted(_ENGINE_REGISTRY)} or 'auto'"
+            )
+
+        instance = self._get_engine(engine)
+        if instance is None:
+            msg = f"Engine {engine!r} is not configured (missing API key)"
+            if not fallback:
+                raise RuntimeError(msg)
+            logger.info(f"{msg}; falling back to auto chain")
+            return self._search_auto(
+                query,
+                exclude={engine},
+                max_results=max_results,
+                timeout=timeout,
+                **kwargs,
+            )
+
+        try:
+            return instance.search(
+                query, max_results=max_results, timeout=timeout, **kwargs
+            )
+        except Exception as e:  # noqa: BLE001
+            if not fallback:
+                raise
+            logger.warning(
+                f"Engine {engine!r} raised {type(e).__name__}: {e}; "
+                f"falling back to auto chain"
+            )
+            return self._search_auto(
+                query,
+                exclude={engine},
+                max_results=max_results,
+                timeout=timeout,
+                **kwargs,
+            )
+
+    def _search_auto(
+        self,
+        query: str,
+        *,
+        exclude: set[str] | None = None,
+        max_results: int = 5,
+        timeout: float = TIMEOUT_DEFAULT,
+        **kwargs,
+    ) -> list[SearchResult]:
+        """Try engines in priority order; return the first successful result.
+
+        Args:
+            query: Search query.
+            exclude: Engine names to skip.
+            max_results: Result cap.
+            timeout: Per-request timeout.
+            **kwargs: Forwarded to engine.
+
+        Returns:
+            Search results from the first successful engine.
+
+        Raises:
+            RuntimeError: If no configured engine succeeds.
+        """
+        skip = exclude or set()
+        last_error: Exception | None = None
+        attempted: list[str] = []
+
+        for name in self._priority:
+            if name in skip:
+                continue
+            instance = self._get_engine(name)
+            if instance is None:
+                continue
+            attempted.append(name)
+            try:
+                logger.debug(f"Trying engine {name!r} for query {query!r}")
+                results = instance.search(
+                    query, max_results=max_results, timeout=timeout, **kwargs
+                )
+                if results:
+                    return results
+                logger.debug(f"Engine {name!r} returned no results; trying next")
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                logger.debug(
+                    f"Engine {name!r} raised {type(e).__name__}: {e}; trying next"
+                )
+
+        if not attempted:
+            raise RuntimeError(
+                "No websearch engines are configured. Set at least one of: "
+                f"{sorted(f'{n.upper()}_API_KEY' for n in _ENGINE_REGISTRY)}"
+            )
+
+        if last_error is not None:
+            raise RuntimeError(
+                f"All attempted engines failed ({attempted}). "
+                f"Last error: {type(last_error).__name__}: {last_error}"
+            ) from last_error
+
+        # All engines returned empty results
+        return []

--- a/tests/websearch/test_websearch_unified.py
+++ b/tests/websearch/test_websearch_unified.py
@@ -1,0 +1,422 @@
+"""Tests for the unified WebSearch entry point.
+
+Covers engine="auto" (priority chain), engine="<specific>" (strict and
+fallback modes), priority configuration via env var, and the
+``_is_configured`` protocol used by ``build_registry``.
+"""
+
+from __future__ import annotations
+
+from typing import get_args, get_type_hints
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from toolregistry_hub.websearch.search_result import SearchResult
+from toolregistry_hub.websearch.websearch_unified import (
+    _DEFAULT_PRIORITY,
+    _ENGINE_REGISTRY,
+    EngineName,
+    WebSearch,
+    _resolve_priority,
+)
+
+
+def _make_result(title: str = "t", url: str = "u", content: str = "c") -> SearchResult:
+    return SearchResult(title=title, url=url, content=content, score=1.0)
+
+
+@pytest.fixture
+def mock_engines(monkeypatch):
+    """Replace ``_get_engine`` with a controllable mock map.
+
+    Returns a ``dict`` that the test can mutate; setting a value to ``None``
+    simulates an unconfigured engine, while a ``MagicMock`` simulates a working
+    one. Default: all engines unconfigured.
+    """
+    state: dict[str, MagicMock | None] = dict.fromkeys(_ENGINE_REGISTRY)
+
+    def fake_get_engine(self, name: str):
+        return state.get(name)
+
+    monkeypatch.setattr(WebSearch, "_get_engine", fake_get_engine)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Priority resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePriority:
+    def test_default_when_nothing_set(self, monkeypatch):
+        monkeypatch.delenv("WEBSEARCH_PRIORITY", raising=False)
+        assert _resolve_priority() == list(_DEFAULT_PRIORITY)
+
+    def test_env_var_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("WEBSEARCH_PRIORITY", "searxng,brave")
+        assert _resolve_priority() == ["searxng", "brave"]
+
+    def test_explicit_arg_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("WEBSEARCH_PRIORITY", "tavily")
+        assert _resolve_priority("brave,searxng") == ["brave", "searxng"]
+
+    def test_unknown_engines_dropped(self, monkeypatch):
+        monkeypatch.delenv("WEBSEARCH_PRIORITY", raising=False)
+        assert _resolve_priority("brave,unknown_xyz,searxng") == ["brave", "searxng"]
+
+    def test_all_unknown_falls_back_to_default(self, monkeypatch):
+        monkeypatch.delenv("WEBSEARCH_PRIORITY", raising=False)
+        assert _resolve_priority("nope,nada") == list(_DEFAULT_PRIORITY)
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.delenv("WEBSEARCH_PRIORITY", raising=False)
+        assert _resolve_priority("BRAVE,Tavily") == ["brave", "tavily"]
+
+
+# ---------------------------------------------------------------------------
+# is_configured / list_engines
+# ---------------------------------------------------------------------------
+
+
+class TestIsConfigured:
+    def test_no_engines_configured(self, mock_engines):
+        ws = WebSearch()
+        assert ws._is_configured() is False
+
+    def test_at_least_one_configured(self, mock_engines):
+        mock_engines["brave"] = MagicMock()
+        ws = WebSearch()
+        assert ws._is_configured() is True
+
+    def test_list_engines_reports_status(self, mock_engines):
+        mock_engines["brave"] = MagicMock()
+        mock_engines["searxng"] = MagicMock()
+        ws = WebSearch()
+        status = ws.list_engines()
+        assert status["brave"] is True
+        assert status["searxng"] is True
+        assert status["tavily"] is False
+
+
+# ---------------------------------------------------------------------------
+# search() — auto mode
+# ---------------------------------------------------------------------------
+
+
+class TestSearchAuto:
+    def test_empty_query_returns_empty(self, mock_engines):
+        ws = WebSearch()
+        assert ws.search("") == []
+        assert ws.search("   ") == []
+
+    def test_no_engines_raises(self, mock_engines):
+        ws = WebSearch()
+        with pytest.raises(RuntimeError, match="No websearch engines"):
+            ws.search("python")
+
+    def test_auto_uses_first_configured_in_priority(self, mock_engines):
+        # tavily is first in default priority
+        tavily = MagicMock()
+        tavily.search.return_value = [_make_result("tavily-result")]
+        mock_engines["tavily"] = tavily
+        # brave also configured but lower priority
+        brave = MagicMock()
+        mock_engines["brave"] = brave
+
+        ws = WebSearch()
+        results = ws.search("python")
+        assert results[0].title == "tavily-result"
+        tavily.search.assert_called_once()
+        brave.search.assert_not_called()
+
+    def test_auto_skips_unconfigured(self, mock_engines):
+        # Only searxng configured (last in priority)
+        searxng = MagicMock()
+        searxng.search.return_value = [_make_result("searxng-result")]
+        mock_engines["searxng"] = searxng
+
+        ws = WebSearch()
+        results = ws.search("python")
+        assert results[0].title == "searxng-result"
+
+    def test_auto_falls_through_on_empty_results(self, mock_engines):
+        tavily = MagicMock()
+        tavily.search.return_value = []
+        mock_engines["tavily"] = tavily
+
+        brave = MagicMock()
+        brave.search.return_value = [_make_result("brave-result")]
+        mock_engines["brave"] = brave
+
+        ws = WebSearch()
+        results = ws.search("python")
+        assert results[0].title == "brave-result"
+
+    def test_auto_falls_through_on_exception(self, mock_engines):
+        tavily = MagicMock()
+        tavily.search.side_effect = RuntimeError("rate limit")
+        mock_engines["tavily"] = tavily
+
+        brave = MagicMock()
+        brave.search.return_value = [_make_result("brave-result")]
+        mock_engines["brave"] = brave
+
+        ws = WebSearch()
+        results = ws.search("python")
+        assert results[0].title == "brave-result"
+
+    def test_auto_all_fail_raises_with_last_error(self, mock_engines):
+        tavily = MagicMock()
+        tavily.search.side_effect = RuntimeError("first error")
+        brave = MagicMock()
+        brave.search.side_effect = RuntimeError("last error")
+        mock_engines["tavily"] = tavily
+        mock_engines["brave"] = brave
+
+        ws = WebSearch()
+        with pytest.raises(RuntimeError, match="last error"):
+            ws.search("python")
+
+    def test_auto_all_empty_returns_empty(self, mock_engines):
+        for name in ("tavily", "brave"):
+            m = MagicMock()
+            m.search.return_value = []
+            mock_engines[name] = m
+
+        ws = WebSearch()
+        assert ws.search("python") == []
+
+
+# ---------------------------------------------------------------------------
+# search() — specific engine
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSpecificEngine:
+    def test_unknown_engine_raises(self, mock_engines):
+        ws = WebSearch()
+        with pytest.raises(ValueError, match="Unknown websearch engine"):
+            ws.search("python", engine="bing")
+
+    def test_specific_engine_runs_only_that_engine(self, mock_engines):
+        brave = MagicMock()
+        brave.search.return_value = [_make_result("brave-result")]
+        mock_engines["brave"] = brave
+        # Tavily configured too — must not be called when engine="brave"
+        mock_engines["tavily"] = MagicMock()
+
+        ws = WebSearch()
+        results = ws.search("python", engine="brave")
+        assert results[0].title == "brave-result"
+        brave.search.assert_called_once()
+        mock_engines["tavily"].search.assert_not_called()
+
+    def test_unconfigured_engine_strict_raises(self, mock_engines):
+        ws = WebSearch()
+        with pytest.raises(RuntimeError, match="not configured"):
+            ws.search("python", engine="brave")
+
+    def test_unconfigured_engine_with_fallback_uses_auto(self, mock_engines):
+        # brave NOT configured, fallback should land on searxng
+        searxng = MagicMock()
+        searxng.search.return_value = [_make_result("searxng-result")]
+        mock_engines["searxng"] = searxng
+
+        ws = WebSearch()
+        results = ws.search("python", engine="brave", fallback=True)
+        assert results[0].title == "searxng-result"
+
+    def test_engine_failure_strict_propagates(self, mock_engines):
+        brave = MagicMock()
+        brave.search.side_effect = RuntimeError("brave api down")
+        mock_engines["brave"] = brave
+
+        ws = WebSearch()
+        with pytest.raises(RuntimeError, match="brave api down"):
+            ws.search("python", engine="brave")
+
+    def test_engine_failure_with_fallback_excludes_failed(self, mock_engines):
+        brave = MagicMock()
+        brave.search.side_effect = RuntimeError("brave api down")
+        mock_engines["brave"] = brave
+
+        # Fallback chain — tavily configured and works
+        tavily = MagicMock()
+        tavily.search.return_value = [_make_result("tavily-result")]
+        mock_engines["tavily"] = tavily
+
+        ws = WebSearch()
+        results = ws.search("python", engine="brave", fallback=True)
+        assert results[0].title == "tavily-result"
+        # brave was tried once originally and excluded from fallback chain
+        brave.search.assert_called_once()
+        tavily.search.assert_called_once()
+
+    def test_engine_name_case_insensitive(self, mock_engines):
+        brave = MagicMock()
+        brave.search.return_value = [_make_result("brave-result")]
+        mock_engines["brave"] = brave
+
+        ws = WebSearch()
+        results = ws.search("python", engine="BRAVE")
+        assert results[0].title == "brave-result"
+
+    def test_kwargs_forwarded(self, mock_engines):
+        brave = MagicMock()
+        brave.search.return_value = []
+        mock_engines["brave"] = brave
+
+        ws = WebSearch()
+        ws.search(
+            "python",
+            engine="brave",
+            max_results=10,
+            timeout=30.0,
+            country="US",
+        )
+        brave.search.assert_called_once_with(
+            "python", max_results=10, timeout=30.0, country="US"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Engine loading (real import paths)
+# ---------------------------------------------------------------------------
+
+
+class TestEngineLoading:
+    """These tests stub ``_load_engine_class`` BEFORE constructing ``WebSearch``
+    so that ``__init__`` (which warms the engine cache via the annotation
+    narrowing pass) sees the stub rather than any real provider classes that
+    may pick up live API keys from the test environment.
+    """
+
+    def test_get_engine_caches(self):
+        """Once instantiated, ``_get_engine`` should return the cached instance."""
+        instance = MagicMock()
+        instance._is_configured.return_value = True
+        fake_cls = MagicMock(return_value=instance)
+
+        with patch(
+            "toolregistry_hub.websearch.websearch_unified._load_engine_class",
+            return_value=fake_cls,
+        ):
+            ws = WebSearch()
+            first = ws._get_engine("brave")
+            second = ws._get_engine("brave")
+
+        assert first is second
+        # __init__ warms the cache for every engine in the priority list (one
+        # construction call per priority entry); after that, repeat lookups
+        # for "brave" must hit the cache rather than re-instantiate.
+        assert fake_cls.call_count == len(ws._priority)
+
+    def test_get_engine_returns_none_when_unconfigured(self):
+        instance = MagicMock()
+        instance._is_configured.return_value = False
+        fake_cls = MagicMock(return_value=instance)
+
+        with patch(
+            "toolregistry_hub.websearch.websearch_unified._load_engine_class",
+            return_value=fake_cls,
+        ):
+            ws = WebSearch()
+            assert ws._get_engine("brave") is None
+
+    def test_get_engine_returns_none_on_construction_failure(self):
+        fake_cls = MagicMock(side_effect=ValueError("missing keys"))
+
+        with patch(
+            "toolregistry_hub.websearch.websearch_unified._load_engine_class",
+            return_value=fake_cls,
+        ):
+            ws = WebSearch()
+            assert ws._get_engine("brave") is None
+
+
+# ---------------------------------------------------------------------------
+# Dynamic engine annotation narrowing (B+C scheme)
+# ---------------------------------------------------------------------------
+
+
+class TestEngineAnnotationNarrowing:
+    """Verify the per-instance ``engine`` annotation is narrowed to only the
+    configured engines. This is what allows LLM clients to see a JSON schema
+    enum that reflects real runtime availability rather than the full menu.
+    """
+
+    def test_static_class_literal_is_full(self):
+        """Class-level ``EngineName`` keeps the full set for IDE / type checkers."""
+        full = set(get_args(EngineName))
+        assert full == {"auto", *_ENGINE_REGISTRY}
+
+    def test_no_narrowing_when_no_engines_configured(self, mock_engines):
+        """No engines configured → no override; class-level annotation remains."""
+        ws = WebSearch()
+        # search is still the class method (no per-instance copy)
+        assert ws.search.__func__ is WebSearch.search
+
+    def test_narrowing_happens_when_one_engine_configured(self, mock_engines):
+        mock_engines["brave"] = MagicMock()
+        ws = WebSearch()
+        # Per-instance copy was bound
+        assert ws.search.__func__ is not WebSearch.search
+        engine_anno = ws.search.__func__.__annotations__["engine"]
+        assert set(get_args(engine_anno)) == {"auto", "brave"}
+
+    def test_narrowing_includes_only_configured_in_priority_order(self, mock_engines):
+        # Configure brave, tavily, searxng
+        for name in ("brave", "tavily", "searxng"):
+            mock_engines[name] = MagicMock()
+        ws = WebSearch()
+        engine_anno = ws.search.__func__.__annotations__["engine"]
+        narrowed = get_args(engine_anno)
+        # "auto" first, then engines in default priority order
+        assert narrowed[0] == "auto"
+        assert set(narrowed) == {"auto", "brave", "tavily", "searxng"}
+
+    def test_narrowing_is_per_instance(self, mock_engines):
+        """Mutating one instance's engines should not affect another."""
+        mock_engines["brave"] = MagicMock()
+        ws1 = WebSearch()
+        anno1 = ws1.search.__func__.__annotations__["engine"]
+
+        # Add a second engine; new instance picks it up but ws1 stays narrowed
+        mock_engines["tavily"] = MagicMock()
+        ws2 = WebSearch()
+        anno2 = ws2.search.__func__.__annotations__["engine"]
+
+        assert set(get_args(anno1)) == {"auto", "brave"}
+        assert set(get_args(anno2)) == {"auto", "brave", "tavily"}
+
+    def test_get_type_hints_returns_narrowed_literal(self, mock_engines):
+        """Confirms toolregistry/pydantic schema generators see the narrowed type."""
+        mock_engines["brave"] = MagicMock()
+        ws = WebSearch()
+        hints = get_type_hints(ws.search.__func__)
+        engine_hint = hints["engine"]
+        assert set(get_args(engine_hint)) == {"auto", "brave"}
+
+    def test_narrowed_search_still_callable(self, mock_engines):
+        """The replacement function must work as a normal bound method."""
+        brave = MagicMock()
+        brave.search.return_value = [_make_result("ok")]
+        mock_engines["brave"] = brave
+
+        ws = WebSearch()
+        results = ws.search("python", engine="brave")
+        assert results[0].title == "ok"
+
+    def test_narrowing_respects_custom_priority(self, mock_engines, monkeypatch):
+        """Narrowed list should include only configured engines from the priority."""
+        monkeypatch.setenv("WEBSEARCH_PRIORITY", "searxng,brave")
+        mock_engines["brave"] = MagicMock()
+        # tavily is configured but NOT in the priority list — must be excluded
+        mock_engines["tavily"] = MagicMock()
+
+        ws = WebSearch()
+        engine_anno = ws.search.__func__.__annotations__["engine"]
+        narrowed = set(get_args(engine_anno))
+        assert narrowed == {"auto", "brave"}
+        assert "tavily" not in narrowed


### PR DESCRIPTION
## Summary

- Add `WebSearch` class that wraps all websearch providers (Brave, Tavily, SearXNG, BrightData, Scrapeless, Serper) behind a single `search()` method with an `engine` selector parameter.
- `engine="auto"` mode picks the first configured provider from a priority chain (configurable via `WEBSEARCH_PRIORITY` env var); unconfigured engines (missing API keys) are automatically skipped.
- `fallback=True` enables graceful degradation: when a specific engine is unavailable or errors, the call falls through to the auto chain excluding the failed engine.
- Per-instance annotation narrowing dynamically rewrites the `engine` parameter's `Literal` type to only include actually-configured engines, so LLM clients see a JSON schema enum that matches real runtime availability.
- Export `WebSearch` from `toolregistry_hub.websearch.__init__`.

## Test plan

- [x] 36 unit tests covering:
  - Priority resolution (default, env var override, explicit arg, unknown engine handling, case insensitivity)
  - `_is_configured` / `list_engines` protocol
  - Auto mode (priority ordering, skip unconfigured, fall-through on empty/exception, all-fail error)
  - Specific engine mode (strict raise, fallback, case insensitivity, kwargs forwarding)
  - Engine loading and caching
  - Dynamic annotation narrowing (per-instance isolation, `get_type_hints` compatibility, custom priority)