### PR TITLE
fix: align parameter and column names across tools (#118, #119)

### DIFF
--- a/src/toolregistry_hub/cron_tool.py
+++ b/src/toolregistry_hub/cron_tool.py
@@ -193,7 +193,7 @@ class CronTool:
             return "No scheduled jobs."
 
         lines = [
-            f"{'ID':<10} {'Cron':<20} {'Recurring':<10} {'Durable':<8} {'Next Fire':<25} Prompt"
+            f"{'Job ID':<10} {'Cron':<20} {'Recurring':<10} {'Durable':<8} {'Next Fire':<25} Prompt"
         ]
         lines.append("-" * 100)
 

--- a/src/toolregistry_hub/file_ops.py
+++ b/src/toolregistry_hub/file_ops.py
@@ -66,7 +66,7 @@ class FileOps:
 
     @staticmethod
     def edit(
-        file_path: str,
+        path: str,
         old_string: str,
         new_string: str,
         replace_all: bool = False,
@@ -75,7 +75,7 @@ class FileOps:
         """Replace exact string in file.
 
         Args:
-            file_path: Absolute path to file.
+            path: Absolute path to file.
             old_string: Exact text to find. Must not be empty.
             new_string: Replacement text (must differ from old_string).
             replace_all: Replace all occurrences instead of just one.
@@ -89,7 +89,7 @@ class FileOps:
         Raises:
             ValueError: If old_string is empty, identical to new_string,
                 not found, or ambiguous without start_line/replace_all.
-            FileNotFoundError: If file_path does not exist.
+            FileNotFoundError: If path does not exist.
         """
         if not old_string:
             raise ValueError("old_string must not be empty")
@@ -97,7 +97,7 @@ class FileOps:
             raise ValueError("old_string and new_string are identical")
 
         # Read file as bytes to preserve encoding
-        with open(file_path, "rb") as f:
+        with open(path, "rb") as f:
             raw = f.read()
 
         encoding, bom = FileOps._detect_encoding(raw)
@@ -159,10 +159,10 @@ class FileOps:
         encoded = bom + new_content.encode(encoding)
 
         # Atomic write (binary)
-        tmp_path = f"{file_path}.tmp"
+        tmp_path = f"{path}.tmp"
         with open(tmp_path, "wb") as f:
             f.write(encoded)
-        os.replace(tmp_path, file_path)
+        os.replace(tmp_path, path)
 
         return diff_output
 

--- a/tests/test_cron_tool.py
+++ b/tests/test_cron_tool.py
@@ -117,6 +117,14 @@ class TestList:
         assert "*/5 * * * *" in output
         assert "0 9 * * *" in output
 
+    def test_list_header_uses_job_id_label(self, cron_tool):
+        tool, _ = cron_tool
+        tool.create("*/5 * * * *", "job one")
+
+        output = tool.list()
+        # Header should say "Job ID" so LLM callers don't try cron-delete(id=...).
+        assert "Job ID" in output
+
     def test_list_after_delete(self, cron_tool):
         tool, _ = cron_tool
         tool.create("*/5 * * * *", "keep this")


### PR DESCRIPTION
## Summary

Two small consistency fixes under #114:

- **#118**: `cron-list` now labels its first column `Job ID` (was `ID`). The parameter on `cron-delete` is `job_id`, so the previous column label set LLM callers up to fail with `cron-delete(id=...)`.
- **#119**: rename `file_ops-edit`'s first parameter from `file_path` to `path`. Every other `file_ops-*` method (`read_file`, `write_file`, `append_file`, `search_files`) already uses `path`, as does the entire `reader-*` family. Standardising on `path` removes the cross-tool gotcha in the direction that requires the least churn.

Breaking change: callers using `file_ops-edit(file_path=...)` by keyword must switch to `path=`. Positional usage (`file_ops-edit("/tmp/x", ...)`) is unaffected.

Closes #118.
Closes #119.

## Test plan

- [x] New `test_list_header_uses_job_id_label` covers the column rename.
- [x] Existing `test_edit_*` suite passes after the param rename (all calls use positional).
- [x] `pytest tests/test_file_ops.py tests/test_cron_tool.py` — 43 + 17 passed.
- [x] `ruff check` + `ruff format` clean.
- [x] `ty check src/` — no new diagnostics.