### PR TITLE
feat(help): make unit_converter/calculator help() fn_name optional (#120)

### DIFF
--- a/src/toolregistry_hub/calculator.py
+++ b/src/toolregistry_hub/calculator.py
@@ -302,18 +302,29 @@ class Calculator:
         return json.dumps(function_help)
 
     @staticmethod
-    def help(fn_name: str) -> str:
-        """Returns the help documentation for a specific function used in the evaluate method.
+    def help(fn_name: str | None = None) -> str:
+        """Returns help documentation for functions used in the evaluate method.
+
+        When ``fn_name`` is omitted, returns an overview document listing every
+        allowed function with its signature (when available) and one-line
+        description. When ``fn_name`` is provided, returns the detailed help
+        for that single function or constant.
 
         Args:
-            fn_name (str): Name of the function to get help for.
+            fn_name (str | None, optional): Name of the function to get help
+                for. If ``None`` (the default), an overview of all allowed
+                functions is returned instead.
 
         Returns:
-            str: Help documentation for the specified function.
+            str: Either the overview document for all allowed functions, or the
+                help documentation for the specified function/constant.
 
         Raises:
-            ValueError: If the function name is not recognized.
+            ValueError: If ``fn_name`` is provided but not recognized.
         """
+        if fn_name is None:
+            return Calculator._overview()
+
         # Check if the function is in Calculator or math
         if fn_name not in Calculator._allowed_functions() + [
             "evaluate",
@@ -343,6 +354,44 @@ class Calculator:
         else:
             docstring = f"Constant value: {target!r}"
             return f"constant: {fn_name}\n{textwrap.indent(docstring, ' ' * 4)}"
+
+    @staticmethod
+    def _overview() -> str:
+        """Builds an overview document of every allowed function/constant.
+
+        Each entry includes the function name with its signature (when
+        introspectable) and the first line of its docstring. Constants and
+        functions whose signatures cannot be retrieved are listed without a
+        signature.
+
+        Returns:
+            str: A human-readable overview listing all allowed functions.
+        """
+        names = Calculator._allowed_functions()
+        lines = [f"Available functions ({len(names)}):", ""]
+        for name in names:
+            if hasattr(BaseCalculator, name):
+                target = getattr(BaseCalculator, name)
+            elif hasattr(math, name):
+                target = getattr(math, name)
+            else:
+                continue
+
+            if callable(target):
+                try:
+                    signature = str(inspect.signature(target))
+                except (TypeError, ValueError):
+                    signature = "(...)"
+                header = f"  {name}{signature}"
+            else:
+                header = f"  {name} = {target!r}"
+
+            lines.append(header)
+            docstring = inspect.getdoc(target) or ""
+            first_line = docstring.strip().splitlines()[0] if docstring.strip() else ""
+            if first_line:
+                lines.append(f"      {first_line}")
+        return "\n".join(lines)
 
     @staticmethod
     def evaluate(expression: str) -> float | int | bool:

--- a/src/toolregistry_hub/unit_converter.py
+++ b/src/toolregistry_hub/unit_converter.py
@@ -379,18 +379,29 @@ class UnitConverter:
         return json.dumps(conversion_help)
 
     @staticmethod
-    def help(fn_name: str) -> str:
-        """Returns the help documentation for a specific conversion function.
+    def help(fn_name: str | None = None) -> str:
+        """Returns help documentation for conversion functions.
+
+        When ``fn_name`` is omitted, returns an overview document listing every
+        available conversion with its signature and one-line description. When
+        ``fn_name`` is provided, returns the detailed help for that single
+        function (signature plus full docstring).
 
         Args:
-            fn_name (str): Name of the conversion function to get help for.
+            fn_name (str | None, optional): Name of the conversion function to
+                get help for. If ``None`` (the default), an overview of all
+                available conversions is returned instead.
 
         Returns:
-            str: Help documentation for the specified function.
+            str: Either the overview document for all conversions, or the help
+                documentation for the specified function.
 
         Raises:
-            ValueError: If the function name is not recognized.
+            ValueError: If ``fn_name`` is provided but not recognized.
         """
+        if fn_name is None:
+            return UnitConverter._overview()
+
         if fn_name not in UnitConverter._all_conversions() + [
             "convert",
             "list_conversions",
@@ -411,6 +422,28 @@ class UnitConverter:
             )
         else:
             raise ValueError(f"'{fn_name}' is not a callable function.")
+
+    @staticmethod
+    def _overview() -> str:
+        """Builds an overview document of every available conversion.
+
+        Each entry includes the function name with its signature and the first
+        line of its docstring, indented for readability.
+
+        Returns:
+            str: A human-readable overview listing all conversion functions.
+        """
+        names = UnitConverter._all_conversions()
+        lines = [f"Available conversions ({len(names)}):", ""]
+        for name in names:
+            target = getattr(BaseUnitConverter, name)
+            signature = inspect.signature(target)
+            docstring = inspect.getdoc(target) or ""
+            first_line = docstring.strip().splitlines()[0] if docstring.strip() else ""
+            lines.append(f"  {name}{signature}")
+            if first_line:
+                lines.append(f"      {first_line}")
+        return "\n".join(lines)
 
     @staticmethod
     def convert(

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -262,6 +262,23 @@ class TestCalculator:
         ):
             Calculator.help("invalid_func")
 
+    def test_help_no_arg_returns_overview(self):
+        """Test that help() with no argument returns an overview of all allowed functions."""
+        overview = Calculator.help()
+        assert isinstance(overview, str)
+        assert overview.strip() != ""
+        assert "Available functions" in overview
+        # Should mention multiple known functions from BaseCalculator and math.
+        assert "add" in overview
+        assert "sqrt" in overview
+        assert "factorial" in overview
+        # First line of docstring should appear.
+        assert "Adds two numbers." in overview
+
+    def test_help_explicit_none_returns_overview(self):
+        """Test that help(None) is equivalent to help() with no argument."""
+        assert Calculator.help(None) == Calculator.help()
+
     def test_evaluate_basic_arithmetic(self):
         """Test evaluation of basic arithmetic expressions."""
         assert Calculator.evaluate("2 + 3") == 5

--- a/tests/test_unit_converter.py
+++ b/tests/test_unit_converter.py
@@ -371,6 +371,25 @@ class TestUnitConverter:
         with pytest.raises(ValueError, match="not recognized"):
             UnitConverter.help("invalid_function")
 
+    def test_help_no_arg_returns_overview(self):
+        """Test that help() with no argument returns an overview of all conversions."""
+        overview = UnitConverter.help()
+        assert isinstance(overview, str)
+        assert overview.strip() != ""
+        assert "Available conversions" in overview
+        # Should mention multiple known conversion functions.
+        assert "celsius_to_fahrenheit" in overview
+        assert "meters_to_feet" in overview
+        assert "kilograms_to_pounds" in overview
+        # Signature should appear next to the function name.
+        assert "celsius_to_fahrenheit(celsius: float)" in overview
+        # First line of docstring should appear.
+        assert "Convert Celsius to Fahrenheit." in overview
+
+    def test_help_explicit_none_returns_overview(self):
+        """Test that help(None) is equivalent to help() with no argument."""
+        assert UnitConverter.help(None) == UnitConverter.help()
+
     # Test round-trip conversions using convert method
     def test_temperature_round_trip(self):
         """Test round-trip temperature conversions."""


### PR DESCRIPTION
## Summary

- `unit_converter-help` and `calculator-help` now accept calls with no `fn_name`, returning an overview of all available functions (signature + first-line docstring).
- `help(fn_name=...)` continues to return per-function detail. Existing callers are unaffected.
- Matches Python's built-in `help()` behavior: zero-arg → overview, one-arg → focused.

Closes #120.

## Test plan

- [x] New tests in `tests/test_unit_converter.py` and `tests/test_calculator.py` cover no-arg and named-arg paths.
- [x] `pytest tests/test_unit_converter.py tests/test_calculator.py` clean.
- [x] `ruff check` + `ruff format` clean.