### PR TITLE
feat(server): upgrade for toolregistry 0.7.0 features

### DIFF
--- a/src/toolregistry_hub/server/cli.py
+++ b/src/toolregistry_hub/server/cli.py
@@ -36,7 +36,7 @@ import sys
 from typing import TYPE_CHECKING, NoReturn
 
 from .. import __version__
-from .._vendor.structlog import get_logger
+from .._structlog import get_logger
 from ..version_check import check_for_updates
 from .banner import BANNER_ART
 

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -17,7 +17,7 @@ import importlib
 from toolregistry import ToolRegistry
 from toolregistry.tool import ToolTag
 
-from .._vendor.structlog import get_logger
+from .._structlog import get_logger
 from ..utils.configurable import Configurable
 from ..utils.fn_namespace import _is_all_static_methods
 


### PR DESCRIPTION
## Summary

- **Tool metadata and tags**: Add `ToolMetadata` with `ToolTag` (READ_ONLY, DESTRUCTIVE, FILE_SYSTEM, NETWORK, PRIVILEGED) and `defer` flags to all registered tools via `_TOOL_METADATA` mapping
- **Tool discovery**: Enable progressive tool disclosure via BM25F search with `--tool-discovery` / `--no-tool-discovery` CLI flag (default: enabled)
- **Think-augmented function calling**: Inject `thought` property into tool schemas for chain-of-thought reasoning with `--think-augment` / `--no-think-augment` CLI flag (default: enabled)
- **FileSystem removal**: Remove deprecated `FileSystem` from default tools in favor of dedicated `FileOps`, `FileReader`, `FileSearch`, and `PathInfo` tools
- **CLI refactor**: `main()` always calls `build_registry()` with all flags (`enable_discovery`, `enable_think`, `tools_config_path`) before starting the server
- **Import path update**: Migrate `_vendor.structlog` import to `_structlog` module path

## Test plan

- [ ] Verify `build_registry()` succeeds without env vars
- [ ] Verify tool metadata tags are correctly applied (READ_ONLY, DESTRUCTIVE, etc.)
- [ ] Verify deferred tools are marked with `defer=True`
- [ ] Verify core tools are not deferred
- [ ] Verify `--tool-discovery` / `--no-tool-discovery` flag works
- [ ] Verify `--think-augment` / `--no-think-augment` flag works
- [ ] Verify FileSystem namespace is absent from defaults
- [ ] Run `pytest tests/test_registry.py` to confirm all tests pass