### PR TITLE
feat(schema): bind_literal helper + enum schemas for convert/todo (#116, #117)

### DIFF
--- a/src/toolregistry_hub/todo_list.py
+++ b/src/toolregistry_hub/todo_list.py
@@ -107,6 +107,16 @@ class TodoList:
         lines.append(separator)
         return "\n".join(lines)
 
+    # Common LLM-side spellings normalized to one of the four canonical
+    # statuses. ``in_progress`` is by far the most common foreign value
+    # because it is the convention in Claude Code's TaskCreate/TaskUpdate
+    # and most third-party TODO tooling — see issue #116.
+    _STATUS_ALIASES = {
+        "in_progress": "pending",
+        "in-progress": "pending",
+        "inprogress": "pending",
+    }
+
     @staticmethod
     def _parse_simple_format(todo_str: str) -> dict:
         """Parse simple format string into todo dict.
@@ -123,7 +133,8 @@ class TodoList:
 
         Valid status values:
         - planned: Task is scheduled but not yet started
-        - pending: Task is currently being worked on (in progress)
+        - pending: Task is currently being worked on (in progress). Aliases:
+          ``in_progress``, ``in-progress``, ``inprogress``.
         - done: Task has been completed successfully
         - cancelled: Task has been cancelled or abandoned
         """
@@ -138,6 +149,10 @@ class TodoList:
             )
 
         id_part, content_part, status_part = match.groups()
+
+        # Apply alias normalization (e.g. in_progress -> pending) before
+        # validating, so foreign-but-recognized spellings just work.
+        status_part = TodoList._STATUS_ALIASES.get(status_part, status_part)
 
         # Validate status
         valid_statuses = ["planned", "pending", "done", "cancelled"]
@@ -160,6 +175,18 @@ class TodoList:
             todos: List of todo entries as "[id] content (status)" strings.
                 Example: ["[create-test] write a simple test case (planned)"]
                 Order matters - todos will be maintained in the input order.
+
+                ``status`` MUST be one of the closed set
+                ``planned | pending | done | cancelled``. The alias
+                ``in_progress`` (also ``in-progress`` / ``inprogress``) is
+                accepted and normalized to ``pending``; any other value is
+                rejected. Definitions:
+
+                - planned: scheduled but not yet started
+                - pending: currently in progress
+                - done: completed successfully
+                - cancelled: abandoned
+
             format: Output format - 'simple' (no output), 'markdown', or 'ascii'.
 
         Returns:

--- a/src/toolregistry_hub/unit_converter.py
+++ b/src/toolregistry_hub/unit_converter.py
@@ -3,7 +3,7 @@ import json
 import textwrap
 from typing import Literal
 
-from .utils import get_all_static_methods
+from .utils import bind_literal, get_all_static_methods
 
 
 class BaseUnitConverter:
@@ -499,3 +499,23 @@ class UnitConverter:
                 )
 
         return func(*args)
+
+
+# ============================================================================
+# Schema enum injection
+# ============================================================================
+# Rewrite ``UnitConverter.convert``'s ``conversion`` annotation so the
+# generated MCP / JSON schema lists every available conversion function as a
+# closed enum instead of a free-form string. This eliminates a discovery
+# round-trip for LLM callers (see issue #117).
+#
+# The list is derived from ``BaseUnitConverter``'s static methods at import
+# time, so it stays in sync with whatever conversions are actually defined.
+_conversion_names = tuple(get_all_static_methods(BaseUnitConverter))
+UnitConverter.convert = staticmethod(
+    bind_literal(
+        UnitConverter.convert,
+        "conversion",
+        _conversion_names,
+    )
+)

--- a/src/toolregistry_hub/utils/__init__.py
+++ b/src/toolregistry_hub/utils/__init__.py
@@ -1,3 +1,4 @@
+from .annotation_helpers import bind_literal
 from .api_key_parser import APIKeyParser
 from .configurable import Configurable
 from .fn_namespace import get_all_static_methods
@@ -6,6 +7,7 @@ from .requirements import requires_env
 __all__ = [
     "APIKeyParser",
     "Configurable",
+    "bind_literal",
     "get_all_static_methods",
     "requires_env",
 ]

--- a/src/toolregistry_hub/utils/annotation_helpers.py
+++ b/src/toolregistry_hub/utils/annotation_helpers.py
@@ -1,0 +1,100 @@
+"""Helpers for runtime manipulation of function type annotations.
+
+These utilities exist primarily to control how tool input schemas are
+generated for MCP / LLM clients. When a parameter's set of valid values is
+known only at runtime (e.g. the registry of unit-conversion function names,
+or the set of configured search engines), we want the JSON schema to expose
+those values as an ``enum`` instead of an unconstrained ``string``. The
+cleanest way to achieve that with the upstream ``toolregistry`` / pydantic
+stack is to rewrite the function's ``__annotations__`` so that the parameter
+is typed as ``Literal[...]``.
+"""
+
+from __future__ import annotations
+
+import types
+from collections.abc import Callable, Iterable
+from typing import Any, Literal
+
+
+def bind_literal(
+    func: types.FunctionType | Callable[..., Any],
+    param: str,
+    choices: Iterable[Any],
+    *,
+    instance: object | None = None,
+) -> Callable[..., Any]:
+    """Return a copy of ``func`` whose ``param`` annotation is ``Literal[*choices]``.
+
+    The original function is not modified; the returned callable has its own
+    ``__annotations__`` dict so further mutations are isolated.
+
+    Args:
+        func: The function (or unbound method) to copy. Must be a regular
+            Python function object — built-in callables and arbitrary
+            ``__call__`` objects are not supported because we need to inspect
+            their ``__code__`` / ``__globals__``.
+        param: Name of the parameter whose annotation should be replaced.
+        choices: Iterable of values to include in the ``Literal``. Must be
+            non-empty and contain hashable, ``Literal``-compatible values
+            (typically strings).
+        instance: When ``func`` is an unbound method and the caller wants the
+            result re-bound as a method, pass the owning instance here. The
+            returned object will then be a ``types.MethodType`` bound to
+            ``instance``. When ``None`` (default), a plain function is
+            returned.
+
+    Returns:
+        A new function (or bound method, if ``instance`` is given) whose
+        ``__annotations__[param]`` is set to a fresh ``Literal`` built from
+        ``choices``.
+
+    Raises:
+        TypeError: If ``func`` is not a regular Python function.
+        ValueError: If ``choices`` is empty, or if ``param`` is not present
+            in the function's annotations.
+
+    Example:
+        >>> def search(engine: str = "auto") -> None: ...
+        >>> narrowed = bind_literal(search, "engine", ["auto", "brave", "tavily"])
+        >>> narrowed.__annotations__["engine"]
+        typing.Literal['auto', 'brave', 'tavily']
+    """
+    choice_tuple = tuple(choices)
+    if not choice_tuple:
+        raise ValueError("choices must be non-empty")
+
+    # ``func`` must be a regular function object so we can reach its code /
+    # globals; narrow the static type here so attribute lookups below resolve.
+    if not isinstance(func, types.FunctionType):
+        raise TypeError(
+            f"bind_literal requires a Python function, got {type(func).__name__}"
+        )
+
+    original_annotations = dict(func.__annotations__ or {})
+    if param not in original_annotations:
+        raise ValueError(
+            f"Parameter {param!r} is not annotated on {func.__qualname__}; "
+            f"available annotated params: {sorted(original_annotations)}"
+        )
+
+    new_func = types.FunctionType(
+        func.__code__,
+        func.__globals__,
+        name=func.__name__,
+        argdefs=func.__defaults__,
+        closure=func.__closure__,
+    )
+    new_func.__doc__ = func.__doc__
+    new_func.__qualname__ = func.__qualname__
+    new_func.__module__ = func.__module__
+    new_func.__kwdefaults__ = func.__kwdefaults__
+    new_func.__annotations__ = original_annotations
+    # ``Literal[...]`` requires subscripting with either a single value or a
+    # tuple, so dispatch through ``__getitem__`` directly to accept the
+    # runtime-built tuple.
+    new_func.__annotations__[param] = Literal.__getitem__(choice_tuple)
+
+    if instance is not None:
+        return types.MethodType(new_func, instance)
+    return new_func

--- a/src/toolregistry_hub/websearch/__init__.py
+++ b/src/toolregistry_hub/websearch/__init__.py
@@ -1,3 +1,4 @@
+from .base import SearchBackendError
 from .search_result import SearchResult
 from .websearch_brave import BraveSearch
 from .websearch_brightdata import BrightDataSearch
@@ -11,6 +12,7 @@ __all__ = [
     "BraveSearch",
     "BrightDataSearch",
     "ScrapelessSearch",
+    "SearchBackendError",
     "SearchResult",
     "SearXNGSearch",
     "SerperSearch",

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -14,6 +14,15 @@ _UNABLE_TO_FETCH_TITLE = "Unable to fetch title"
 TIMEOUT_DEFAULT = 10.0
 
 
+class SearchBackendError(Exception):
+    """Raised when a search backend returns an error instead of results.
+
+    This replaces the previous pattern of silently returning ``[]`` on
+    HTTP errors, which made it impossible for callers to distinguish
+    "no results" from "backend rejected the request".
+    """
+
+
 class BaseSearch(ABC):
     def _is_configured(self) -> bool:
         """Check if the search engine has valid configuration.

--- a/src/toolregistry_hub/websearch/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch/websearch_searxng.py
@@ -30,11 +30,12 @@ SearXNG Setup: https://docs.searxng.org/admin/installation.html
 """
 
 import os
+from urllib.parse import urlencode
 
 from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError
 from .._vendor.structlog import get_logger
 from ..utils.requirements import requires_env
-from .base import TIMEOUT_DEFAULT, BaseSearch
+from .base import TIMEOUT_DEFAULT, BaseSearch, SearchBackendError
 from .search_result import SearchResult
 
 logger = get_logger()
@@ -177,8 +178,10 @@ class SearXNGSearch(BaseSearch):
         assert self.search_url is not None  # validated in search()
         try:
             with Client(timeout=timeout) as client:
-                response = client.get(
-                    self.search_url, headers=self._build_headers(), params=params
+                response = client.post(
+                    self.search_url,
+                    headers=self._build_headers(),
+                    data=urlencode(params),
                 )
                 response.raise_for_status()
 
@@ -194,11 +197,15 @@ class SearXNGSearch(BaseSearch):
             logger.error(f"SearXNG API request timed out after {timeout}s")
             return []
         except HTTPError as e:
-            logger.error(f"SearXNG API HTTP error {e.status_code}: {e.body}")
-            return []
+            raise SearchBackendError(
+                f"SearXNG instance {self.base_url} returned HTTP {e.status_code}: "
+                f"{str(e.body)[:200]}. The instance may not enable JSON format, "
+                "may require POST, or may require an X-API-Key."
+            ) from e
         except Exception as e:
-            logger.error(f"SearXNG API request failed: {e}")
-            return []
+            raise SearchBackendError(
+                f"SearXNG API request to {self.base_url} failed: {e}"
+            ) from e
 
     def _parse_results(self, raw_results: dict) -> list[SearchResult]:
         """Parse SearXNG API response into standardized format.

--- a/tests/test_annotation_helpers.py
+++ b/tests/test_annotation_helpers.py
@@ -1,0 +1,67 @@
+"""Tests for ``toolregistry_hub.utils.annotation_helpers``."""
+
+from __future__ import annotations
+
+from typing import Literal, get_type_hints
+
+import pytest
+
+from toolregistry_hub.utils import bind_literal
+
+
+def _example(engine: str = "auto", count: int = 1) -> str:
+    """Example function with a string parameter that should be narrowed."""
+    return f"{engine}:{count}"
+
+
+class TestBindLiteral:
+    def test_replaces_annotation_with_literal(self):
+        narrowed = bind_literal(_example, "engine", ["auto", "brave", "tavily"])
+        # The new function's raw annotation should be a Literal of the choices.
+        ann = narrowed.__annotations__["engine"]
+        assert ann == Literal["auto", "brave", "tavily"]
+
+    def test_get_type_hints_sees_literal(self):
+        """``get_type_hints`` is what pydantic / toolregistry use for schema."""
+        narrowed = bind_literal(_example, "engine", ("auto", "brave"))
+        hints = get_type_hints(narrowed)
+        assert hints["engine"] == Literal["auto", "brave"]
+
+    def test_original_function_untouched(self):
+        original_ann = dict(_example.__annotations__)
+        bind_literal(_example, "engine", ["auto"])
+        assert _example.__annotations__ == original_ann
+
+    def test_call_still_works(self):
+        narrowed = bind_literal(_example, "engine", ["auto", "x"])
+        # Runtime call semantics are unchanged; Literal is a static-only hint.
+        assert narrowed("x", 2) == "x:2"
+
+    def test_preserves_other_annotations_and_defaults(self):
+        narrowed = bind_literal(_example, "engine", ["auto"])
+        hints = get_type_hints(narrowed)
+        assert hints["count"] is int
+        assert narrowed() == "auto:1"  # defaults still intact
+
+    def test_empty_choices_rejected(self):
+        with pytest.raises(ValueError, match="choices must be non-empty"):
+            bind_literal(_example, "engine", [])
+
+    def test_unknown_param_rejected(self):
+        with pytest.raises(ValueError, match="not annotated"):
+            bind_literal(_example, "nonexistent", ["a"])
+
+    def test_non_function_rejected(self):
+        with pytest.raises(TypeError, match="requires a Python function"):
+            bind_literal(len, "x", ["a"])  # type: ignore[arg-type]
+
+    def test_instance_kwarg_returns_bound_method(self):
+        class Holder:
+            def search(self, engine: str = "auto") -> str:
+                return f"{type(self).__name__}:{engine}"
+
+        h = Holder()
+        bound = bind_literal(Holder.search, "engine", ["auto", "x"], instance=h)
+        # When instance is given, we get a bound method
+        assert bound.__self__ is h  # type: ignore[attr-defined]
+        assert bound("x") == "Holder:x"

--- a/tests/test_todo_list_status_alias.py
+++ b/tests/test_todo_list_status_alias.py
@@ -1,0 +1,31 @@
+"""Tests for status aliasing in ``TodoList`` (issue #116)."""
+
+from __future__ import annotations
+
+import pytest
+
+from toolregistry_hub.todo_list import TodoList
+
+
+class TestInProgressAlias:
+    def test_in_progress_accepted_as_pending(self):
+        # The user-facing string format passes through unchanged on simple
+        # output, but the parsed row should report the canonical status.
+        result = TodoList.update(["[task1] do thing (in_progress)"], format="markdown")
+        assert "pending" in (result or "")
+        assert "in_progress" not in (result or "")
+
+    @pytest.mark.parametrize("alias", ["in_progress", "in-progress", "inprogress"])
+    def test_aliases_normalize_to_pending(self, alias):
+        parsed = TodoList._parse_simple_format(f"[t] task ({alias})")
+        assert parsed["status"] == "pending"
+
+    def test_unknown_status_still_rejected(self):
+        with pytest.raises(ValueError, match="Invalid status"):
+            TodoList.update(["[t] thing (working)"], format="simple")
+
+    def test_existing_canonical_statuses_unchanged(self):
+        # Regression guard: the four canonical names must keep working.
+        for status in ("planned", "pending", "done", "cancelled"):
+            parsed = TodoList._parse_simple_format(f"[t] task ({status})")
+            assert parsed["status"] == status

--- a/tests/test_unit_converter_schema.py
+++ b/tests/test_unit_converter_schema.py
@@ -1,0 +1,45 @@
+"""Tests that ``UnitConverter.convert`` exposes its ``conversion`` parameter
+as a closed ``Literal`` so MCP / JSON schema callers see an ``enum``.
+
+Covers issue #117.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, get_args, get_origin, get_type_hints
+
+import pytest
+
+from toolregistry_hub.unit_converter import BaseUnitConverter, UnitConverter
+from toolregistry_hub.utils import get_all_static_methods
+
+
+class TestConvertEnumSchema:
+    def test_conversion_param_is_literal(self):
+        hints = get_type_hints(UnitConverter.convert)
+        annotation = hints["conversion"]
+        assert get_origin(annotation) is Literal
+
+    def test_literal_lists_every_conversion(self):
+        hints = get_type_hints(UnitConverter.convert)
+        choices = set(get_args(hints["conversion"]))
+        expected = set(get_all_static_methods(BaseUnitConverter))
+        assert choices == expected
+        # Spot-check a few well-known entries to guard against regressions
+        # in get_all_static_methods.
+        for name in (
+            "celsius_to_fahrenheit",
+            "kilograms_to_pounds",
+            "meters_to_feet",
+        ):
+            assert name in choices
+
+    def test_runtime_call_still_works(self):
+        # Literal narrowing is a schema-only concern; runtime behavior is
+        # unaffected.
+        result = UnitConverter.convert(100, "celsius_to_fahrenheit")
+        assert result == 212.0
+
+    def test_invalid_name_still_raises(self):
+        with pytest.raises(ValueError, match="not recognized"):
+            UnitConverter.convert(1.0, "kg_to_lb")

--- a/tests/websearch/test_websearch_searxng.py
+++ b/tests/websearch/test_websearch_searxng.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from toolregistry_hub._vendor.httpclient import HTTPError, HttpTimeoutError
+from toolregistry_hub.websearch.base import SearchBackendError
 from toolregistry_hub.websearch.search_result import SearchResult
 from toolregistry_hub.websearch.websearch_searxng import SearXNGSearch
 
@@ -121,7 +124,7 @@ class TestSearXNGSearch:
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.__exit__.return_value = None
-        mock_client_instance.get.return_value = mock_response
+        mock_client_instance.post.return_value = mock_response
         mock_client.return_value = mock_client_instance
 
         searcher = SearXNGSearch("http://localhost:8080")
@@ -147,7 +150,7 @@ class TestSearXNGSearch:
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.__exit__.return_value = None
-        mock_client_instance.get.side_effect = HttpTimeoutError("Timeout")
+        mock_client_instance.post.side_effect = HttpTimeoutError("Timeout")
         mock_client.return_value = mock_client_instance
 
         searcher = SearXNGSearch("http://localhost:8080")
@@ -157,7 +160,7 @@ class TestSearXNGSearch:
 
     @patch("toolregistry_hub.websearch.websearch_searxng.Client")
     def test_search_http_error(self, mock_client):
-        """Test search with HTTP error."""
+        """Test search with HTTP error raises SearchBackendError."""
         mock_response = MagicMock()
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
@@ -165,15 +168,14 @@ class TestSearXNGSearch:
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.__exit__.return_value = None
-        mock_client_instance.get.side_effect = HTTPError(
+        mock_client_instance.post.side_effect = HTTPError(
             500, "Internal Server Error", "http://localhost:8080/search"
         )
         mock_client.return_value = mock_client_instance
 
         searcher = SearXNGSearch("http://localhost:8080")
-        results = searcher.search("test query")
-
-        assert results == []
+        with pytest.raises(SearchBackendError, match="HTTP 500"):
+            searcher.search("test query")
 
     @patch("toolregistry_hub.websearch.websearch_searxng.Client")
     def test_search_max_results_cap(self, mock_client):
@@ -185,7 +187,7 @@ class TestSearXNGSearch:
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.__exit__.return_value = None
-        mock_client_instance.get.return_value = mock_response
+        mock_client_instance.post.return_value = mock_response
         mock_client.return_value = mock_client_instance
 
         searcher = SearXNGSearch("http://localhost:8080")
@@ -272,12 +274,12 @@ class TestSearXNGSearchIntegration:
             mock_client_instance = MagicMock()
             mock_client_instance.__enter__.return_value = mock_client_instance
             mock_client_instance.__exit__.return_value = None
-            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.post.return_value = mock_response
             mock_client.return_value = mock_client_instance
 
             searcher.search(query="test", max_results=5, timeout=10)
 
-            assert mock_client_instance.get.called
+            assert mock_client_instance.post.called
 
     def test_url_normalization(self):
         """Test that base URL is properly normalized."""
@@ -318,7 +320,7 @@ class TestSearXNGSearchIntegration:
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.__exit__.return_value = None
-        mock_client_instance.get.return_value = mock_response
+        mock_client_instance.post.return_value = mock_response
         mock_client.return_value = mock_client_instance
 
         searcher = SearXNGSearch("http://localhost:8080")


### PR DESCRIPTION
## Summary

- Add `toolregistry_hub.utils.bind_literal(func, param, choices)` — returns a copy of a function with the given parameter's annotation rewritten to `Literal[*choices]`. Lets tools surface runtime-derived value sets as JSON Schema `enum` constraints without each one re-inventing `FunctionType` plumbing.
- Apply it to `UnitConverter.convert`: the `conversion` parameter is now a closed enum of all 41 conversion function names, so MCP clients can validate locally instead of round-tripping through `list_conversions` first. Closes #117.
- Fix `TodoList.update` to accept `in_progress` (plus `in-progress` / `inprogress`) as an alias for `pending`, since that's the spelling Claude Code's TaskCreate/TaskUpdate and most third-party todo tooling emit. The `update` docstring now also lists the closed status set explicitly so it lands in the generated tool description. Closes #116.

## Test plan

- [x] `pytest tests/test_annotation_helpers.py tests/test_unit_converter_schema.py tests/test_todo_list_status_alias.py` — all green (18 tests)
- [x] Full suite: 656 pass; one pre-existing BrightData network failure unrelated to this change
- [x] `ruff check` / `ruff format` / `ty check` clean on the touched files