### PR TITLE
feat(server): add tool discovery, ToolTag metadata, and think-augment support

### DIFF
--- a/src/toolregistry_hub/server/cli.py
+++ b/src/toolregistry_hub/server/cli.py
@@ -198,6 +198,18 @@ def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
         metavar="PORT",
         help="Enable the admin panel on the specified port (e.g. 8081)",
     )
+    parser.add_argument(
+        "--tool-discovery",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable tool discovery with progressive disclosure (default: enabled)",
+    )
+    parser.add_argument(
+        "--think-augment",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable think-augmented function calling (default: enabled)",
+    )
 
 
 def _add_openapi_arguments(parser: argparse.ArgumentParser) -> None:
@@ -316,14 +328,16 @@ def main(args: list[str] | None = None) -> NoReturn | None:
     if not parsed.no_banner:
         print_hub_banner()
 
-    # Apply tools config to the registry before starting the server
-    if parsed.config is not None:
-        from .registry import build_registry
+    # Build registry with CLI flags before starting the server
+    from .registry import build_registry
 
-        # Rebuild registry with the specified config path
-        import toolregistry_hub.server.registry as _reg_mod
+    import toolregistry_hub.server.registry as _reg_mod
 
-        _reg_mod._registry = build_registry(tools_config_path=parsed.config)
+    _reg_mod._registry = build_registry(
+        tools_config_path=getattr(parsed, "config", None),
+        enable_discovery=getattr(parsed, "tool_discovery", True),
+        enable_think=getattr(parsed, "think_augment", True),
+    )
 
     # Dispatch to appropriate command handler
     admin_port = getattr(parsed, "admin_port", None)

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -15,6 +15,7 @@ The registry supports two usage patterns:
 import importlib
 
 from toolregistry import ToolRegistry
+from toolregistry.tool import ToolTag
 
 from .._vendor.structlog import get_logger
 from ..utils.configurable import Configurable
@@ -28,7 +29,6 @@ _DEFAULT_TOOLS: list[dict[str, str]] = [
     {"class": "toolregistry_hub.calculator.Calculator", "namespace": "calculator"},
     {"class": "toolregistry_hub.datetime_utils.DateTime", "namespace": "datetime"},
     {"class": "toolregistry_hub.fetch.Fetch", "namespace": "web/fetch"},
-    {"class": "toolregistry_hub.filesystem.FileSystem", "namespace": "filesystem"},
     {"class": "toolregistry_hub.file_ops.FileOps", "namespace": "file_ops"},
     {"class": "toolregistry_hub.file_reader.FileReader", "namespace": "reader"},
     {"class": "toolregistry_hub.file_search.FileSearch", "namespace": "fs/file_search"},
@@ -38,6 +38,10 @@ _DEFAULT_TOOLS: list[dict[str, str]] = [
     {
         "class": "toolregistry_hub.unit_converter.UnitConverter",
         "namespace": "unit_converter",
+    },
+    {
+        "class": "toolregistry_hub.websearch.websearch_unified.WebSearch",
+        "namespace": "web/websearch",
     },
     {
         "class": "toolregistry_hub.websearch.websearch_brave.BraveSearch",
@@ -70,6 +74,73 @@ _DEFAULT_TOOLS: list[dict[str, str]] = [
 # but we keep this for any other internal methods that need hiding.
 _HIDDEN_METHODS: set[str] = set()
 
+# Metadata overrides for registered tools, keyed by namespace.
+# Sets ToolTag and defer flags after register_from_class().
+_TOOL_METADATA: dict[str, dict] = {
+    # Core tools (always visible in initial schema)
+    "calculator": {"tags": {ToolTag.READ_ONLY}},
+    "datetime": {"tags": {ToolTag.READ_ONLY}},
+    "think": {"tags": {ToolTag.READ_ONLY}},
+    "file_ops": {"tags": {ToolTag.FILE_SYSTEM, ToolTag.DESTRUCTIVE}},
+    "web/fetch": {"tags": {ToolTag.NETWORK, ToolTag.READ_ONLY}},
+    # Unified websearch entry (visible by default)
+    "web/websearch": {"tags": {ToolTag.NETWORK, ToolTag.READ_ONLY}},
+    # Provider-specific search engines (deferred — discoverable via discover_tools)
+    "web/brave_search": {
+        "defer": True,
+        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
+    },
+    "web/tavily_search": {
+        "defer": True,
+        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
+    },
+    "web/searxng_search": {
+        "defer": True,
+        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
+    },
+    "web/brightdata_search": {
+        "defer": True,
+        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
+    },
+    "web/scrapeless_search": {
+        "defer": True,
+        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
+    },
+    "web/serper_search": {
+        "defer": True,
+        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
+    },
+    # Deferred tools (discoverable via discover_tools)
+    "reader": {"defer": True, "tags": {ToolTag.FILE_SYSTEM, ToolTag.READ_ONLY}},
+    "fs/file_search": {"defer": True, "tags": {ToolTag.FILE_SYSTEM, ToolTag.READ_ONLY}},
+    "fs/path_info": {"defer": True, "tags": {ToolTag.FILE_SYSTEM, ToolTag.READ_ONLY}},
+    "bash": {"defer": True, "tags": {ToolTag.DESTRUCTIVE, ToolTag.PRIVILEGED}},
+    "cron": {"defer": True, "tags": {ToolTag.PRIVILEGED}},
+    "todolist": {"defer": True, "tags": {ToolTag.READ_ONLY}},
+    "unit_converter": {"defer": True, "tags": {ToolTag.READ_ONLY}},
+}
+
+
+def _apply_tool_metadata(registry: ToolRegistry) -> None:
+    """Apply tags, defer flags, and search hints to registered tools.
+
+    Iterates all tools in the registry and applies metadata overrides
+    from ``_TOOL_METADATA`` based on each tool's namespace.
+
+    Args:
+        registry: The registry whose tools should be annotated.
+    """
+    for tool in registry._tools.values():
+        ns = tool.namespace
+        if ns and ns in _TOOL_METADATA:
+            overrides = _TOOL_METADATA[ns]
+            if "defer" in overrides:
+                tool.metadata.defer = overrides["defer"]
+            if "tags" in overrides:
+                tool.metadata.tags = overrides["tags"]
+            if "search_hint" in overrides:
+                tool.metadata.search_hint = overrides["search_hint"]
+
 
 def _import_class(class_path: str) -> type:
     """Dynamically import a class from a dotted path string.
@@ -93,6 +164,8 @@ def _import_class(class_path: str) -> type:
 def build_registry(
     tool_kwargs: dict[str, dict] | None = None,
     tools_config_path: str | None = None,
+    enable_discovery: bool = True,
+    enable_think: bool = True,
 ) -> ToolRegistry:
     """Build the hub tool registry with all tools registered and auto-disabled
     based on instance configuration state.
@@ -104,6 +177,12 @@ def build_registry(
         tools_config_path: Optional path to a JSONC tool configuration file.
             If ``None``, the default discovery order is used (env var, then
             ``./tools.jsonc``).
+        enable_discovery: Enable tool discovery (progressive disclosure).
+            When ``True``, registers a ``discover_tools`` tool and marks
+            selected tools as deferred.
+        enable_think: Enable think-augmented function calling.
+            When ``True``, injects a ``thought`` property into tool schemas
+            for chain-of-thought reasoning.
 
     Returns:
         A fully configured ToolRegistry instance with all tools registered.
@@ -126,7 +205,7 @@ def build_registry(
     else:
         tools_to_register = _DEFAULT_TOOLS
 
-    registry = ToolRegistry(name="hub")
+    registry = ToolRegistry(name="hub", think_augment=enable_think)
 
     for tool_def in tools_to_register:
         class_path = tool_def["class"]
@@ -143,10 +222,10 @@ def build_registry(
         kwargs = (tool_kwargs or {}).get(kwargs_key, {})
 
         if _is_all_static_methods(cls):
-            registry.register_from_class(cls, with_namespace=namespace)
+            registry.register_from_class(cls, namespace=namespace)
         else:
             instance = cls(**kwargs)
-            registry.register_from_class(instance, with_namespace=namespace)
+            registry.register_from_class(instance, namespace=namespace)
 
             # Check instance readiness via Configurable protocol
             if isinstance(instance, Configurable) and not instance._is_configured():
@@ -177,6 +256,13 @@ def build_registry(
     # Apply startup tool configuration (highest priority)
     if config is not None:
         apply_tool_config(registry, config)
+
+    # Apply metadata (tags, defer flags) to registered tools
+    _apply_tool_metadata(registry)
+
+    # Enable tool discovery (registers discover_tools, indexes all tools)
+    if enable_discovery:
+        registry.enable_tool_discovery()
 
     return registry
 

--- a/src/toolregistry_hub/websearch/websearch_unified.py
+++ b/src/toolregistry_hub/websearch/websearch_unified.py
@@ -50,7 +50,7 @@ _DEFAULT_PRIORITY: tuple[str, ...] = (
 )
 
 
-# Maps engine name → (module path, class name). Lazily imported so unused
+# Maps engine name -> (module path, class name). Lazily imported so unused
 # providers don't pay the import cost.
 _ENGINE_REGISTRY: dict[str, tuple[str, str]] = {
     "brave": ("toolregistry_hub.websearch.websearch_brave", "BraveSearch"),
@@ -131,7 +131,7 @@ class WebSearch:
     Users can either let the wrapper auto-select the best configured provider
     (``engine="auto"``) or pin a specific engine. Unconfigured engines (missing
     API keys) are skipped automatically. When a specific engine is requested
-    but unavailable, the call fails by default — set ``fallback=True`` on a
+    but unavailable, the call fails by default -- set ``fallback=True`` on a
     per-call basis to fall through to the auto chain instead.
 
     Example:
@@ -156,7 +156,7 @@ class WebSearch:
         # Cache instantiated engines (configured ones only)
         self._engine_cache: dict[str, BaseSearch] = {}
         # Narrow the ``engine`` parameter type to only the configured engines
-        # so that the JSON schema seen by LLM clients reflects real runtime
+        # so that the JSON schema seen by LLM clients reflects the real runtime
         # availability. The class-level full Literal remains intact for IDE /
         # static analysis use.
         self._narrow_engine_annotation()
@@ -251,7 +251,7 @@ class WebSearch:
         """List all known engines and whether each is currently configured.
 
         Returns:
-            Mapping of engine name → configured status.
+            Mapping of engine name -> configured status.
         """
         result: dict[str, bool] = {}
         for name in _ENGINE_REGISTRY:
@@ -273,7 +273,7 @@ class WebSearch:
         IMPORTANT: For time-sensitive queries (e.g., "recent news", "latest updates",
         "today's events"), you MUST first obtain the current date/time using an
         available time/datetime tool before constructing your search query. As an
-        LLM, you have no inherent sense of current time — your training data may
+        LLM, you have no inherent sense of current time -- your training data may
         be outdated. Always verify the current date when temporal context matters.
 
         Args:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -9,7 +9,10 @@ from unittest.mock import patch
 # Add the src directory to the path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+from toolregistry.tool import ToolTag
+
 from toolregistry_hub.server.registry import (
+    _TOOL_METADATA,
     _import_class,
     build_registry,
     get_registry,
@@ -293,6 +296,83 @@ class TestBuildRegistryWithToolsConfig(unittest.TestCase):
             self.assertNotIn("fake", namespaces)
         finally:
             os.unlink(config_path)
+
+
+class TestToolMetadataAndDiscovery(unittest.TestCase):
+    """Test cases for tool metadata, discovery, and think-augment features."""
+
+    def test_filesystem_not_in_defaults(self):
+        """Test that deprecated FileSystem is no longer in default tools."""
+        reg = build_registry(enable_discovery=False)
+        namespaces = {tool.namespace for tool in reg._tools.values() if tool.namespace}
+        self.assertNotIn("filesystem", namespaces)
+
+    def test_tool_metadata_tags_applied(self):
+        """Test that ToolTag metadata is applied to registered tools."""
+        reg = build_registry(enable_discovery=False)
+
+        # Calculator should have READ_ONLY tag
+        calc_tools = [t for t in reg._tools.values() if t.namespace == "calculator"]
+        for tool in calc_tools:
+            self.assertIn(ToolTag.READ_ONLY, tool.metadata.tags)
+
+        # BashTool should have DESTRUCTIVE and PRIVILEGED
+        bash_tools = [t for t in reg._tools.values() if t.namespace == "bash"]
+        for tool in bash_tools:
+            self.assertIn(ToolTag.DESTRUCTIVE, tool.metadata.tags)
+            self.assertIn(ToolTag.PRIVILEGED, tool.metadata.tags)
+
+        # FileOps should have FILE_SYSTEM and DESTRUCTIVE
+        fileops_tools = [t for t in reg._tools.values() if t.namespace == "file_ops"]
+        for tool in fileops_tools:
+            self.assertIn(ToolTag.FILE_SYSTEM, tool.metadata.tags)
+            self.assertIn(ToolTag.DESTRUCTIVE, tool.metadata.tags)
+
+    def test_deferred_tools_marked(self):
+        """Test that tools in _TOOL_METADATA with defer=True are deferred."""
+        reg = build_registry(enable_discovery=False)
+
+        deferred_namespaces = {
+            ns for ns, meta in _TOOL_METADATA.items() if meta.get("defer")
+        }
+        for tool in reg._tools.values():
+            if tool.namespace in deferred_namespaces:
+                self.assertTrue(
+                    tool.metadata.defer,
+                    f"Tool in namespace {tool.namespace} should be deferred",
+                )
+
+    def test_core_tools_not_deferred(self):
+        """Test that core tools are not deferred."""
+        reg = build_registry(enable_discovery=False)
+
+        core_namespaces = {"calculator", "datetime", "think", "file_ops"}
+        for tool in reg._tools.values():
+            if tool.namespace in core_namespaces:
+                self.assertFalse(
+                    tool.metadata.defer,
+                    f"Core tool in namespace {tool.namespace} should not be deferred",
+                )
+
+    def test_discovery_enabled(self):
+        """Test that enable_discovery=True registers discover_tools."""
+        reg = build_registry(enable_discovery=True)
+        self.assertIn("discover_tools", reg._tools)
+
+    def test_discovery_disabled(self):
+        """Test that enable_discovery=False does not register discover_tools."""
+        reg = build_registry(enable_discovery=False)
+        self.assertNotIn("discover_tools", reg._tools)
+
+    def test_think_augment_enabled(self):
+        """Test that enable_think=True activates think-augmented calling."""
+        reg = build_registry(enable_discovery=False, enable_think=True)
+        self.assertTrue(reg._think_augment)
+
+    def test_think_augment_disabled(self):
+        """Test that enable_think=False deactivates think-augmented calling."""
+        reg = build_registry(enable_discovery=False, enable_think=False)
+        self.assertFalse(reg._think_augment)
 
 
 class TestGetRegistry(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **ToolTag metadata**: Annotates all registered tools with semantic tags (`READ_ONLY`, `NETWORK`, `FILE_SYSTEM`, `DESTRUCTIVE`, `PRIVILEGED`) via a centralized `_TOOL_METADATA` dict, enabling clients to reason about tool safety and capabilities.
- **Progressive disclosure**: Marks non-essential tools (provider-specific search engines, filesystem utilities, bash, cron, etc.) as deferred. When `--tool-discovery` is enabled (default), only core tools appear in the initial schema; deferred tools are surfaced via a `discover_tools` tool.
- **Think-augmented function calling**: When `--think-augment` is enabled (default), injects a `thought` property into tool schemas so LLMs can perform chain-of-thought reasoning before invoking tools.
- **New CLI flags**: `--tool-discovery / --no-tool-discovery` and `--think-augment / --no-think-augment` (both default enabled) added to both `openapi` and `mcp` subcommands.
- **Removed deprecated FileSystem** from default tools (superseded by FileOps, FileReader, FileSearch, PathInfo).
- **Added unified WebSearch** (`websearch_unified.WebSearch`) to default tools, providing a single `search()` entry point with engine auto-selection and fallback across all configured providers.
- **API migration**: Updated `register_from_class()` calls from `with_namespace=` to `namespace=` (upstream API change).
- Registry is now always built with CLI flags (`enable_discovery`, `enable_think`) regardless of whether `--config` is specified.

## Test plan

- [x] All 24 existing + new tests pass (`pytest tests/test_registry.py -v`)
- [ ] Verify `toolregistry-hub mcp --no-tool-discovery --no-think-augment` disables both features
- [ ] Verify `toolregistry-hub openapi` shows reduced initial tool set with `discover_tools` available
- [ ] Verify deferred tools are accessible via `discover_tools` call