### PR TITLE
refactor: replace ua-generator with inline useragent module (P1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = [
-    "ua-generator>=1.0.6",
-]
+dependencies = []
 
 [project.optional-dependencies]
 dev = [

--- a/src/toolregistry_hub/_vendor/useragent.py
+++ b/src/toolregistry_hub/_vendor/useragent.py
@@ -1,0 +1,428 @@
+"""Lightweight User-Agent generator for Chrome/Edge with Client Hints.
+
+Generates realistic browser UA strings and matching ``Sec-CH-UA-*`` headers.
+Covers Windows, macOS, Linux (desktop) and Android (mobile) platforms with
+Chrome and Edge browsers only – this is intentionally minimal.
+
+Inspired by `ua-generator <https://github.com/iamdual/ua-generator>`_ (Apache-2.0).
+
+Zero external dependencies – stdlib ``random`` only.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Sequence, Union
+
+__version__ = "0.1.0"
+
+# ---------------------------------------------------------------------------
+# Version data
+# ---------------------------------------------------------------------------
+
+# (major, build) pairs.  Patch is randomised at generation time.
+# Sources:
+#   Chrome – https://chromereleases.googleblog.com/search/label/Stable%20updates
+#   Edge   – https://learn.microsoft.com/en-us/deployedge/microsoft-edge-release-schedule
+
+_CHROME_VERSIONS: list[tuple[int, int]] = [
+    (120, 6099),
+    (121, 6167),
+    (122, 6261),
+    (123, 6312),
+    (124, 6367),
+    (125, 6422),
+    (126, 6478),
+    (127, 6533),
+    (128, 6613),
+    (129, 6668),
+    (130, 6723),
+    (131, 6778),
+    (132, 6834),
+    (133, 6943),
+    (134, 6998),
+    (135, 7049),
+    (136, 7103),
+    (137, 7151),
+    (138, 7204),
+    (139, 7258),
+    (140, 7339),
+    (141, 7390),
+    (142, 7444),
+    (143, 7499),
+    (144, 7559),
+    (145, 7632),
+    (146, 7680),
+]
+
+_EDGE_VERSIONS: list[tuple[int, int]] = [
+    (120, 2210),
+    (121, 2277),
+    (122, 2365),
+    (123, 2420),
+    (124, 2478),
+    (125, 2535),
+    (126, 2592),
+    (127, 2651),
+    (128, 2739),
+    (129, 2792),
+    (130, 2849),
+    (131, 2903),
+    (132, 2957),
+    (133, 3065),
+    (134, 3124),
+    (135, 3179),
+    (136, 3240),
+    (137, 3296),
+    (138, 3351),
+    (139, 3405),
+    (140, 3485),
+    (141, 3537),
+    (142, 3595),
+    (143, 3650),
+    (144, 3719),
+    (145, 3800),
+    (146, 3856),
+]
+
+# Windows NT versions: (nt_major, nt_minor, ch_platform_range)
+_WINDOWS_VERSIONS: list[tuple[float, tuple[int, int]]] = [
+    (10.0, (1, 10)),  # Windows 10
+    (10.0, (13, 16)),  # Windows 11
+]
+
+# macOS versions: (major, minor, max_build)
+_MACOS_VERSIONS: list[tuple[int, int, int]] = [
+    (13, 6, 9),
+    (13, 7, 8),
+    (14, 4, 1),
+    (14, 5, 0),
+    (14, 6, 1),
+    (14, 7, 8),
+    (14, 8, 4),
+    (15, 0, 1),
+    (15, 1, 1),
+    (15, 2, 1),
+    (15, 3, 1),
+    (15, 4, 1),
+    (15, 5, 0),
+    (15, 6, 1),
+    (15, 7, 4),
+    (26, 0, 1),
+    (26, 1, 0),
+    (26, 2, 0),
+    (26, 3, 2),
+]
+
+# Android model strings (Samsung subset – most common vendor)
+_ANDROID_MODELS: tuple[str, ...] = (
+    "SM-G991B",
+    "SM-G996B",
+    "SM-G998B",
+    "SM-A526B",
+    "SM-A536B",
+    "SM-S901B",
+    "SM-S906B",
+    "SM-S908B",
+    "SM-S911B",
+    "SM-S916B",
+    "SM-S918B",
+    "SM-S921B",
+    "SM-S926B",
+    "SM-S928B",
+    "SM-A546B",
+    "SM-A556B",
+    "SM-A346B",
+    "SM-A256B",
+    "SM-A156B",
+    "SM-G781B",
+)
+
+_DESKTOP_PLATFORMS = ("windows", "macos", "linux")
+_MOBILE_PLATFORMS = ("android",)
+_ALL_PLATFORMS = _DESKTOP_PLATFORMS + _MOBILE_PLATFORMS
+
+_WEBKIT = "537.36"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _pick_chrome_version() -> tuple[int, int, int, int]:
+    """Return (major, minor=0, build, patch)."""
+    major, build = random.choice(_CHROME_VERSIONS)
+    return (major, 0, build, random.randint(0, 255))
+
+
+def _pick_edge_version() -> tuple[int, int, int, int]:
+    major, build = random.choice(_EDGE_VERSIONS)
+    return (major, 0, build, random.randint(0, 99))
+
+
+def _fmt_ver(v: tuple[int, ...], n: int = 4, sep: str = ".") -> str:
+    """Format version tuple to string, padding with 0s up to *n* parts."""
+    parts = list(v[:n])
+    while len(parts) < n:
+        parts.append(0)
+    return sep.join(str(p) for p in parts)
+
+
+def _pick_platform(device: str | None) -> str:
+    if device == "desktop":
+        return random.choice(_DESKTOP_PLATFORMS)
+    if device == "mobile":
+        return random.choice(_MOBILE_PLATFORMS)
+    return random.choice(_ALL_PLATFORMS)
+
+
+def _build_ua_string(
+    browser: str,
+    platform: str,
+    ver: tuple[int, int, int, int],
+) -> str:
+    """Build a User-Agent string from browser/platform/version."""
+    chrome_str = _fmt_ver(ver)
+
+    if platform == "windows":
+        nt = random.choice(_WINDOWS_VERSIONS)
+        nt_str = f"{nt[0]:.1f}".replace(".0", ".0")  # "10.0"
+        base = f"Mozilla/5.0 (Windows NT {nt_str}; Win64; x64) AppleWebKit/{_WEBKIT} (KHTML, like Gecko) Chrome/{chrome_str} Safari/{_WEBKIT}"
+        if browser == "edge":
+            base += f" Edg/{chrome_str}"
+        return base
+
+    if platform == "linux":
+        tpl = random.choice(
+            (
+                f"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/{_WEBKIT} (KHTML, like Gecko) Chrome/{chrome_str} Safari/{_WEBKIT}",
+                f"Mozilla/5.0 (X11; Ubuntu; Linux x86_64) AppleWebKit/{_WEBKIT} (KHTML, like Gecko) Chrome/{chrome_str} Safari/{_WEBKIT}",
+            )
+        )
+        if browser == "edge":
+            tpl += f" Edg/{chrome_str}"
+        return tpl
+
+    if platform == "macos":
+        mv = random.choice(_MACOS_VERSIONS)
+        build = random.randint(0, mv[2]) if mv[2] > 0 else 0
+        mac_str = f"{mv[0]}_{mv[1]}"
+        if build:
+            mac_str += f"_{build}"
+        base = f"Mozilla/5.0 (Macintosh; Intel Mac OS X {mac_str}) AppleWebKit/{_WEBKIT} (KHTML, like Gecko) Chrome/{chrome_str} Safari/{_WEBKIT}"
+        if browser == "edge":
+            base += f" Edg/{chrome_str}"
+        return base
+
+    if platform == "android":
+        android_ver = random.randint(12, 16)
+        model = random.choice(_ANDROID_MODELS)
+        base = (
+            f"Mozilla/5.0 (Linux; Android {android_ver}; {model}) "
+            f"AppleWebKit/{_WEBKIT} (KHTML, like Gecko) Chrome/{chrome_str} Mobile Safari/{_WEBKIT}"
+        )
+        if browser == "edge":
+            base += f" EdgA/{chrome_str}"
+        return base
+
+    raise ValueError(f"Unsupported platform: {platform}")
+
+
+# ---------------------------------------------------------------------------
+# Client Hints serialization
+# ---------------------------------------------------------------------------
+
+
+def _ch_bool(val: bool) -> str:
+    return "?1" if val else "?0"
+
+
+def _ch_string(val: str) -> str:
+    return f'"{val}"'
+
+
+def _ch_brand_list(brands: list[dict[str, str]]) -> str:
+    return ", ".join(f'"{b["brand"]}";v="{b["version"]}"' for b in brands)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class UserAgent:
+    """A generated user-agent with matching Client Hints headers.
+
+    Usage::
+
+        ua = generate(browser=["chrome", "edge"])
+        ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
+        headers = ua.headers.get()
+    """
+
+    def __init__(
+        self,
+        *,
+        browser: str,
+        platform: str,
+        version: tuple[int, int, int, int],
+        ua_string: str,
+    ) -> None:
+        self.browser = browser
+        self.platform = platform
+        self.version = version
+        self.text = ua_string
+        self.headers = _Headers(self)
+
+    # -- Client Hints data methods --
+
+    def _is_mobile(self) -> bool:
+        return self.platform in _MOBILE_PLATFORMS
+
+    def _ch_platform_name(self) -> str:
+        mapping = {
+            "windows": "Windows",
+            "macos": "macOS",
+            "linux": "Linux",
+            "android": "Android",
+        }
+        return mapping.get(self.platform, self.platform.title())
+
+    def _ch_platform_version(self) -> str:
+        if self.platform == "windows":
+            # Client Hints reports a different version for Windows
+            lo, hi = random.choice(_WINDOWS_VERSIONS)[1]
+            return f"{random.randint(lo, hi)}.0.0"
+        if self.platform == "macos":
+            mv = random.choice(_MACOS_VERSIONS)
+            return f"{mv[0]}.{mv[1]}.{random.randint(0, max(mv[2], 1))}"
+        if self.platform == "android":
+            return f"{random.randint(12, 16)}.0.0"
+        # Linux
+        return ""
+
+    def _ch_brands(self, full_version: bool = False) -> list[dict[str, str]]:
+        ver_str = _fmt_ver(self.version) if full_version else str(self.version[0])
+        filler_ver = "99.0.0.0" if full_version else "99"
+        brands: list[dict[str, str]] = [{"brand": "Not A(Brand", "version": filler_ver}]
+        if self.browser == "chrome":
+            brands.append({"brand": "Chromium", "version": ver_str})
+            brands.append({"brand": "Google Chrome", "version": ver_str})
+        elif self.browser == "edge":
+            brands.append({"brand": "Chromium", "version": ver_str})
+            brands.append({"brand": "Microsoft Edge", "version": ver_str})
+        return brands
+
+    def _ch_architecture(self) -> str:
+        if self.platform in ("android",):
+            return "arm"
+        if self.platform == "macos":
+            return random.choice(("arm", "x86", "arm", "arm"))
+        return "x86"
+
+    def _ch_bitness(self) -> str:
+        if self.platform == "android":
+            return random.choice(("32", "64", "32", "32"))
+        return "64"
+
+    def _ch_model(self) -> str:
+        if self.platform == "android":
+            return random.choice(_ANDROID_MODELS)
+        return ""
+
+    def __str__(self) -> str:
+        return self.text
+
+    def __repr__(self) -> str:
+        return f"UserAgent(browser={self.browser!r}, platform={self.platform!r})"
+
+
+class _Headers:
+    """Lazy header builder matching the ``ua_generator.Headers`` interface."""
+
+    def __init__(self, ua: UserAgent) -> None:
+        self._ua = ua
+        self._headers: dict[str, str] = {}
+        self._initialised = False
+
+    def _reset(self) -> None:
+        self._initialised = True
+        self._headers = {"user-agent": self._ua.text}
+        # Low-entropy hints (always included for Chromium)
+        self._add("sec-ch-ua")
+        self._add("sec-ch-ua-mobile")
+        self._add("sec-ch-ua-platform")
+
+    def _add(self, key: str) -> None:
+        ua = self._ua
+        if key == "sec-ch-ua":
+            self._headers[key] = _ch_brand_list(ua._ch_brands(full_version=False))
+        elif key == "sec-ch-ua-full-version-list":
+            self._headers[key] = _ch_brand_list(ua._ch_brands(full_version=True))
+        elif key == "sec-ch-ua-platform":
+            self._headers[key] = _ch_string(ua._ch_platform_name())
+        elif key == "sec-ch-ua-platform-version":
+            self._headers[key] = _ch_string(ua._ch_platform_version())
+        elif key == "sec-ch-ua-mobile":
+            self._headers[key] = _ch_bool(ua._is_mobile())
+        elif key == "sec-ch-ua-arch":
+            self._headers[key] = _ch_string(ua._ch_architecture())
+        elif key == "sec-ch-ua-bitness":
+            self._headers[key] = _ch_string(ua._ch_bitness())
+        elif key == "sec-ch-ua-model":
+            self._headers[key] = _ch_string(ua._ch_model())
+
+    def accept_ch(self, val: str) -> None:
+        """Process an ``Accept-CH`` header value and populate matching hints."""
+        self._reset()
+        for hint in val.split(","):
+            self._add(hint.strip().lower())
+
+    def get(self) -> dict[str, str]:
+        """Return all generated headers as a dict."""
+        if not self._initialised:
+            self._reset()
+        return self._headers
+
+
+def generate(
+    *,
+    browser: Union[str, Sequence[str]] | None = None,
+    device: str | None = None,
+) -> UserAgent:
+    """Generate a random User-Agent with matching Client Hints.
+
+    Args:
+        browser: Browser name or list of names to pick from.
+            Supported: ``"chrome"``, ``"edge"``. Defaults to both.
+        device: Device type – ``"desktop"`` or ``"mobile"``.
+            Defaults to random selection across all platforms.
+
+    Returns:
+        A :class:`UserAgent` instance.
+    """
+    # Resolve browser
+    if browser is None:
+        chosen_browser = random.choice(("chrome", "edge"))
+    elif isinstance(browser, str):
+        chosen_browser = browser
+    else:
+        chosen_browser = random.choice(list(browser))
+
+    if chosen_browser not in ("chrome", "edge"):
+        raise ValueError(f"Unsupported browser: {chosen_browser!r}")
+
+    # Resolve platform
+    platform = _pick_platform(device)
+
+    # Pick version
+    if chosen_browser == "chrome":
+        ver = _pick_chrome_version()
+    else:
+        ver = _pick_edge_version()
+
+    ua_string = _build_ua_string(chosen_browser, platform, ver)
+    return UserAgent(
+        browser=chosen_browser, platform=platform, version=ver, ua_string=ua_string
+    )

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -7,8 +7,6 @@ import time
 import unicodedata
 from typing import TYPE_CHECKING, Literal
 
-import ua_generator
-
 from ._vendor.httpclient import (
     HTTPError,
     HttpConnectionError,
@@ -19,6 +17,7 @@ from ._vendor.httpclient import (
 from ._vendor.readability import extract as readability_extract
 from ._vendor.soup import Soup
 from ._vendor.structlog import get_logger
+from ._vendor.useragent import generate
 
 if TYPE_CHECKING:
     from .utils.api_key_parser import APIKeyParser
@@ -345,7 +344,7 @@ def _get_content_with_markdown_negotiation(
         str: Markdown content if the server supports it, otherwise empty string.
     """
     try:
-        ua = ua_generator.generate(browser=["chrome", "edge"])
+        ua = generate(browser=["chrome", "edge"])
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         headers = ua.headers.get()
         headers["Accept"] = "text/markdown"
@@ -550,7 +549,7 @@ def _fetch_raw(
     last_exception: Exception | None = None
     for attempt in range(_FETCH_MAX_RETRIES):
         try:
-            ua = ua_generator.generate(browser=["chrome", "edge"])
+            ua = generate(browser=["chrome", "edge"])
             ua.headers.accept_ch(
                 "Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List"
             )

--- a/src/toolregistry_hub/websearch_legacy/websearch_bing.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_bing.py
@@ -7,7 +7,7 @@ from time import sleep
 from urllib.parse import parse_qs, unquote, urlparse
 
 from .._vendor.httpclient import Client, HTTPError, HttpClientError
-import ua_generator
+from .._vendor.useragent import generate as _ua_generate
 from .._vendor.soup import Soup, Tag
 
 from .._vendor.structlog import get_logger
@@ -193,7 +193,7 @@ class WebSearchBing(WebSearchGeneral):
         fetched_links: set[str] = set()
 
         # Create a persistent client with connection pooling
-        ua = ua_generator.generate(browser=["chrome", "edge"])
+        ua = _ua_generate(browser=["chrome", "edge"])
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         with Client(
             proxy=proxy,

--- a/src/toolregistry_hub/websearch_legacy/websearch_google.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_google.py
@@ -6,7 +6,7 @@ from time import sleep
 from urllib.parse import unquote  # to decode the url
 
 from .._vendor.httpclient import Client, HTTPError, HttpClientError
-import ua_generator
+from .._vendor.useragent import generate as _ua_generate
 from .._vendor.soup import Soup, Tag
 
 from .._vendor.structlog import get_logger
@@ -138,7 +138,7 @@ class WebSearchGoogle(WebSearchGeneral):
         fetched_links: set[str] = set()
 
         # Create a persistent client with connection pooling
-        ua = ua_generator.generate(device="mobile")
+        ua = _ua_generate(device="mobile")
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         with Client(
             proxy=proxy,

--- a/src/toolregistry_hub/websearch_legacy/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch_legacy/websearch_searxng.py
@@ -3,7 +3,7 @@ from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 
 from .._vendor.httpclient import HTTPError, HttpClientError, get as _http_get
-import ua_generator
+from .._vendor.useragent import generate as _ua_generate
 
 from .._vendor.structlog import get_logger
 from .filter import filter_search_results
@@ -144,7 +144,7 @@ class WebSearchSearXNG(WebSearchGeneral):
         """
         Perform a search using SearXNG and return the results.
         """
-        ua = ua_generator.generate(browser=["chrome", "edge"])
+        ua = _ua_generate(browser=["chrome", "edge"])
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         response = _http_get(
             searxng_base_url,


### PR DESCRIPTION
## Summary

- Add `_vendor/useragent.py` (~250 lines) — lightweight UA generator for Chrome/Edge with Client Hints support
- Migrate all 4 calling files (`fetch.py`, 3 legacy websearch modules) from `ua-generator` to the vendored module
- Remove `ua-generator>=1.0.6` from `dependencies` — **`dependencies` is now empty**

This completes the zero-dep migration tracked in #98. All 3 original core dependencies (pydantic, httpx, ua-generator) have been replaced.

## Test plan
- [x] 698 tests pass (only preexisting Bright Data API test excluded)
- [x] ruff check + ruff format clean
- [x] ty check passes (same 18 warnings as before — unrelated vendored httpclient type)