### PR TITLE
feat(fetch): improve SPA content quality detection

### DIFF
--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -46,6 +46,17 @@ _FETCH_MAX_RETRIES = 3
 # Base delay (in seconds) for exponential backoff between retries.
 _FETCH_RETRY_BASE_DELAY = 1.0
 
+# Navigation-only content detection thresholds.
+# These are used by _is_content_sufficient() to detect pages that consist
+# mostly of short navigation links/menu items rather than real content.
+_NAV_MIN_LINES = 5  # Minimum lines before applying structure analysis
+_NAV_SHORT_LINE_THRESHOLD = 30  # Characters; lines shorter are "short"
+_NAV_SHORT_LINE_RATIO = 0.7  # Fraction of short lines to trigger check
+_NAV_LONG_LINE_THRESHOLD = (
+    80  # Characters; lines at least this long are "real paragraphs"
+)
+_NAV_MIN_LONG_LINES = 2  # Minimum long lines required to pass the check
+
 # Content types that should be returned directly without HTML extraction.
 # When the server responds with one of these MIME types, the body is already
 # usable text/data — running it through readability or soup would be wasteful
@@ -171,6 +182,21 @@ def _is_content_sufficient(text: str) -> bool:
     for indicator in _SPA_SHELL_INDICATORS:
         if indicator in text_lower:
             return False
+
+    # Text structure analysis: detect navigation-only content.
+    lines = [line for line in text.split("\n") if line.strip()]
+    if len(lines) > _NAV_MIN_LINES:
+        short_lines = sum(
+            1 for line in lines if len(line.strip()) < _NAV_SHORT_LINE_THRESHOLD
+        )
+        short_ratio = short_lines / len(lines)
+        if short_ratio > _NAV_SHORT_LINE_RATIO:
+            # Mostly short lines — check for real paragraphs
+            long_lines = sum(
+                1 for line in lines if len(line.strip()) >= _NAV_LONG_LINE_THRESHOLD
+            )
+            if long_lines < _NAV_MIN_LONG_LINES:
+                return False
 
     return True
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -71,6 +71,59 @@ class TestIsContentSufficient:
         )
         assert _is_content_sufficient(text) is True
 
+    def test_navigation_only_text_rejected(self):
+        """Navigation-only content with many short lines should be rejected."""
+        nav_text = "\n".join(
+            [
+                "产品",
+                "文档",
+                "快速入门",
+                "产品简介",
+                "计费说明",
+                "使用指南",
+                "API参考",
+                "常见问题",
+                "联系我们",
+                "技术支持",
+                "帮助中心",
+                "开发者工具",
+                "SDK下载",
+                "版本更新",
+            ]
+        )
+        assert not _is_content_sufficient(nav_text)
+
+    def test_real_article_content_accepted(self):
+        """Content with real paragraphs should be accepted."""
+        article = (
+            "This is a comprehensive guide to using the API.\n\n"
+            "The API provides several endpoints for managing resources. "
+            "Each endpoint accepts standard HTTP methods and returns JSON "
+            "responses with appropriate status codes.\n\n"
+            "For authentication, include your API key in the Authorization header."
+        )
+        assert _is_content_sufficient(article)
+
+    def test_short_valid_content_accepted(self):
+        """Short content with fewer than threshold lines should pass."""
+        short = "Error: Connection refused\nPlease check your network settings.\nRetry later."
+        # Pad to meet minimum length
+        short = short + " " * (101 - len(short)) if len(short) < 101 else short
+        assert _is_content_sufficient(short)
+
+    def test_mixed_changelog_content_accepted(self):
+        """Mixed content with both short and long lines should pass."""
+        changelog = (
+            "## v2.0.0\n"
+            "- Added new authentication system with OAuth 2.0 support and "
+            "token refresh capabilities\n"
+            "- Fixed critical bug in data processing pipeline that caused "
+            "memory leaks under heavy load\n"
+            "## v1.9.0\n"
+            "- Minor updates"
+        )
+        assert _is_content_sufficient(changelog)
+
 
 # ============================================================
 # _format_text tests


### PR DESCRIPTION
## Summary

- Add text structure analysis to `_is_content_sufficient()` to detect navigation-only extractions that pass the existing length and keyword checks
- Uses line length distribution heuristics inspired by jusText: when most lines are very short (typical of navigation menus), the content is rejected unless it also contains paragraph-length lines
- Introduces configurable module-level thresholds (`_NAV_MIN_LINES`, `_NAV_SHORT_LINE_THRESHOLD`, `_NAV_SHORT_LINE_RATIO`, `_NAV_LONG_LINE_THRESHOLD`, `_NAV_MIN_LONG_LINES`)

## Problem

SPA pages (e.g. Chinese cloud console docs) often return navigation-only text after BS4 extraction — short menu items like "产品\n文档\n快速入门\n..." that exceed `_MIN_CONTENT_LENGTH` and contain none of the `_SPA_SHELL_INDICATORS`. The previous quality check passed these through as valid content instead of falling back to Jina Reader.

## Solution

After the existing length and keyword checks, `_is_content_sufficient()` now performs text structure analysis:

1. Split the text into non-empty lines
2. If there are more than `_NAV_MIN_LINES` (5) lines, compute the ratio of "short" lines (< 30 chars)
3. If > 70% of lines are short, require at least 2 "long" lines (>= 80 chars) to consider the content real paragraphs
4. Otherwise reject as navigation-only content

## New test cases

- `test_navigation_only_text_rejected` — many short nav-style lines are correctly rejected
- `test_real_article_content_accepted` — text with real paragraphs passes
- `test_short_valid_content_accepted` — fewer than 6 lines bypasses structure analysis
- `test_mixed_changelog_content_accepted` — changelog-style mix of short and long lines passes

Closes #94

## Test plan

- [ ] `pytest tests/test_fetch.py::TestIsContentSufficient` — all new and existing content quality tests pass
- [ ] `pytest tests/test_fetch.py` — full test suite passes