### PR TITLE
feat: add --profile flag for deployment context filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,15 +55,15 @@ reader_plus = [
     "pdfplumber>=0.10.0",
 ]
 server_core = [
-    "toolregistry-server>=0.2.0",
+    "toolregistry-server>=0.2.2",
 ]
 server_openapi = [
     "toolregistry-hub[server_core]",
-    "toolregistry-server[openapi]>=0.2.0",
+    "toolregistry-server[openapi]>=0.2.2",
 ]
 server_mcp = [
     "toolregistry-hub[server_core]",
-    "toolregistry-server[mcp]>=0.2.0",
+    "toolregistry-server[mcp]>=0.2.2",
 ]
 server = [
     "toolregistry-hub[server_openapi]",

--- a/src/toolregistry_hub/server/cli.py
+++ b/src/toolregistry_hub/server/cli.py
@@ -210,6 +210,19 @@ def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
         default=True,
         help="Enable/disable think-augmented function calling (default: enabled)",
     )
+    parser.add_argument(
+        "--profile",
+        type=str,
+        choices=["remote", "local"],
+        default=None,
+        help=(
+            "Deployment profile filter. "
+            "'remote': disable filesystem/shell/cron tools (they access the server's "
+            "own filesystem, not the user's). "
+            "'local': keep only filesystem/shell/cron tools, disable network tools. "
+            "Default: no filter, all tools enabled."
+        ),
+    )
 
 
 def _add_openapi_arguments(parser: argparse.ArgumentParser) -> None:
@@ -337,6 +350,7 @@ def main(args: list[str] | None = None) -> NoReturn | None:
         tools_config_path=getattr(parsed, "config", None),
         enable_discovery=getattr(parsed, "tool_discovery", True),
         enable_think=getattr(parsed, "think_augment", True),
+        profile=getattr(parsed, "profile", None),
     )
 
     # Dispatch to appropriate command handler
@@ -387,12 +401,10 @@ def _run_openapi_server(
         port: Port to bind the server to.
         tokens_path: Path to tokens file for authentication.
         reload: Enable auto-reload for development.
+        admin_port: Port for the admin panel, or None to disable.
     """
     try:
-        import uvicorn
-        from toolregistry_server import RouteTable
-        from toolregistry_server.auth import BearerTokenAuth, create_bearer_dependency
-        from toolregistry_server.openapi import create_openapi_app
+        from toolregistry_server.cli.openapi import run_openapi_server
     except ImportError as e:
         logger.error(f"OpenAPI server dependencies not installed: {e}")
         logger.info("Installation options:")
@@ -400,61 +412,22 @@ def _run_openapi_server(
         logger.info("  Full server:  pip install toolregistry-hub[server]")
         sys.exit(1)
 
-    from .auth import get_valid_tokens
     from .registry import get_registry
-    from .routes.version import router as version_router
 
-    # Log server info
     logger.info("Server mode: OpenAPI")
 
-    # Get the hub registry
     registry = get_registry()
 
-    # Enable admin panel if requested
     if admin_port is not None:
         _enable_admin_panel(registry, admin_port)
 
-    # Create route table from registry
-    route_table = RouteTable(registry)
-
-    # Setup authentication
-    valid_tokens = get_valid_tokens(tokens_path)
-    dependencies = None
-
-    if valid_tokens:
-        auth = BearerTokenAuth(tokens=list(valid_tokens))
-        dependency = create_bearer_dependency(auth)
-        from fastapi import Depends
-
-        dependencies = [Depends(dependency)]
-        logger.info("Token authentication enabled for OpenAPI server")
-    else:
-        logger.info(
-            "No tokens configured - OpenAPI server running without authentication"
-        )
-
-    # Create the OpenAPI app using toolregistry-server
-    app = create_openapi_app(
-        route_table,
-        title="ToolRegistry-Hub Server",
-        version=__version__,
-        description="A server for accessing various tools like calculators, "
-        "unit converters, and web search engines.",
-        dependencies=dependencies,
+    run_openapi_server(
+        host=host,
+        port=port,
+        tokens_path=tokens_path,
+        reload=reload,
+        registry=registry,
     )
-
-    # Add hub-specific routes (version endpoint)
-    app.include_router(version_router)
-    logger.info("Included version router at /version")
-
-    logger.info("OpenAPI app initialized with toolregistry-server")
-    logger.info(f"Registered {len(route_table.list_routes())} tool(s)")
-
-    # Run the server
-    if reload:
-        logger.warning("Reload mode is not fully supported with dynamic configuration")
-
-    uvicorn.run(app, host=host, port=port, reload=reload)
 
 
 def _run_mcp_server(
@@ -466,15 +439,10 @@ def _run_mcp_server(
         host: Host to bind the server to.
         port: Port to bind the server to.
         transport: MCP transport type ('stdio', 'sse', or 'streamable-http').
+        admin_port: Port for the admin panel, or None to disable.
     """
     try:
-        from toolregistry_server import RouteTable
-        from toolregistry_server.mcp import (
-            create_mcp_server,
-            run_sse,
-            run_stdio,
-            run_streamable_http,
-        )
+        from toolregistry_server.cli.mcp import run_mcp_server
     except ImportError as e:
         logger.error(f"MCP server dependencies not installed: {e}")
         logger.info("Installation options:")
@@ -486,38 +454,21 @@ def _run_mcp_server(
         )
         sys.exit(1)
 
-    import asyncio
-
     from .registry import get_registry
 
-    # Log server info
     logger.info(f"Server mode: MCP (transport: {transport})")
 
-    # Get the hub registry
     registry = get_registry()
 
-    # Enable admin panel if requested
     if admin_port is not None:
         _enable_admin_panel(registry, admin_port)
 
-    # Create route table from registry
-    route_table = RouteTable(registry)
-
-    # Create MCP server using toolregistry-server
-    mcp_server = create_mcp_server(route_table, name="ToolRegistry-Hub")
-
-    logger.info("MCP server initialized with toolregistry-server")
-    logger.info(f"Registered {len(route_table.list_routes())} tool(s)")
-
-    # Run the appropriate transport
-    if transport == "stdio":
-        asyncio.run(run_stdio(mcp_server))
-    elif transport == "sse":
-        logger.info(f"SSE endpoint: http://{host}:{port}/sse")
-        asyncio.run(run_sse(mcp_server, host=host, port=port))
-    else:  # streamable-http
-        logger.info(f"HTTP endpoint: http://{host}:{port}/mcp")
-        asyncio.run(run_streamable_http(mcp_server, host=host, port=port))
+    run_mcp_server(
+        transport=transport,
+        host=host,
+        port=port,
+        registry=registry,
+    )
 
 
 if __name__ == "__main__":

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -76,6 +76,13 @@ _HIDDEN_METHODS: set[str] = set()
 
 # Metadata overrides for registered tools, keyed by namespace.
 # Sets ToolTag and defer flags after register_from_class().
+# Tags that identify tools as "local-only" — they access the server's own
+# filesystem or process space, so they have no value when the server is
+# deployed remotely (they'd touch the server's fs, not the user's machine).
+_LOCAL_ONLY_TAGS: frozenset[ToolTag] = frozenset(
+    {ToolTag.FILE_SYSTEM, ToolTag.DESTRUCTIVE, ToolTag.PRIVILEGED}
+)
+
 _TOOL_METADATA: dict[str, dict] = {
     # Core tools (always visible in initial schema)
     "calculator": {"tags": {ToolTag.READ_ONLY}},
@@ -119,6 +126,33 @@ _TOOL_METADATA: dict[str, dict] = {
     "todolist": {"defer": True, "tags": {ToolTag.READ_ONLY}},
     "unit_converter": {"defer": True, "tags": {ToolTag.READ_ONLY}},
 }
+
+
+def _apply_profile_filter(registry: ToolRegistry, profile: str) -> None:
+    """Disable tools that do not match the deployment profile.
+
+    Tools tagged with :attr:`~toolregistry.tool.ToolTag.FILE_SYSTEM`,
+    :attr:`~toolregistry.tool.ToolTag.DESTRUCTIVE`, or
+    :attr:`~toolregistry.tool.ToolTag.PRIVILEGED` are considered
+    *local-only*: they access the server's own filesystem or process space
+    and have no practical value when the server runs on a remote machine.
+
+    Args:
+        registry: The registry to filter in-place.
+        profile: ``"remote"`` disables local-only tools; ``"local"`` disables
+            all other tools (keeps only local-only ones).
+    """
+    for tool_name, tool in registry._tools.items():
+        tags: set[ToolTag] = tool.metadata.tags or set()
+        is_local_tool = bool(tags & _LOCAL_ONLY_TAGS)
+        if (
+            profile == "remote"
+            and is_local_tool
+            or profile == "local"
+            and not is_local_tool
+        ):
+            registry.disable(tool_name, reason=f"Not available in '{profile}' profile")
+    logger.info(f"Applied profile filter: profile={profile}")
 
 
 def _apply_tool_metadata(registry: ToolRegistry) -> None:
@@ -245,6 +279,7 @@ def build_registry(
     tools_config_path: str | None = None,
     enable_discovery: bool = True,
     enable_think: bool = True,
+    profile: str | None = None,
 ) -> ToolRegistry:
     """Build the hub tool registry with all tools registered and auto-disabled
     based on instance configuration state.
@@ -262,6 +297,10 @@ def build_registry(
         enable_think: Enable think-augmented function calling.
             When ``True``, injects a ``thought`` property into tool schemas
             for chain-of-thought reasoning.
+        profile: Optional deployment profile filter. ``"remote"`` disables
+            tools that only make sense on the local machine (filesystem,
+            shell, cron). ``"local"`` disables network-only tools and keeps
+            only local-machine tools. ``None`` applies no filter.
 
     Returns:
         A fully configured ToolRegistry instance with all tools registered.
@@ -300,6 +339,10 @@ def build_registry(
 
     # Apply metadata (tags, defer flags) to registered tools
     _apply_tool_metadata(registry)
+
+    # Apply deployment profile filter (after metadata so tags are set)
+    if profile is not None:
+        _apply_profile_filter(registry, profile)
 
     # Enable tool discovery (registers discover_tools, indexes all tools)
     if enable_discovery:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -369,6 +369,119 @@ class TestToolMetadataAndDiscovery(unittest.TestCase):
         self.assertFalse(reg._think_augment)
 
 
+class TestBuildRegistryProfile(unittest.TestCase):
+    """Test deployment profile filter in build_registry()."""
+
+    def _enabled_namespaces(self, reg):
+        return {
+            tool.namespace
+            for name, tool in reg._tools.items()
+            if reg.is_enabled(name) and tool.namespace
+        }
+
+    def _disabled_namespaces(self, reg):
+        return {
+            tool.namespace
+            for name, tool in reg._tools.items()
+            if not reg.is_enabled(name) and tool.namespace
+        }
+
+    def test_remote_profile_disables_local_tools(self):
+        """Test that remote profile disables filesystem/shell/cron tools."""
+        reg = build_registry(enable_discovery=False, profile="remote")
+        disabled = self._disabled_namespaces(reg)
+        local_namespaces = (
+            "file_ops",
+            "bash",
+            "cron",
+            "reader",
+            "fs/file_search",
+            "fs/path_info",
+        )
+        for ns in local_namespaces:
+            self.assertIn(
+                ns,
+                disabled,
+                f"'{ns}' should be disabled in remote profile",
+            )
+
+    def test_remote_profile_keeps_network_and_compute_tools(self):
+        """Test that remote profile keeps calculator, datetime, web/fetch, think."""
+        reg = build_registry(enable_discovery=False, profile="remote")
+        enabled = self._enabled_namespaces(reg)
+        # These tools have no LOCAL_ONLY tags so remote profile must not disable them.
+        # (web/websearch may still be env-disabled, so we only assert the ones
+        # that never need API keys.)
+        always_remote_safe = ("calculator", "datetime", "think", "web/fetch")
+        for ns in always_remote_safe:
+            self.assertIn(
+                ns,
+                enabled,
+                f"'{ns}' should be enabled in remote profile",
+            )
+
+    def test_remote_profile_does_not_add_profile_reason_to_network_tools(self):
+        """Test that web/websearch (if disabled) is not disabled by profile filter."""
+        reg = build_registry(enable_discovery=False, profile="remote")
+        for name, tool in reg._tools.items():
+            if tool.namespace == "web/websearch":
+                reason = str(reg._disabled.get(name, ""))
+                self.assertNotIn(
+                    "profile",
+                    reason,
+                    "web/websearch should not be disabled by profile filter in remote mode",
+                )
+
+    def test_local_profile_disables_network_and_compute_tools(self):
+        """Test that local profile disables calculator, datetime, web tools."""
+        reg = build_registry(enable_discovery=False, profile="local")
+        disabled = self._disabled_namespaces(reg)
+        remote_namespaces = (
+            "calculator",
+            "datetime",
+            "think",
+            "web/fetch",
+            "web/websearch",
+            "todolist",
+            "unit_converter",
+        )
+        for ns in remote_namespaces:
+            self.assertIn(
+                ns,
+                disabled,
+                f"'{ns}' should be disabled in local profile",
+            )
+
+    def test_local_profile_does_not_add_profile_reason_to_local_tools(self):
+        """Test that local profile doesn't disable file_ops/bash via profile filter."""
+        reg = build_registry(enable_discovery=False, profile="local")
+        for name, tool in reg._tools.items():
+            if tool.namespace == "file_ops":
+                reason = reg._disabled.get(name, "")
+                self.assertNotIn(
+                    "profile",
+                    str(reason),
+                    f"'{name}' should not be disabled by profile filter in local mode",
+                )
+
+    def test_no_profile_no_additional_disables(self):
+        """Test that no profile means no profile-based disabling."""
+        reg_none = build_registry(enable_discovery=False, profile=None)
+        reg_remote = build_registry(enable_discovery=False, profile="remote")
+        # Without profile, at least as many tools are enabled as with remote
+        none_enabled = sum(1 for n in reg_none._tools if reg_none.is_enabled(n))
+        remote_enabled = sum(1 for n in reg_remote._tools if reg_remote.is_enabled(n))
+        self.assertGreaterEqual(none_enabled, remote_enabled)
+
+    def test_profile_reason_string(self):
+        """Test that disabled tools show the profile reason."""
+        reg = build_registry(enable_discovery=False, profile="remote")
+        for name, tool in reg._tools.items():
+            if tool.namespace == "bash":
+                reason = reg._disabled.get(name, "")
+                self.assertIn("remote", str(reason))
+
+
 class TestGetRegistry(unittest.TestCase):
     """Test cases for get_registry singleton function."""
 


### PR DESCRIPTION
## Summary

- Adds `--profile {remote,local}` to the hub CLI (available on both `openapi` and `mcp` subcommands)
- `remote`: disables tools tagged FILE_SYSTEM/DESTRUCTIVE/PRIVILEGED — they access the server's own filesystem, not the user's machine
- `local`: disables everything else, keeps only local-machine tools
- Default (no flag): no change in behaviour

Also refactors `_run_openapi_server()` / `_run_mcp_server()` in `cli.py` to delegate to `toolregistry-server`'s `run_openapi_server(registry=...)` / `run_mcp_server(registry=...)`, eliminating ~80 lines of duplicated startup logic. Requires toolregistry-server>=0.2.2 (closes #28 upstream).

## Test plan

- [ ] `pytest tests/test_registry.py` — 30 tests pass including new `TestBuildRegistryProfile`
- [ ] `pre-commit run --all-files` — ruff, ty, complexipy all pass
- [ ] Smoke: `toolregistry-hub openapi --profile remote` — file_ops/bash/cron absent from tool list
- [ ] Smoke: `toolregistry-hub openapi --profile local` — calculator/datetime/web tools absent
- [ ] Smoke: `toolregistry-hub openapi` (no flag) — all tools present as before