### PR TITLE
feat(fetch): add Jina API key support with key rotation

### DIFF
--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -1,7 +1,10 @@
-import random
+"""Fetch and extract content from URLs."""
+
+from __future__ import annotations
+
 import re
 import unicodedata
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import httpx
 import ua_generator
@@ -9,6 +12,9 @@ import ua_generator
 from ._vendor.readability import extract as readability_extract
 from ._vendor.soup import Soup
 from ._vendor.structlog import get_logger
+
+if TYPE_CHECKING:
+    from .utils.api_key_parser import APIKeyParser
 
 logger = get_logger()
 
@@ -34,49 +40,47 @@ _SPA_SHELL_INDICATORS = [
 ]
 
 
-def _get_lynx_useragent():
-    """
-    Generates a random user agent string mimicking the format of various software versions.
-
-    The user agent string is composed of:
-    - Lynx version: Lynx/x.y.z where x is 2-3, y is 8-9, and z is 0-2
-    - libwww version: libwww-FM/x.y where x is 2-3 and y is 13-15
-    - SSL-MM version: SSL-MM/x.y where x is 1-2 and y is 3-5
-    - OpenSSL version: OpenSSL/x.y.z where x is 1-3, y is 0-4, and z is 0-9
-
-    Returns:
-        str: A randomly generated user agent string.
-    """
-    lynx_version = (
-        f"Lynx/{random.randint(2, 3)}.{random.randint(8, 9)}.{random.randint(0, 2)}"
-    )
-    libwww_version = f"libwww-FM/{random.randint(2, 3)}.{random.randint(13, 15)}"
-    ssl_mm_version = f"SSL-MM/{random.randint(1, 2)}.{random.randint(3, 5)}"
-    openssl_version = (
-        f"OpenSSL/{random.randint(1, 3)}.{random.randint(0, 4)}.{random.randint(0, 9)}"
-    )
-    return f"{lynx_version} {libwww_version} {ssl_mm_version} {openssl_version}"
-
-
-HEADERS_LYNX = {
-    "User-Agent": _get_lynx_useragent(),
-    "Accept": "*/*",
-}
-
-
 class Fetch:
-    """
-    A class to handle fetching and extracting content from URLs.
+    """Fetch and extract content from URLs.
+
+    Supports optional Jina Reader API keys for higher rate limits.
+    Multiple keys are rotated automatically via round-robin with
+    failure tracking.
     """
 
-    @staticmethod
+    def __init__(self, api_keys: str | None = None):
+        """Initialize Fetch with optional Jina Reader API keys.
+
+        Args:
+            api_keys: Comma-separated Jina API keys. Falls back to
+                the ``JINA_API_KEY`` environment variable if not provided.
+                When set, requests to the Jina Reader API include an
+                ``Authorization: Bearer <key>`` header.
+        """
+        from .utils.api_key_parser import APIKeyParser
+
+        parser = APIKeyParser(
+            api_keys=api_keys,
+            env_var_name="JINA_API_KEY",
+            rate_limit_delay=0.0,
+        )
+        self.api_key_parser: APIKeyParser | None = parser if parser.api_keys else None
+
+    def _is_configured(self) -> bool:
+        """Check if Fetch is configured.
+
+        Always returns True because Jina API keys are optional.
+        Fetch works without keys (unauthenticated requests).
+        """
+        return True
+
     def fetch_content(
+        self,
         url: str,
         timeout: float = TIMEOUT_DEFAULT,
         proxy: str | None = None,
     ) -> str:
-        """
-        Fetch and extract content from a given URL.
+        """Fetch and extract content from a given URL.
 
         Args:
             url (str): The URL to fetch content from.
@@ -87,7 +91,12 @@ class Fetch:
             str: Extracted content from the URL, or a message indicating failure if extraction fails.
         """
         try:
-            content = _extract(url, timeout=timeout, proxy=proxy)
+            content = _extract(
+                url,
+                timeout=timeout,
+                proxy=proxy,
+                api_key_parser=self.api_key_parser,
+            )
             return content
         except Exception as e:
             logger.error(f"Failed to fetch content from {url}: {e}")
@@ -121,6 +130,7 @@ def _extract(
     url: str,
     timeout: float = TIMEOUT_DEFAULT,
     proxy: str | None = None,
+    api_key_parser: APIKeyParser | None = None,
 ) -> str:
     """Extract content from a given URL using available methods.
 
@@ -136,6 +146,7 @@ def _extract(
         url: The URL to extract content from.
         timeout: Request timeout in seconds. Defaults to TIMEOUT_DEFAULT.
         proxy: Proxy to use for the request. Defaults to None.
+        api_key_parser: Optional API key parser for Jina Reader authentication.
 
     Returns:
         Extracted content, or ``"Unable to fetch content"`` if all strategies fail.
@@ -199,6 +210,7 @@ def _extract(
         url,
         timeout=timeout,
         proxy=proxy,
+        api_key_parser=api_key_parser,
     )
 
     if jina_content and _is_content_sufficient(jina_content):
@@ -297,6 +309,7 @@ def _get_content_with_jina_reader(
     return_format: Literal["markdown", "text", "html"] = "markdown",
     timeout: float = TIMEOUT_DEFAULT,
     proxy: str | None = None,
+    api_key_parser: APIKeyParser | None = None,
 ) -> str:
     """Fetch parsed content from Jina AI Reader for a given URL.
 
@@ -315,17 +328,30 @@ def _get_content_with_jina_reader(
         timeout: Maximum seconds Jina should spend rendering the page.
             Defaults to TIMEOUT_DEFAULT.
         proxy: Proxy to use for the HTTP request.  Defaults to ``None``.
+        api_key_parser: Optional API key parser for authentication.
 
     Returns:
         Parsed content from Jina AI, or empty string on failure.
     """
     for engine in _JINA_ENGINES:
+        # Get next valid API key for this attempt (if available)
+        api_key: str | None = None
+        if api_key_parser:
+            try:
+                api_key = api_key_parser.get_next_valid_key()
+            except ValueError:
+                logger.debug(
+                    "All Jina API keys currently failed, proceeding without key"
+                )
+
         content = _jina_reader_request(
             url,
             engine=engine,
             return_format=return_format,
             timeout=timeout,
             proxy=proxy,
+            api_key=api_key,
+            api_key_parser=api_key_parser,
         )
         if content and _is_content_sufficient(content):
             return content
@@ -343,6 +369,8 @@ def _jina_reader_request(
     return_format: Literal["markdown", "text", "html"] = "markdown",
     timeout: float = TIMEOUT_DEFAULT,
     proxy: str | None = None,
+    api_key: str | None = None,
+    api_key_parser: APIKeyParser | None = None,
 ) -> str:
     """Send a single request to the Jina Reader API.
 
@@ -353,6 +381,8 @@ def _jina_reader_request(
         return_format: Desired output format.
         timeout: Maximum seconds Jina should spend rendering the page.
         proxy: Optional HTTP proxy URL.
+        api_key: Optional Jina API key for the ``Authorization`` header.
+        api_key_parser: Optional parser for marking failed keys.
 
     Returns:
         Extracted content string, or empty string on failure.
@@ -366,6 +396,9 @@ def _jina_reader_request(
             "X-Remove-Selector": "header, footer, nav, aside",
             "X-Wait-For-Selector": _JINA_WAIT_SELECTORS,
         }
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
         jina_reader_url = "https://r.jina.ai/"
         # httpx timeout must exceed Jina's rendering timeout so we don't
         # abort the HTTP connection before Jina finishes.
@@ -390,9 +423,13 @@ def _jina_reader_request(
             logger.debug(f"Jina Reader ({engine}) returned empty content for {url}")
         return content
     except httpx.HTTPStatusError as e:
-        logger.debug(
-            f"Jina Reader ({engine}) HTTP Error [{e.response.status_code}]: {e}"
-        )
+        status = e.response.status_code
+        logger.debug(f"Jina Reader ({engine}) HTTP Error [{status}]: {e}")
+        if api_key and api_key_parser:
+            if status in (401, 403):
+                api_key_parser.mark_key_failed(api_key, f"HTTP {status}", ttl=3600.0)
+            elif status == 429:
+                api_key_parser.mark_key_failed(api_key, "rate limited", ttl=300.0)
         return ""
     except Exception as e:
         logger.debug(f"Jina Reader ({engine}) error: {e}")

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -123,7 +123,7 @@ class BaseSearch(ABC):
             raise ValueError("Result missing URL")
 
         try:
-            content = Fetch.fetch_content(
+            content = Fetch().fetch_content(
                 url,
                 timeout=timeout,
                 proxy=proxy,

--- a/src/toolregistry_hub/websearch_legacy/websearch.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch.py
@@ -61,7 +61,7 @@ class WebSearchGeneral(ABC):
             raise ValueError("Result missing URL")
 
         try:
-            content = Fetch.fetch_content(
+            content = Fetch().fetch_content(
                 url,
                 timeout=timeout or TIMEOUT_DEFAULT,
                 proxy=proxy,

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -10,6 +10,7 @@ from toolregistry_hub.fetch import (
     _JINA_WAIT_SELECTORS,
     _MIN_CONTENT_LENGTH,
     _SPA_SHELL_INDICATORS,
+    Fetch,
     _extract,
     _extract_with_readability,
     _extract_with_soup,
@@ -20,6 +21,7 @@ from toolregistry_hub.fetch import (
     _is_content_sufficient,
     _jina_reader_request,
 )
+from toolregistry_hub.utils.api_key_parser import APIKeyParser
 
 
 # ============================================================
@@ -587,3 +589,122 @@ class TestExtract:
 
         result = _extract("https://example.com")
         assert result == "Unable to fetch content"
+
+
+# ============================================================
+# Jina API key tests
+# ============================================================
+
+
+class TestJinaApiKey:
+    """Tests for Jina API key support in Fetch."""
+
+    @patch("toolregistry_hub.fetch.httpx.post")
+    def test_api_key_in_authorization_header(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"code": 200, "data": {"content": "test"}}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        _jina_reader_request("https://example.com", api_key="test-key-123")
+
+        call_kwargs = mock_post.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+        assert headers["Authorization"] == "Bearer test-key-123"
+
+    @patch("toolregistry_hub.fetch.httpx.post")
+    def test_no_api_key_no_authorization_header(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"code": 200, "data": {"content": "test"}}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        _jina_reader_request("https://example.com")
+
+        call_kwargs = mock_post.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+        assert "Authorization" not in headers
+
+    @patch("toolregistry_hub.fetch.httpx.post")
+    def test_401_marks_key_failed(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Unauthorized", request=MagicMock(), response=mock_response
+        )
+        mock_post.return_value = mock_response
+
+        parser = APIKeyParser(api_keys="key1,key2")
+        _jina_reader_request(
+            "https://example.com",
+            api_key="key1",
+            api_key_parser=parser,
+        )
+
+        assert "key1" in parser._failed_keys
+
+    @patch("toolregistry_hub.fetch.httpx.post")
+    def test_429_marks_key_rate_limited(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Too Many Requests", request=MagicMock(), response=mock_response
+        )
+        mock_post.return_value = mock_response
+
+        parser = APIKeyParser(api_keys="key1,key2")
+        _jina_reader_request(
+            "https://example.com",
+            api_key="key1",
+            api_key_parser=parser,
+        )
+
+        assert "key1" in parser._failed_keys
+        reason, _, ttl = parser._failed_keys["key1"]
+        assert reason == "rate limited"
+        assert ttl == 300.0
+
+    @patch("toolregistry_hub.fetch.httpx.post")
+    def test_500_does_not_mark_key_failed(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server Error", request=MagicMock(), response=mock_response
+        )
+        mock_post.return_value = mock_response
+
+        parser = APIKeyParser(api_keys="key1")
+        _jina_reader_request(
+            "https://example.com",
+            api_key="key1",
+            api_key_parser=parser,
+        )
+
+        assert "key1" not in parser._failed_keys
+
+    def test_fetch_instance_with_api_keys(self):
+        fetcher = Fetch(api_keys="key1,key2,key3")
+        assert fetcher.api_key_parser is not None
+        assert len(fetcher.api_key_parser.api_keys) == 3
+
+    def test_fetch_instance_without_api_keys(self):
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("JINA_API_KEY", None)
+            fetcher = Fetch()
+            assert fetcher.api_key_parser is None
+
+    @patch.dict("os.environ", {"JINA_API_KEY": "env-key-1,env-key-2"})
+    def test_fetch_instance_from_env(self):
+        fetcher = Fetch()
+        assert fetcher.api_key_parser is not None
+        assert len(fetcher.api_key_parser.api_keys) == 2
+
+    def test_is_configured_always_true(self):
+        fetcher = Fetch()
+        assert fetcher._is_configured() is True
+
+    def test_is_configured_true_with_keys(self):
+        fetcher = Fetch(api_keys="key1")
+        assert fetcher._is_configured() is True


### PR DESCRIPTION
## Summary
- Jina Reader now supports authenticated requests via `JINA_API_KEY` env var (comma-separated for multiple keys)
- Key rotation with round-robin selection via `APIKeyParser`, with automatic failover on 401/403 (1h cooldown) and 429 (5min cooldown) errors
- `Fetch` class changed from static to instance-based with optional `api_keys` constructor parameter
- `Fetch._is_configured()` always returns `True` since Jina keys are optional

## Test plan
- [x] `_jina_reader_request()` sends `Authorization: Bearer <key>` header when key provided
- [x] No `Authorization` header when no key provided
- [x] 401/403 errors mark key as failed (1h TTL)
- [x] 429 errors mark key as rate-limited (5min TTL)
- [x] 500 errors do not mark key as failed
- [x] `Fetch(api_keys=...)` correctly initializes `APIKeyParser`
- [x] `Fetch()` reads from `JINA_API_KEY` env var
- [x] `Fetch()` without env var has `api_key_parser=None`
- [x] `_is_configured()` returns True with and without keys
- [x] All 67 tests pass