### PR TITLE
chore: add complexipy for cognitive complexity analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,9 @@ cython_debug/
 # Ruff stuff:
 .ruff_cache/
 
+# complexipy cache
+.complexipy_cache/
+
 # PyPI configuration file
 .pypirc
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md — AI Agent Guide for toolregistry-hub
+
+## Project Overview
+
+**toolregistry-hub** is a ready-to-use tool collection for LLM agents, providing 19 pre-configured tools (calculator, web search, file ops, code execution, etc.) exposed via OpenAPI or MCP servers.
+
+It is part of a three-package ecosystem:
+
+| Package | Role | Depends on |
+|---------|------|------------|
+| `toolregistry` | Core library: `Tool` model, `ToolRegistry`, client integrations | — |
+| `toolregistry-server` | Server infrastructure: `RouteTable`, OpenAPI/MCP adapters, auth, CLI | `toolregistry` |
+| `toolregistry-hub` | Tool implementations + default server configuration | `toolregistry-server` (transitively provides `toolregistry`) |
+
+Entry point: `toolregistry-hub` CLI (defined in `pyproject.toml` `[project.scripts]`).
+
+## Directory Structure
+
+```
+src/toolregistry_hub/
+├── __init__.py              # Package exports, __version__
+├── server/
+│   ├── cli.py               # CLI entry point (argparse, openapi/mcp subcommands)
+│   ├── registry.py          # build_registry() — tool registration + auto-disable
+│   ├── tool_config.py       # JSONC config loading (tools.jsonc)
+│   ├── auth.py              # Token auth helpers
+│   ├── banner.py            # Startup banner art
+│   └── routes/              # Non-tool routes (e.g. /version)
+├── utils/
+│   ├── configurable.py      # Configurable protocol (structural subtyping)
+│   ├── api_key_parser.py    # API key rotation/parsing
+│   └── fn_namespace.py      # Static-method detection helper
+├── _vendor/                 # Vendored modules from zerodep (see below)
+├── websearch/               # Search providers (brave, tavily, searxng, brightdata, scrapeless, serper)
+├── calculator.py            # Math operations
+├── datetime_utils.py        # Time/timezone utilities
+├── fetch.py                 # URL content fetching
+├── file_ops.py              # File manipulation (replace lines, etc.)
+├── file_reader.py           # PDF/text/image file reading
+├── file_search.py           # Glob/grep file search
+├── filesystem.py            # File system operations (exists, read, write)
+├── path_info.py             # Path metadata
+├── bash_tool.py             # Shell command execution
+├── cron_tool.py             # Cron scheduling
+├── think_tool.py            # Chain-of-thought reasoning
+├── todo_list.py             # Task/todo management
+├── unit_converter.py        # Unit conversions
+└── version_check.py         # PyPI update checker
+
+tests/
+├── run_tests.py             # Test runner with modular targets
+├── Makefile                 # Test/lint/format targets
+├── test_*.py                # Per-module unit tests
+└── websearch/               # Websearch-specific tests
+
+docker/                      # Dockerfile and Docker docs
+```
+
+## Architecture
+
+### Registry-Driven Design
+
+All tools are registered dynamically in `build_registry()` (`server/registry.py`). The function:
+
+1. Loads tool config from `tools.jsonc` (if present)
+2. Imports each tool class via `_DEFAULT_TOOLS` list (or config-specified list)
+3. Registers classes/instances into `ToolRegistry`
+4. Auto-disables tools that fail `Configurable._is_configured()` (e.g. missing API keys)
+5. Applies `tools.jsonc` enable/disable rules (highest priority)
+6. Applies metadata (tags, defer flags) from `_TOOL_METADATA`
+7. Enables progressive tool discovery if `enable_discovery=True`
+
+### Registered Tools
+
+Default tools and their namespaces (from `_DEFAULT_TOOLS` in `server/registry.py`):
+
+| Namespace | Class | Tags |
+|-----------|-------|------|
+| `bash` | `BashTool` | DESTRUCTIVE, PRIVILEGED, deferred |
+| `cron` | `CronTool` | PRIVILEGED, deferred |
+| `calculator` | `Calculator` | READ_ONLY |
+| `datetime` | `DateTime` | READ_ONLY |
+| `web/fetch` | `Fetch` | NETWORK, READ_ONLY |
+| `file_ops` | `FileOps` | FILE_SYSTEM, DESTRUCTIVE |
+| `reader` | `FileReader` | FILE_SYSTEM, READ_ONLY, deferred |
+| `fs/file_search` | `FileSearch` | FILE_SYSTEM, READ_ONLY, deferred |
+| `fs/path_info` | `PathInfo` | FILE_SYSTEM, READ_ONLY, deferred |
+| `think` | `ThinkTool` | READ_ONLY |
+| `todolist` | `TodoList` | READ_ONLY, deferred |
+| `unit_converter` | `UnitConverter` | READ_ONLY, deferred |
+| `web/websearch` | `WebSearch` (unified) | NETWORK, READ_ONLY |
+| `web/brave_search` | `BraveSearch` | NETWORK, READ_ONLY, deferred |
+| `web/tavily_search` | `TavilySearch` | NETWORK, READ_ONLY, deferred |
+| `web/searxng_search` | `SearXNGSearch` | NETWORK, READ_ONLY, deferred |
+| `web/brightdata_search` | `BrightDataSearch` | NETWORK, READ_ONLY, deferred |
+| `web/scrapeless_search` | `ScrapelessSearch` | NETWORK, READ_ONLY, deferred |
+| `web/serper_search` | `SerperSearch` | NETWORK, READ_ONLY, deferred |
+
+"Deferred" tools are hidden from initial schema and discoverable via `discover_tools` (progressive disclosure).
+
+### Auto-Disable
+
+Tools implementing the `Configurable` protocol (a `_is_configured() -> bool` method) are checked at startup. If `_is_configured()` returns `False`, all tools in that namespace are disabled with a reason (e.g. `"Missing env: BRAVE_API_KEY"`). This prevents the server from crashing due to missing credentials.
+
+### Configuration Priority
+
+```
+tools.jsonc config  >  Configurable auto-disable  >  Default (all enabled)
+```
+
+`tools.jsonc` supports two modes:
+- `denylist` (default): disable listed namespaces
+- `allowlist`: enable only listed namespaces
+
+Namespace matching is hierarchical: `"web"` matches `"web/brave_search"`, `"web/fetch"`, etc.
+
+## Server Modes
+
+### OpenAPI
+
+```bash
+toolregistry-hub openapi [--host 0.0.0.0] [--port 8000] [--config tools.jsonc] [--tokens tokens.txt]
+```
+
+Routes are auto-generated from the registry. Includes a `/version` endpoint.
+
+### MCP (Model Context Protocol)
+
+```bash
+toolregistry-hub mcp [--transport stdio|sse|streamable-http] [--host 127.0.0.1] [--port 8000]
+```
+
+### Common Flags
+
+- `--config PATH` — JSONC tool configuration file
+- `--env PATH` — custom `.env` file path
+- `--no-env` — skip loading `.env`
+- `--admin-port PORT` — enable admin panel
+- `--tool-discovery / --no-tool-discovery` — toggle progressive disclosure
+- `--think-augment / --no-think-augment` — toggle think-augmented function calling
+- `--no-banner` — suppress startup banner
+
+## Development
+
+### Environment
+
+```bash
+# Conda environment
+conda activate toolregistry_hub
+
+# Install for development
+pip install -e ".[dev,server]"
+```
+
+### Code Quality
+
+```bash
+# Lint (ruff rules: E, F, UP; ignores UP007, E501)
+ruff check src/
+ruff check --fix src/       # auto-fix
+
+# Format
+ruff format src/
+
+# Type check (ty, Python 3.10 target; vendor dir excluded)
+ty check src/
+
+# Cognitive complexity analysis (complexipy)
+complexipy src/ -e "_vendor"
+```
+
+### Testing
+
+```bash
+# All tests
+make test                   # or: cd tests && python run_tests.py
+
+# Specific module
+cd tests && python run_tests.py --module calculator
+
+# Unit / integration / fast
+cd tests && python run_tests.py --unit
+cd tests && python run_tests.py --integration
+cd tests && python run_tests.py --fast
+```
+
+### Build & Release
+
+```bash
+make build-package          # python -m build
+make push-package           # twine upload dist/*
+make build-docker           # Docker image build
+make build-docker V=0.8.0 PYPI_MIRROR=https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+## Adding a New Tool
+
+1. Create `src/toolregistry_hub/your_tool.py` — implement the tool class
+   - Use static methods for stateless tools, instance methods for stateful/configurable ones
+   - If the tool needs API keys: implement `Configurable._is_configured()` and set `_required_envs`
+2. Add entry to `_DEFAULT_TOOLS` in `server/registry.py` with `class` and `namespace`
+3. Add metadata to `_TOOL_METADATA` in `server/registry.py` (tags, defer flag)
+4. Export from `__init__.py` (add to imports and `__all__`)
+5. Write tests in `tests/test_your_tool.py`
+6. Run `ruff check --fix src/ && ruff format src/ && ty check src/ && complexipy src/ -e "_vendor"`
+
+## CI Pipeline
+
+GitHub Actions (`.github/workflows/ci.yml`) runs on push/PR to `master`:
+
+1. **Lint**: `ruff check` + `ruff format --check`
+2. **Type check**: `ty check src/`
+3. **Test**: `pytest tests/ -v`
+
+Python version: 3.10. Install: `pip install -e ".[dev,server_core]"`.
+
+## Key Conventions
+
+- **Python ≥ 3.10** required
+- **Zero runtime dependencies** — the base package has `dependencies = []` in `pyproject.toml`; all deps are in optional extras
+- **Vendored modules** in `_vendor/` — sourced from [zerodep](https://github.com/Oaklight/zerodep), managed via `zerodep` CLI (see below)
+- **Google-style docstrings** throughout
+- **snake_case** for functions/variables, **PascalCase** for classes
+- Comments and docstrings in **English**
+- Hierarchical namespaces use `/` separator (e.g. `web/brave_search`, `fs/file_search`)
+
+## Vendored Modules (`_vendor/`)
+
+All vendored modules come from [zerodep](https://github.com/Oaklight/zerodep) — a zero-dependency Python module collection by the same author. They are managed via the `zerodep` CLI tool.
+
+### Modules
+
+| Module | Version | Purpose |
+|--------|---------|---------|
+| `httpclient` | 0.3.1 | Sync+async HTTP client (replaces httpx) |
+| `structlog` | 0.3.0 | Structured logging (replaces loguru) |
+| `useragent` | 0.1.0 | User-Agent string generator |
+| `validate` | 0.4.3 | Runtime type validator with JSON Schema |
+| `scheduler` | 0.3.1 | In-process cron task scheduler |
+| `soup/` | 0.6.0 | HTML parser (replaces beautifulsoup4) |
+| `readability/` | 0.1.0 | HTML content extractor (depends on `soup`) |
+| `sparse_search/` | 0.4.0 | BM25/TF-IDF full-text search engine for search result reranking |
+
+### Management
+
+Each module file embeds a `# /// zerodep` metadata block with version, deps, and tier info. To add or update a vendored module:
+
+```bash
+zerodep add <module>             # add/update a flat module
+zerodep add --nested <module>    # add with nested package layout
+```
+
+### Rules
+
+- **Never edit vendored files manually** — update upstream in zerodep, then re-vendor via CLI
+- `_vendor/` is excluded from `ty` type checking, `complexipy` analysis, and from ruff `UP035` rule (see `pyproject.toml`)
+- Vendored modules must remain stdlib-only (no third-party imports)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = []
 dev = [
     "ty>=0.0.21",
     "ruff>=0.1.0",
+    "complexipy>=5.2.0",
     "python-dotenv>=1.0.1",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
@@ -108,3 +109,8 @@ exclude = ["src/toolregistry_hub/_vendor"]
 unresolved-import = "ignore"
 invalid-assignment = "ignore"
 unresolved-attribute = "warn"
+
+[tool.complexipy]
+paths = ["src"]
+max-complexity-allowed = 15
+exclude = ["src/toolregistry_hub/_vendor"]

--- a/src/toolregistry_hub/cron_tool.py
+++ b/src/toolregistry_hub/cron_tool.py
@@ -241,32 +241,54 @@ class CronTool:
             if record is None:
                 return
 
-            # TTL check for recurring jobs
-            if record.recurring:
-                created = datetime.fromisoformat(record.created_at)
-                if datetime.now() - created > timedelta(days=_TTL_DAYS):
-                    # Expired — remove the job
-                    with self._lock:
-                        self._jobs.pop(job_id, None)
-                    try:
-                        self._scheduler.remove_job(job_id)
-                    except JobNotFound:
-                        pass
-                    if record.durable:
-                        self._save_durable()
-                    return
+            if record.recurring and self._is_expired(record):
+                self._remove_job(job_id, record)
+                return
 
-            # One-shot cleanup: remove from _jobs after firing
             if not record.recurring:
-                with self._lock:
-                    self._jobs.pop(job_id, None)
-                if record.durable:
-                    self._save_durable()
+                self._remove_job_record(job_id, record)
 
             if self._on_trigger is not None:
                 self._on_trigger(record.prompt)
 
         return _fire
+
+    def _is_expired(self, record: _JobRecord) -> bool:
+        """Check if a recurring job has exceeded its TTL.
+
+        Args:
+            record: The job record to check.
+
+        Returns:
+            True if the job has expired.
+        """
+        created = datetime.fromisoformat(record.created_at)
+        return datetime.now() - created > timedelta(days=_TTL_DAYS)
+
+    def _remove_job(self, job_id: str, record: _JobRecord) -> None:
+        """Remove a job from both the registry and the scheduler.
+
+        Args:
+            job_id: The job identifier.
+            record: The job record (used to check durable flag).
+        """
+        self._remove_job_record(job_id, record)
+        try:
+            self._scheduler.remove_job(job_id)
+        except JobNotFound:
+            pass
+
+    def _remove_job_record(self, job_id: str, record: _JobRecord) -> None:
+        """Remove a job from the internal registry (but not the scheduler).
+
+        Args:
+            job_id: The job identifier.
+            record: The job record (used to check durable flag).
+        """
+        with self._lock:
+            self._jobs.pop(job_id, None)
+        if record.durable:
+            self._save_durable()
 
     def _save_durable(self) -> None:
         """Persist all durable jobs to the JSON file."""

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -206,6 +206,47 @@ def _is_content_sufficient(text: str) -> bool:
     return True
 
 
+def _pick_local_content(
+    readability_content: str,
+    soup_content: str,
+    url: str,
+) -> str:
+    """Choose the best local extraction result.
+
+    Prefers readability unless soup produced substantially more content
+    (> 2x). Falls back to the next candidate if the preferred one is
+    insufficient.
+
+    Args:
+        readability_content: Text from readability extraction.
+        soup_content: Text from soup extraction.
+        url: URL being processed (for logging).
+
+    Returns:
+        Best sufficient content string, or empty string if neither qualifies.
+    """
+    candidates = [
+        (readability_content, "readability"),
+        (soup_content, "soup"),
+    ]
+    for candidate, strategy in candidates:
+        if not candidate or not _is_content_sufficient(candidate):
+            continue
+        if (
+            strategy == "readability"
+            and soup_content
+            and len(soup_content) > len(candidate) * 2
+        ):
+            logger.debug(
+                f"Readability result shorter than soup "
+                f"({len(candidate)} vs {len(soup_content)}), trying soup"
+            )
+            continue
+        logger.info(f"Successfully fetched {url} using strategy: {strategy}")
+        return candidate
+    return ""
+
+
 def _extract(
     url: str,
     timeout: float = TIMEOUT_DEFAULT,
@@ -262,29 +303,10 @@ def _extract(
         # 3. Try simple soup extraction (CSS selector fallback)
         soup_content = _extract_with_soup(html)
 
-        # Pick the best local result: prefer whichever is longer and sufficient.
-        # Readability produces cleaner article text; soup captures more structural
-        # content.  When readability returns only a short skeleton (e.g. SPA pages),
-        # soup's broader extraction is usually more useful.
-        for candidate, strategy in [
-            (readability_content, "readability"),
-            (soup_content, "soup"),
-        ]:
-            if candidate and _is_content_sufficient(candidate):
-                # Prefer readability if it extracted substantially more or equal
-                # content; otherwise fall through to soup.
-                if (
-                    strategy == "readability"
-                    and soup_content
-                    and len(soup_content) > len(candidate) * 2
-                ):
-                    logger.debug(
-                        f"Readability result shorter than soup "
-                        f"({len(candidate)} vs {len(soup_content)}), trying soup"
-                    )
-                    continue
-                logger.info(f"Successfully fetched {url} using strategy: {strategy}")
-                return _format_text(candidate)
+        # Pick the best local result
+        best = _pick_local_content(readability_content, soup_content, url)
+        if best:
+            return _format_text(best)
 
         # Stash best local result for final fallback
         local_content = readability_content or soup_content or ""

--- a/src/toolregistry_hub/file_search.py
+++ b/src/toolregistry_hub/file_search.py
@@ -195,6 +195,46 @@ class FileSearch:
         return "\n".join(lines)
 
     @staticmethod
+    def _list_entries(
+        directory: Path,
+        show_hidden: bool,
+        file_pattern: str | None,
+    ) -> list[Path]:
+        """List and filter directory entries for tree display.
+
+        Sorts directories first, then by name.  Filters hidden entries
+        and applies optional file glob pattern (directories always pass
+        so the tree structure stays intact).
+
+        Args:
+            directory: Directory to list.
+            show_hidden: Whether to include hidden entries.
+            file_pattern: Optional glob to filter files.
+
+        Returns:
+            Sorted, filtered list of entries, or empty list on
+            permission error.
+        """
+        try:
+            entries = sorted(
+                directory.iterdir(), key=lambda e: (not e.is_dir(), e.name)
+            )
+        except PermissionError:
+            return []
+
+        if not show_hidden:
+            entries = [e for e in entries if not e.name.startswith(".")]
+
+        if file_pattern:
+            entries = [
+                e
+                for e in entries
+                if e.is_dir() or fnmatch.fnmatch(e.name, file_pattern)
+            ]
+
+        return entries
+
+    @staticmethod
     def _build_tree(
         directory: Path,
         prefix: str,
@@ -220,24 +260,7 @@ class FileSearch:
         if current_depth > max_depth:
             return
 
-        try:
-            entries = sorted(
-                directory.iterdir(), key=lambda e: (not e.is_dir(), e.name)
-            )
-        except PermissionError:
-            return
-
-        # Filter hidden
-        if not show_hidden:
-            entries = [e for e in entries if not e.name.startswith(".")]
-
-        # Filter files by pattern (directories always shown so tree structure is intact)
-        if file_pattern:
-            entries = [
-                e
-                for e in entries
-                if e.is_dir() or fnmatch.fnmatch(e.name, file_pattern)
-            ]
+        entries = FileSearch._list_entries(directory, show_hidden, file_pattern)
 
         for i, entry in enumerate(entries):
             if count[0] >= _MAX_TREE_ENTRIES:

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -198,9 +198,7 @@ def _register_tool(
         _disable_namespace(registry, cls, namespace)
 
 
-def _disable_namespace(
-    registry: ToolRegistry, cls: type, namespace: str
-) -> None:
+def _disable_namespace(registry: ToolRegistry, cls: type, namespace: str) -> None:
     """Disable all tools under *namespace* due to missing configuration.
 
     Args:

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -161,6 +161,87 @@ def _import_class(class_path: str) -> type:
     return getattr(module, class_name)
 
 
+def _register_tool(
+    registry: ToolRegistry,
+    class_path: str,
+    namespace: str,
+    kwargs: dict,
+) -> None:
+    """Import, instantiate, and register a single tool class.
+
+    Static-method-only classes are registered directly; others are
+    instantiated first.  Instances that implement the
+    :class:`~toolregistry_hub.utils.Configurable` protocol are checked
+    for readiness, and all tools under their namespace are auto-disabled
+    when configuration is incomplete.
+
+    Args:
+        registry: The registry to add the tool to.
+        class_path: Fully qualified class path to import.
+        namespace: Namespace under which to register.
+        kwargs: Constructor keyword arguments for the tool class.
+    """
+    try:
+        cls = _import_class(class_path)
+    except (ImportError, AttributeError) as e:
+        logger.error(f"Failed to import tool class '{class_path}': {e}")
+        return
+
+    if _is_all_static_methods(cls):
+        registry.register_from_class(cls, namespace=namespace)
+        return
+
+    instance = cls(**kwargs)
+    registry.register_from_class(instance, namespace=namespace)
+
+    if isinstance(instance, Configurable) and not instance._is_configured():
+        _disable_namespace(registry, cls, namespace)
+
+
+def _disable_namespace(
+    registry: ToolRegistry, cls: type, namespace: str
+) -> None:
+    """Disable all tools under *namespace* due to missing configuration.
+
+    Args:
+        registry: The registry containing the tools.
+        cls: The tool class (used to read ``_required_envs``).
+        namespace: Namespace whose tools should be disabled.
+    """
+    required_envs: list[str] = getattr(cls, "_required_envs", [])
+    reason = (
+        f"Missing env: {', '.join(required_envs)}"
+        if required_envs
+        else "Not configured"
+    )
+    for tool_name, tool in registry._tools.items():
+        if tool.namespace == namespace:
+            registry.disable(tool_name, reason=reason)
+    logger.info(f"Disabled {namespace}: {reason}")
+
+
+def _remove_hidden_methods(registry: ToolRegistry) -> None:
+    """Remove explicitly hidden methods from the registry.
+
+    Note: Methods starting with ``_`` are already excluded by toolregistry;
+    this handles any additional methods listed in ``_HIDDEN_METHODS``.
+
+    Args:
+        registry: The registry to clean up.
+    """
+    if not _HIDDEN_METHODS:
+        return
+    to_remove = [
+        name
+        for name, tool in registry._tools.items()
+        if tool.method_name in _HIDDEN_METHODS
+    ]
+    for name in to_remove:
+        del registry._tools[name]
+        registry._disabled.pop(name, None)
+        logger.debug(f"Removed hidden method from registry: {name}")
+
+
 def build_registry(
     tool_kwargs: dict[str, dict] | None = None,
     tools_config_path: str | None = None,
@@ -208,50 +289,12 @@ def build_registry(
     registry = ToolRegistry(name="hub", think_augment=enable_think)
 
     for tool_def in tools_to_register:
-        class_path = tool_def["class"]
         namespace = tool_def["namespace"]
-
-        try:
-            cls = _import_class(class_path)
-        except (ImportError, AttributeError) as e:
-            logger.error(f"Failed to import tool class '{class_path}': {e}")
-            continue
-
-        # For tool_kwargs lookup, use the leaf namespace (after last '/')
         kwargs_key = namespace.rsplit("/", 1)[-1]
         kwargs = (tool_kwargs or {}).get(kwargs_key, {})
+        _register_tool(registry, tool_def["class"], namespace, kwargs)
 
-        if _is_all_static_methods(cls):
-            registry.register_from_class(cls, namespace=namespace)
-        else:
-            instance = cls(**kwargs)
-            registry.register_from_class(instance, namespace=namespace)
-
-            # Check instance readiness via Configurable protocol
-            if isinstance(instance, Configurable) and not instance._is_configured():
-                required_envs: list[str] = getattr(cls, "_required_envs", [])
-                reason = (
-                    f"Missing env: {', '.join(required_envs)}"
-                    if required_envs
-                    else "Not configured"
-                )
-                for tool_name, tool in registry._tools.items():
-                    if tool.namespace == namespace:
-                        registry.disable(tool_name, reason=reason)
-                logger.info(f"Disabled {namespace}: {reason}")
-
-    # Remove hidden methods from the registry (if any are explicitly listed)
-    # Note: Methods starting with "_" are already excluded by toolregistry
-    if _HIDDEN_METHODS:
-        to_remove = [
-            name
-            for name, tool in registry._tools.items()
-            if tool.method_name in _HIDDEN_METHODS
-        ]
-        for name in to_remove:
-            del registry._tools[name]
-            registry._disabled.pop(name, None)
-            logger.debug(f"Removed hidden method from registry: {name}")
+    _remove_hidden_methods(registry)
 
     # Apply startup tool configuration (highest priority)
     if config is not None:

--- a/src/toolregistry_hub/server/tool_config.py
+++ b/src/toolregistry_hub/server/tool_config.py
@@ -110,6 +110,49 @@ class ToolConfig:
 # ---------------------------------------------------------------------------
 
 
+def _parse_tools_field(
+    tools_list: Any, path: Path
+) -> list[ToolEntry] | None:
+    """Parse the optional ``tools`` field from a config file.
+
+    Args:
+        tools_list: Raw value of the ``"tools"`` key (may be ``None``).
+        path: Config file path, used for log messages.
+
+    Returns:
+        Parsed list of :class:`ToolEntry`, or ``None`` if the field is
+        absent or invalid.
+    """
+    if tools_list is None:
+        return None
+
+    if not isinstance(tools_list, list):
+        logger.warning(
+            f"Invalid 'tools' field in {path}: "
+            f"expected list, got {type(tools_list).__name__}"
+        )
+        return None
+
+    tools: list[ToolEntry] = []
+    for i, entry in enumerate(tools_list):
+        if not isinstance(entry, dict):
+            logger.warning(
+                f"Invalid tool entry at index {i} in {path}: expected dict"
+            )
+            continue
+        entry_dict: dict[str, Any] = entry
+        class_path = entry_dict.get("class")
+        namespace = entry_dict.get("namespace")
+        if not class_path or not namespace:
+            logger.warning(
+                f"Tool entry at index {i} missing 'class' or "
+                f"'namespace' in {path}"
+            )
+            continue
+        tools.append(ToolEntry(class_path=class_path, namespace=namespace))
+    return tools
+
+
 def load_tool_config(config_path: str | None = None) -> ToolConfig | None:
     """Discover and parse a JSONC tool configuration file.
 
@@ -159,33 +202,7 @@ def load_tool_config(config_path: str | None = None) -> ToolConfig | None:
     if not isinstance(enabled, list) or not all(isinstance(x, str) for x in enabled):
         raise ValueError(f"'enabled' in {path} must be a list of strings.")
 
-    # Parse optional 'tools' field
-    tools_list = data.get("tools")
-    tools = None
-    if tools_list is not None:
-        if not isinstance(tools_list, list):
-            logger.warning(
-                f"Invalid 'tools' field in {path}: "
-                f"expected list, got {type(tools_list).__name__}"
-            )
-        else:
-            tools = []
-            for i, entry in enumerate(tools_list):
-                if not isinstance(entry, dict):
-                    logger.warning(
-                        f"Invalid tool entry at index {i} in {path}: expected dict"
-                    )
-                    continue
-                entry_dict: dict[str, Any] = entry
-                class_path = entry_dict.get("class")
-                namespace = entry_dict.get("namespace")
-                if not class_path or not namespace:
-                    logger.warning(
-                        f"Tool entry at index {i} missing 'class' or "
-                        f"'namespace' in {path}"
-                    )
-                    continue
-                tools.append(ToolEntry(class_path=class_path, namespace=namespace))
+    tools = _parse_tools_field(data.get("tools"), path)
 
     return ToolConfig(
         mode=mode,

--- a/src/toolregistry_hub/server/tool_config.py
+++ b/src/toolregistry_hub/server/tool_config.py
@@ -110,9 +110,7 @@ class ToolConfig:
 # ---------------------------------------------------------------------------
 
 
-def _parse_tools_field(
-    tools_list: Any, path: Path
-) -> list[ToolEntry] | None:
+def _parse_tools_field(tools_list: Any, path: Path) -> list[ToolEntry] | None:
     """Parse the optional ``tools`` field from a config file.
 
     Args:
@@ -136,17 +134,14 @@ def _parse_tools_field(
     tools: list[ToolEntry] = []
     for i, entry in enumerate(tools_list):
         if not isinstance(entry, dict):
-            logger.warning(
-                f"Invalid tool entry at index {i} in {path}: expected dict"
-            )
+            logger.warning(f"Invalid tool entry at index {i} in {path}: expected dict")
             continue
         entry_dict: dict[str, Any] = entry
         class_path = entry_dict.get("class")
         namespace = entry_dict.get("namespace")
         if not class_path or not namespace:
             logger.warning(
-                f"Tool entry at index {i} missing 'class' or "
-                f"'namespace' in {path}"
+                f"Tool entry at index {i} missing 'class' or 'namespace' in {path}"
             )
             continue
         tools.append(ToolEntry(class_path=class_path, namespace=namespace))

--- a/src/toolregistry_hub/version_check.py
+++ b/src/toolregistry_hub/version_check.py
@@ -41,6 +41,55 @@ async def get_latest_pypi_version(
         return None
 
 
+def _pre_release_weight(pre_release_part: str) -> int:
+    """Map a pre-release suffix to a sort weight.
+
+    Args:
+        pre_release_part: The non-numeric suffix, e.g. ``"a1"``, ``"rc2"``.
+
+    Returns:
+        Negative integer (alpha < beta < rc < other < release).
+    """
+    if "a" in pre_release_part:
+        return -3
+    if "b" in pre_release_part:
+        return -2
+    if "rc" in pre_release_part:
+        return -1
+    return -4
+
+
+def _parse_version_tuple(v: str) -> tuple[int, ...]:
+    """Parse a version string into a comparable tuple of integers.
+
+    Handles standard versions (``"1.2.3"``) and pre-release tags
+    (``"1.0.0a1"``, ``"2.0.0rc1"``).
+
+    Args:
+        v: Version string.
+
+    Returns:
+        Tuple of integers suitable for comparison.
+    """
+    parts: list[int] = []
+    weight = 0
+
+    for segment in v.split("."):
+        numeric = ""
+        for i, char in enumerate(segment):
+            if char.isdigit():
+                numeric += char
+            else:
+                pre = segment[i:]
+                weight = _pre_release_weight(pre)
+                break
+
+        parts.append(int(numeric) if numeric else 0)
+
+    parts.append(weight)
+    return tuple(parts)
+
+
 def compare_versions(current: str, latest: str) -> bool:
     """Compare two version strings to determine if an update is available.
 
@@ -52,42 +101,7 @@ def compare_versions(current: str, latest: str) -> bool:
         True if latest > current, False otherwise
     """
     try:
-        # Use a simple version parsing approach (Python 3.8+ supported)
-        def parse_version_tuple(v):
-            """Parse version string into tuple of integers for comparison."""
-            parts = []
-            pre_release_weight = 0
-
-            for part in v.split("."):
-                # Handle pre-release versions like "1.0.0a1", "1.0.0b2", "1.0.0rc1"
-                numeric_part = ""
-                pre_release_part = ""
-
-                for char in part:
-                    if char.isdigit():
-                        numeric_part += char
-                    else:
-                        pre_release_part = part[len(numeric_part) :]
-                        break
-
-                parts.append(int(numeric_part) if numeric_part else 0)
-
-                # Handle pre-release identifiers
-                if pre_release_part:
-                    if "a" in pre_release_part:  # alpha
-                        pre_release_weight = -3
-                    elif "b" in pre_release_part:  # beta
-                        pre_release_weight = -2
-                    elif "rc" in pre_release_part:  # release candidate
-                        pre_release_weight = -1
-                    else:
-                        pre_release_weight = -4  # other pre-release
-
-            # Add pre-release weight as the last element
-            parts.append(pre_release_weight)
-            return tuple(parts)
-
-        return parse_version_tuple(latest) > parse_version_tuple(current)
+        return _parse_version_tuple(latest) > _parse_version_tuple(current)
     except Exception as e:
         logger.debug(f"Version comparison failed: {e}")
         return False

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+from .._vendor.httpclient import HTTPError, HttpTimeoutError
 from .._vendor.structlog import get_logger
 from ..fetch import Fetch
 from .search_result import SearchResult
@@ -100,6 +101,46 @@ class BaseSearch(ABC):
         Returns:
             List of SearchResult
         """
+
+    def _handle_http_error(
+        self,
+        error: HTTPError,
+        api_key: str,
+        provider_name: str,
+    ) -> bool:
+        """Handle an HTTPError with API key failover logic.
+
+        Marks the key as failed for auth or rate-limit errors so the
+        caller can retry with the next available key.
+
+        Args:
+            error: The HTTP error to handle.
+            api_key: The API key that was used for the failed request.
+            provider_name: Provider name for log messages.
+
+        Returns:
+            ``True`` if the caller should retry with the next key,
+            ``False`` if the error is terminal.
+        """
+        status = error.status_code
+        if status in (401, 403):
+            self.api_key_parser.mark_key_failed(
+                api_key, f"HTTP {status}", ttl=3600.0
+            )
+            logger.warning(
+                f"{provider_name} API key auth failed (HTTP {status}), trying next key"
+            )
+            return True
+        if status == 429:
+            self.api_key_parser.mark_key_failed(
+                api_key, "rate limited", ttl=300.0
+            )
+            logger.warning(
+                f"{provider_name} API rate limit exceeded, trying next key"
+            )
+            return True
+        logger.error(f"{provider_name} API HTTP error {status}: {error.body}")
+        return False
 
     @staticmethod
     def _fetch_webpage_content(

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -124,20 +124,14 @@ class BaseSearch(ABC):
         """
         status = error.status_code
         if status in (401, 403):
-            self.api_key_parser.mark_key_failed(
-                api_key, f"HTTP {status}", ttl=3600.0
-            )
+            self.api_key_parser.mark_key_failed(api_key, f"HTTP {status}", ttl=3600.0)
             logger.warning(
                 f"{provider_name} API key auth failed (HTTP {status}), trying next key"
             )
             return True
         if status == 429:
-            self.api_key_parser.mark_key_failed(
-                api_key, "rate limited", ttl=300.0
-            )
-            logger.warning(
-                f"{provider_name} API rate limit exceeded, trying next key"
-            )
+            self.api_key_parser.mark_key_failed(api_key, "rate limited", ttl=300.0)
+            logger.warning(f"{provider_name} API rate limit exceeded, trying next key")
             return True
         logger.error(f"{provider_name} API HTTP error {status}: {error.body}")
         return False

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from .._vendor.httpclient import HTTPError, HttpTimeoutError
+from .._vendor.httpclient import HTTPError
 from .._vendor.structlog import get_logger
 from ..fetch import Fetch
 from .search_result import SearchResult

--- a/src/toolregistry_hub/websearch/websearch_brave.py
+++ b/src/toolregistry_hub/websearch/websearch_brave.py
@@ -113,6 +113,43 @@ class BraveSearch(BaseSearch):
 
         return results[:max_results] if results else []
 
+    def _build_params(self, query: str, **kwargs) -> dict:
+        """Build query parameters for the Brave Search API.
+
+        Args:
+            query: The search query string.
+            **kwargs: Additional parameters from the caller.
+
+        Returns:
+            Dict of query parameters ready for the request.
+        """
+        params = {
+            "q": query,
+            "count": kwargs.get("count", 20),
+            "offset": kwargs.get("offset", 0),
+        }
+
+        optional_params = [
+            "country",
+            "search_lang",
+            "safesearch",
+            "freshness",
+            "result_filter",
+        ]
+        for param in optional_params:
+            if param in kwargs and kwargs[param] is not None:
+                params[param] = kwargs[param]
+
+        if "safesearch" not in params:
+            params["safesearch"] = "moderate"
+
+        skip = {"count", "offset", "timeout", *optional_params}
+        for key, value in kwargs.items():
+            if key not in skip:
+                params[key] = value
+
+        return params
+
     def _search_impl(self, query: str, **kwargs) -> list[SearchResult]:
         """Perform the actual search using Brave Search API for a single query.
 
@@ -127,33 +164,7 @@ class BraveSearch(BaseSearch):
             logger.warning("Empty query provided")
             return []
 
-        params = {
-            "q": query,
-            "count": kwargs.get("count", 20),
-            "offset": kwargs.get("offset", 0),
-        }
-
-        # Add optional parameters
-        optional_params = [
-            "country",
-            "search_lang",
-            "safesearch",
-            "freshness",
-            "result_filter",
-        ]
-        for param in optional_params:
-            if param in kwargs and kwargs[param] is not None:
-                params[param] = kwargs[param]
-
-        # Set default safesearch if not provided
-        if "safesearch" not in params:
-            params["safesearch"] = "moderate"
-
-        # Add any additional kwargs
-        for key, value in kwargs.items():
-            if key not in ["count", "offset", "timeout"] + optional_params:
-                params[key] = value
-
+        params = self._build_params(query, **kwargs)
         timeout = kwargs.get("timeout", TIMEOUT_DEFAULT)
         max_attempts = max(self.api_key_parser.key_count, 1)
 
@@ -187,22 +198,8 @@ class BraveSearch(BaseSearch):
                 logger.error(f"Brave API request timed out after {timeout}s")
                 return []
             except HTTPError as e:
-                status = e.status_code
-                if status in (401, 403):
-                    self.api_key_parser.mark_key_failed(
-                        api_key, f"HTTP {status}", ttl=3600.0
-                    )
-                    logger.warning(
-                        f"Brave API key auth failed (HTTP {status}), trying next key"
-                    )
+                if self._handle_http_error(e, api_key, "Brave"):
                     continue
-                if status == 429:
-                    self.api_key_parser.mark_key_failed(
-                        api_key, "rate limited", ttl=300.0
-                    )
-                    logger.warning("Brave API rate limit exceeded, trying next key")
-                    continue
-                logger.error(f"Brave API HTTP error {status}: {e.body}")
                 return []
             except Exception as e:
                 logger.error(f"Brave API request failed: {e}")

--- a/src/toolregistry_hub/websearch/websearch_brightdata.py
+++ b/src/toolregistry_hub/websearch/websearch_brightdata.py
@@ -264,29 +264,13 @@ class BrightDataSearch(BaseSearch):
                 logger.error(f"Bright Data API request timed out after {timeout}s")
                 return []
             except HTTPError as e:
-                status = e.status_code
-                if status in (401, 403):
-                    self.api_key_parser.mark_key_failed(
-                        api_key, f"HTTP {status}", ttl=3600.0
-                    )
-                    logger.warning(
-                        f"Bright Data API key auth failed (HTTP {status}), trying next key"
-                    )
-                    continue
-                if status == 429:
-                    self.api_key_parser.mark_key_failed(
-                        api_key, "rate limited", ttl=300.0
-                    )
-                    logger.warning(
-                        "Bright Data API rate limit exceeded, trying next key"
-                    )
-                    continue
-                if status == 422:
+                if e.status_code == 422:
                     logger.error(
                         f"Zone '{self.zone}' does not exist. Check your BRIGHTDATA_ZONE configuration"
                     )
                     return []
-                logger.error(f"Bright Data API HTTP error {status}: {e.body}")
+                if self._handle_http_error(e, api_key, "Bright Data"):
+                    continue
                 return []
             except json.JSONDecodeError as e:
                 logger.error(f"Failed to parse Bright Data API response: {e}")

--- a/src/toolregistry_hub/websearch/websearch_serper.py
+++ b/src/toolregistry_hub/websearch/websearch_serper.py
@@ -139,6 +139,34 @@ class SerperSearch(BaseSearch):
 
         return results[:max_results] if results else []
 
+    def _build_payload(self, query: str, **kwargs) -> dict:
+        """Build request payload for the Serper API.
+
+        Args:
+            query: The search query string.
+            **kwargs: Additional parameters from the caller.
+
+        Returns:
+            Dict payload ready for the POST request.
+        """
+        payload: dict[str, Any] = {"q": query}
+
+        num = kwargs.get("num")
+        if num is not None:
+            payload["num"] = num
+
+        optional_params = ["gl", "hl", "location", "autocorrect", "page"]
+        for param in optional_params:
+            if param in kwargs and kwargs[param] is not None:
+                payload[param] = kwargs[param]
+
+        handled = {"num", "timeout", *optional_params}
+        for key, value in kwargs.items():
+            if key not in handled:
+                payload[key] = value
+
+        return payload
+
     def _search_impl(self, query: str, **kwargs) -> list[SearchResult]:
         """Perform the actual search using Serper API for a single request.
 
@@ -153,25 +181,7 @@ class SerperSearch(BaseSearch):
             logger.warning("Empty query provided")
             return []
 
-        payload: dict[str, Any] = {"q": query}
-
-        # Add num parameter
-        num = kwargs.get("num")
-        if num is not None:
-            payload["num"] = num
-
-        # Add optional parameters
-        optional_params = ["gl", "hl", "location", "autocorrect", "page"]
-        for param in optional_params:
-            if param in kwargs and kwargs[param] is not None:
-                payload[param] = kwargs[param]
-
-        # Add any additional kwargs not already handled
-        handled = {"num", "timeout"} | set(optional_params)
-        for key, value in kwargs.items():
-            if key not in handled:
-                payload[key] = value
-
+        payload = self._build_payload(query, **kwargs)
         timeout = kwargs.get("timeout", TIMEOUT_DEFAULT)
 
         max_attempts = max(self.api_key_parser.key_count, 1)
@@ -206,22 +216,8 @@ class SerperSearch(BaseSearch):
                 logger.error(f"Serper API request timed out after {timeout}s")
                 return []
             except HTTPError as e:
-                status = e.status_code
-                if status in (401, 403):
-                    self.api_key_parser.mark_key_failed(
-                        api_key, f"HTTP {status}", ttl=3600.0
-                    )
-                    logger.warning(
-                        f"Serper API key auth failed (HTTP {status}), trying next key"
-                    )
+                if self._handle_http_error(e, api_key, "Serper"):
                     continue
-                if status == 429:
-                    self.api_key_parser.mark_key_failed(
-                        api_key, "rate limited", ttl=300.0
-                    )
-                    logger.warning("Serper API rate limit exceeded, trying next key")
-                    continue
-                logger.error(f"Serper API HTTP error {status}: {e.body}")
                 return []
             except json.JSONDecodeError as e:
                 logger.error(f"Failed to parse Serper API response: {e}")

--- a/src/toolregistry_hub/websearch/websearch_tavily.py
+++ b/src/toolregistry_hub/websearch/websearch_tavily.py
@@ -172,22 +172,8 @@ class TavilySearch(BaseSearch):
                 logger.error(f"Tavily API request timed out after {timeout}s")
                 return []
             except HTTPError as e:
-                status = e.status_code
-                if status in (401, 403):
-                    self.api_key_parser.mark_key_failed(
-                        api_key, f"HTTP {status}", ttl=3600.0
-                    )
-                    logger.warning(
-                        f"Tavily API key auth failed (HTTP {status}), trying next key"
-                    )
+                if self._handle_http_error(e, api_key, "Tavily"):
                     continue
-                if status == 429:
-                    self.api_key_parser.mark_key_failed(
-                        api_key, "rate limited", ttl=300.0
-                    )
-                    logger.warning("Tavily API rate limit exceeded, trying next key")
-                    continue
-                logger.error(f"Tavily API HTTP error {status}: {e.body}")
                 return []
             except Exception as e:
                 logger.error(f"Tavily API request failed: {e}")


### PR DESCRIPTION
## Summary
- Add `complexipy>=5.2.0` to dev dependencies
- Configure `[tool.complexipy]` in `pyproject.toml` with threshold 15, excluding `_vendor/`
- Add `.complexipy_cache/` to `.gitignore`

Configuration matches `llm-rosetta` project conventions.

## Current status

16 non-vendor functions exceed the threshold (complexity 16–33), mostly in websearch `_search_impl` methods and `websearch_legacy/`. These can be addressed as follow-up refactoring.

## Test plan
- [x] `complexipy src/ -e "src/toolregistry_hub/_vendor"` runs and reports results
- [x] Vendor modules are excluded from analysis