### PR TITLE
fix(file_ops): drop deprecated validate_path (#113)

### DIFF
--- a/src/toolregistry_hub/file_ops.py
+++ b/src/toolregistry_hub/file_ops.py
@@ -323,30 +323,3 @@ class FileOps:
             stacklevel=2,
         )
         return f"<<<<<<< HEAD\n{ours}\n=======\n{theirs}\n>>>>>>> incoming\n"
-
-    @staticmethod
-    def validate_path(path: str) -> dict[str, bool | str]:
-        """Validate file path safety (checks for empty paths, dangerous characters).
-
-        .. deprecated:: This utility method will be removed in a future release.
-
-        Args:
-            path: The path string to validate.
-
-        Returns:
-            Dictionary with keys:
-            - valid (bool): Path safety status
-            - message (str): Description if invalid
-        """
-        warnings.warn(
-            "FileOps.validate_path() is deprecated and will be removed.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if not path:
-            return {"valid": False, "message": "Empty path"}
-        if "~" in path:
-            path = os.path.expanduser(path)
-        if any(c in path for c in '*?"><|'):
-            return {"valid": False, "message": "Contains dangerous characters"}
-        return {"valid": True, "message": ""}

--- a/tests/test_file_ops.py
+++ b/tests/test_file_ops.py
@@ -99,33 +99,6 @@ class TestFileOps:
         assert ours in conflict
         assert theirs in conflict
 
-    def test_validate_path_valid(self):
-        """Test path validation with valid path."""
-        result = FileOps.validate_path("/valid/path/file.txt")
-        assert result["valid"] is True
-        assert result["message"] == ""
-
-    def test_validate_path_empty(self):
-        """Test path validation with empty path."""
-        result = FileOps.validate_path("")
-        assert result["valid"] is False
-        assert "Empty path" in str(result["message"])
-
-    def test_validate_path_dangerous_chars(self):
-        """Test path validation with dangerous characters."""
-        dangerous_paths = [
-            "/path/with*wildcard",
-            "/path/with?question",
-            "/path/with>redirect",
-            "/path/with<redirect",
-            "/path/with|pipe",
-        ]
-
-        for path in dangerous_paths:
-            result = FileOps.validate_path(path)
-            assert result["valid"] is False
-            assert "dangerous characters" in str(result["message"])
-
     def test_search_files(self):
         """Test searching files with regex."""
         # Create additional test files


### PR DESCRIPTION
## Summary

- Removes `FileOps.validate_path()` and the three associated tests.
- The method's name implies real path validation, but it only screened for empty strings and a handful of shell-glob characters. Over MCP it produced `{"valid": true}` for nonexistent absolute paths, which misled LLM clients using it as a pre-flight check.
- Already marked `@deprecated`; for real path checks use `fs/path_info-info`, which reports `exists` correctly.

Closes #113.

## Test plan

- [x] `pytest tests/test_file_ops.py` — 23 passed
- [x] `ruff check --fix` + `ruff format` clean
- [x] `ty check src/` — no new diagnostics related to file_ops