### PR TITLE
fix(searxng): switch JSON API from GET to POST (#115)

### DIFF
--- a/src/toolregistry_hub/_vendor/httpclient.py
+++ b/src/toolregistry_hub/_vendor/httpclient.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.4.1"
+# version = "0.4.2"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -2230,7 +2230,8 @@ def _prepare_body(
 
     Priority: json > files > data.
     When files is provided and data is a dict, data fields are included
-    as text parts in the multipart body.
+    as text parts in the multipart body. When data is a dict without files,
+    it is URL-encoded as application/x-www-form-urlencoded.
 
     Returns:
         (body_bytes, content_type) tuple.
@@ -2240,6 +2241,8 @@ def _prepare_body(
     if files is not None:
         form_data = data if isinstance(data, dict) else None
         return _encode_multipart(form_data, files)
+    if isinstance(data, dict):
+        return urlencode(data).encode("utf-8"), "application/x-www-form-urlencoded"
     if isinstance(data, str):
         return data.encode("utf-8"), "application/x-www-form-urlencoded"
     if isinstance(data, bytes):

--- a/src/toolregistry_hub/websearch/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch/websearch_searxng.py
@@ -30,7 +30,6 @@ SearXNG Setup: https://docs.searxng.org/admin/installation.html
 """
 
 import os
-from urllib.parse import urlencode
 
 from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError
 from .._vendor.structlog import get_logger
@@ -181,7 +180,7 @@ class SearXNGSearch(BaseSearch):
                 response = client.post(
                     self.search_url,
                     headers=self._build_headers(),
-                    data=urlencode(params),
+                    data=params,
                 )
                 response.raise_for_status()
 


### PR DESCRIPTION
## Summary

- Switch SearXNG `_search_impl` from HTTP GET to POST for JSON API requests. Modern SearXNG instances with `limiter: true` (default since 2023.x) block GET requests for `format=json` via `Sec-Fetch-*` header checks; POST bypasses the limiter and matches the upstream-documented JSON API usage.
- Replace silent `return []` on HTTP errors with a typed `SearchBackendError`, so callers can distinguish "no results" from "backend rejected the request". The unified `WebSearch` auto-chain already catches generic `Exception` and falls through to the next engine.
- Update tests to match the new POST method and error behavior.

Fixes the SearXNG portion of #115. BrightData fix is deferred per discussion on that issue.

Companion docs commits on `docs_en` and `docs_zh` branches add instance configuration notes and changelog entries.

## Test plan

- [x] All 24 SearXNG unit tests pass (mocks updated for POST)
- [x] Full websearch test suite: 137 passed, 1 pre-existing BrightData failure (unrelated)
- [x] Smoke test against `https://search.oaklight.cn` returns real results via POST
- [x] Error path test: bogus URL correctly raises `SearchBackendError`
- [x] Unified `WebSearch` dispatches to SearXNG via `engine="searxng"` successfully
- [x] `ruff check` and `ruff format` clean
- [x] `ty check` clean (only pre-existing warnings)