### PR TITLE
feat(brightdata): align with official MCP package and fix timeout

### DIFF
--- a/src/toolregistry_hub/websearch/websearch_brightdata.py
+++ b/src/toolregistry_hub/websearch/websearch_brightdata.py
@@ -31,15 +31,68 @@ import os
 from typing import Any
 from urllib.parse import urlencode
 
-from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError
+from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError, Response
 from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
-from .base import TIMEOUT_DEFAULT, BaseSearch
+from .base import BaseSearch, SearchBackendError
 from .google_parser import BRIGHTDATA_CONFIG, GoogleResultParser
 from .search_result import SearchResult
 
 logger = get_logger()
+
+# Bright Data SERP API routes through a proxy/scraping layer, so it is
+# significantly slower than direct API services like Serper or Brave.
+# 60 seconds gives enough headroom for slow responses while still
+# catching stuck requests.
+_BRIGHTDATA_TIMEOUT_DEFAULT: float = 60.0
+
+# Aligned with official @brightdata/mcp package
+_MCP_PACKAGE_NAME = "@brightdata/mcp"
+_MCP_FALLBACK_VERSION = "2.9.5"
+_NPM_REGISTRY_URL = "https://registry.npmjs.org/@brightdata/mcp/latest"
+
+# Official MCP remote endpoint for account activation
+_MCP_REMOTE_URL = "https://mcp.brightdata.com/mcp"
+
+# Known BrightData error codes returned via x-brd-err-code header
+_BRD_ERR_SUSPENDED = "client_10020"
+_BRD_ERR_USAGE_LIMIT = "client_10100"
+
+# Cached at module level — fetched once per process lifetime.
+_mcp_version_cache: str | None = None
+
+
+def _get_mcp_version() -> str:
+    """Fetch the latest ``@brightdata/mcp`` version from the npm registry.
+
+    The result is cached in ``_mcp_version_cache`` so subsequent calls
+    are free.  Falls back to ``_MCP_FALLBACK_VERSION`` on any error.
+    """
+    global _mcp_version_cache  # noqa: PLW0603
+    if _mcp_version_cache is not None:
+        return _mcp_version_cache
+
+    try:
+        with Client(timeout=5.0) as client:
+            resp = client.get(_NPM_REGISTRY_URL)
+            resp.raise_for_status()
+            version = resp.json().get("version", _MCP_FALLBACK_VERSION)
+            _mcp_version_cache = version
+            logger.debug(f"Fetched @brightdata/mcp version from npm: {version}")
+            return version
+    except Exception:
+        logger.debug(
+            f"Could not fetch @brightdata/mcp version from npm, "
+            f"using fallback {_MCP_FALLBACK_VERSION}"
+        )
+        _mcp_version_cache = _MCP_FALLBACK_VERSION
+        return _MCP_FALLBACK_VERSION
+
+
+def _get_mcp_user_agent() -> str:
+    """Return the user-agent string matching the official MCP package."""
+    return f"{_MCP_PACKAGE_NAME}/{_get_mcp_version()}"
 
 
 @requires_env("BRIGHTDATA_API_KEY")
@@ -54,11 +107,14 @@ class BrightDataSearch(BaseSearch):
         """Initialize Bright Data search client.
 
         Args:
-            api_keys: Comma-separated Bright Data API tokens. If not provided, will try to get from BRIGHTDATA_API_KEY env var.
-            zone: Zone name for the request. If not provided, will try BRIGHTDATA_ZONE env var, defaults to 'mcp_unlocker'.
+            api_keys: Comma-separated Bright Data API tokens. If not provided,
+                will try to get from BRIGHTDATA_API_KEY env var.
+            zone: Zone name for the request. If not provided, will try
+                BRIGHTDATA_ZONE env var, defaults to 'mcp_unlocker'.
 
         Raises:
-            ValueError: If API tokens are not provided and not found in environment variables.
+            ValueError: If API tokens are not provided and not found in
+                environment variables.
         """
         # Initialize API key parser for multiple tokens
         self.api_key_parser = APIKeyParser(
@@ -67,28 +123,44 @@ class BrightDataSearch(BaseSearch):
         )
 
         self.zone = zone or os.getenv("BRIGHTDATA_ZONE", "mcp_unlocker")
+        self.browser_zone = os.getenv("BRIGHTDATA_BROWSER_ZONE", "mcp_browser")
         self.base_url = "https://api.brightdata.com/request"
 
         # Initialize parser with Bright Data configuration
         self.parser = GoogleResultParser(BRIGHTDATA_CONFIG)
 
-        # Ensure zone exists for each API key
+        # Ensure zones exist for each API key
         self._ensure_zone_exists_for_all_keys()
 
         logger.info(
-            f"Initialized BrightDataSearch with zone: {self.zone}, {self.api_key_parser.key_count} API tokens"
+            f"Initialized BrightDataSearch with zone: {self.zone}, "
+            f"{self.api_key_parser.key_count} API tokens"
         )
 
+    def _zone_api_headers(self, api_key: str) -> dict:
+        """Generate headers for zone management API calls.
+
+        Aligned with official @brightdata/mcp headers.
+
+        Args:
+            api_key: Bright Data API token.
+        """
+        return {
+            "user-agent": _get_mcp_user_agent(),
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
     def _ensure_zone_exists_for_all_keys(self):
-        """Ensure the required zone exists for all API keys."""
+        """Ensure the required zones exist for all API keys.
+
+        Creates both ``mcp_unlocker`` (unblocker) and ``mcp_browser``
+        (browser_api) zones, aligned with the official @brightdata/mcp
+        initialization behaviour.
+        """
         for i, api_key in enumerate(self.api_key_parser.api_keys):
             try:
-                # Check if zone exists using current API key
-                headers = {
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                    "Accept": "application/json",
-                }
+                headers = self._zone_api_headers(api_key)
 
                 with Client(timeout=30.0) as client:
                     response = client.get(
@@ -98,68 +170,209 @@ class BrightDataSearch(BaseSearch):
                     response.raise_for_status()
                     zones = response.json() or []
 
-                    has_zone = any(zone.get("name") == self.zone for zone in zones)
+                    has_unlocker = any(zone.get("name") == self.zone for zone in zones)
+                    has_browser = any(
+                        zone.get("name") == self.browser_zone for zone in zones
+                    )
 
-                    if not has_zone:
+                    key_label = f"key {i + 1}/{self.api_key_parser.key_count}"
+
+                    if not has_unlocker:
                         logger.info(
-                            f"Zone '{self.zone}' not found for key {i + 1}/{len(self.api_key_parser)}, creating it..."
+                            f"Zone '{self.zone}' not found for {key_label}, "
+                            f"creating it..."
                         )
-                        # Create the zone
                         create_response = client.post(
                             "https://api.brightdata.com/zone",
                             headers=headers,
                             json={
-                                "zone": {"name": self.zone, "type": "unblocker"},
-                                "plan": {"type": "unblocker"},
+                                "zone": {
+                                    "name": self.zone,
+                                    "type": "unblocker",
+                                },
+                                "plan": {
+                                    "type": "unblocker",
+                                    "ub_premium": True,
+                                },
+                            },
+                        )
+                        create_response.raise_for_status()
+                        logger.info(f"Zone '{self.zone}' created for {key_label}")
+                    else:
+                        logger.debug(
+                            f"Zone '{self.zone}' already exists for {key_label}"
+                        )
+
+                    if not has_browser:
+                        logger.info(
+                            f"Zone '{self.browser_zone}' not found for "
+                            f"{key_label}, creating it..."
+                        )
+                        create_response = client.post(
+                            "https://api.brightdata.com/zone",
+                            headers=headers,
+                            json={
+                                "zone": {
+                                    "name": self.browser_zone,
+                                    "type": "browser_api",
+                                },
+                                "plan": {"type": "browser_api"},
                             },
                         )
                         create_response.raise_for_status()
                         logger.info(
-                            f"Zone '{self.zone}' created successfully for key {i + 1}/{len(self.api_key_parser)}"
+                            f"Zone '{self.browser_zone}' created for {key_label}"
                         )
                     else:
                         logger.debug(
-                            f"Zone '{self.zone}' already exists for key {i + 1}/{len(self.api_key_parser)}"
+                            f"Zone '{self.browser_zone}' already exists for {key_label}"
                         )
 
             except Exception as e:
                 logger.warning(
-                    f"Could not verify/create zone '{self.zone}' for key {i + 1}/{len(self.api_key_parser)}: {e}. "
-                    f"Proceeding anyway - zone might exist or will be created on first use."
+                    f"Could not verify/create zones for key "
+                    f"{i + 1}/{self.api_key_parser.key_count}: {e}. "
+                    f"Proceeding anyway - zones might exist or will be "
+                    f"created on first use."
                 )
 
     def _build_headers(self, api_key: str | None = None) -> dict:
-        """Generate headers with the given API key.
+        """Generate headers for search API requests.
+
+        Aligned with official @brightdata/mcp ``api_headers()`` including
+        ``user-agent`` and ``x-mcp-tool`` headers.
 
         Args:
             api_key: Bright Data API token to use for authentication.
         """
         return {
+            "user-agent": _get_mcp_user_agent(),
             "Authorization": f"Bearer {api_key or ''}",
             "Content-Type": "application/json",
             "Accept": "application/json",
+            "x-mcp-tool": "search_engine",
         }
+
+    @staticmethod
+    def _check_brd_error(response: Response) -> None:
+        """Check BrightData-specific error headers on the response.
+
+        BrightData may return HTTP 200 with an empty body when the account
+        has issues.  The actual error information is conveyed via
+        ``x-brd-err-code`` / ``x-brd-err-msg`` response headers.
+
+        Args:
+            response: The HTTP response to inspect.
+
+        Raises:
+            SearchBackendError: If a BrightData error code is detected.
+        """
+        err_code = response.headers.get("x-brd-err-code")
+        if not err_code:
+            return
+
+        err_msg = response.headers.get(
+            "x-brd-err-msg",
+            response.headers.get("x-brd-error", "Unknown error"),
+        )
+
+        if err_code == _BRD_ERR_SUSPENDED:
+            raise SearchBackendError(
+                f"BrightData account is suspended ({err_code}): {err_msg}. "
+                f"Visit https://brightdata.com/cp/setting/billing to "
+                f"reactivate."
+            )
+
+        if err_code == _BRD_ERR_USAGE_LIMIT:
+            raise SearchBackendError(
+                f"BrightData free tier limit reached ({err_code}): {err_msg}. "
+                f"Create a new Web Unlocker zone at brightdata.com/cp or "
+                f"upgrade your plan."
+            )
+
+        raise SearchBackendError(f"BrightData API error ({err_code}): {err_msg}")
+
+    @staticmethod
+    def activate_account(api_key: str, timeout: float = 30.0) -> bool:
+        """Activate a new BrightData account via the official remote MCP.
+
+        New BrightData accounts must be initialized through the official
+        MCP endpoint at ``mcp.brightdata.com`` to provision the free
+        monthly allowance ($7.50).  This method performs that one-time
+        initialization.
+
+        Args:
+            api_key: The BrightData API token to activate.
+            timeout: Request timeout in seconds.
+
+        Returns:
+            True if activation succeeded, False otherwise.
+        """
+        try:
+            with Client(timeout=timeout) as client:
+                response = client.post(
+                    f"{_MCP_REMOTE_URL}?token={api_key}",
+                    headers={
+                        "Content-Type": "application/json",
+                        "Accept": "text/event-stream, application/json",
+                    },
+                    data=json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "method": "initialize",
+                            "params": {
+                                "protocolVersion": "2024-11-05",
+                                "capabilities": {},
+                                "clientInfo": {
+                                    "name": _MCP_PACKAGE_NAME,
+                                    "version": _get_mcp_version(),
+                                },
+                            },
+                        }
+                    ),
+                )
+                if response.status_code == 200 and response.text:
+                    logger.info(
+                        f"BrightData account activated via official MCP "
+                        f"for key {api_key[:8]}..."
+                    )
+                    return True
+                logger.warning(
+                    f"BrightData account activation returned "
+                    f"HTTP {response.status_code} for key {api_key[:8]}..."
+                )
+                return False
+        except Exception as e:
+            logger.warning(
+                f"Failed to activate BrightData account for key {api_key[:8]}...: {e}"
+            )
+            return False
 
     def search(
         self,
         query: str,
         *,
         max_results: int = 5,
-        timeout: float = TIMEOUT_DEFAULT,
+        timeout: float = _BRIGHTDATA_TIMEOUT_DEFAULT,
         cursor: str | None = None,
         **kwargs,
     ) -> list[SearchResult]:
         """Perform a web search using Bright Data Google Search API.
 
-        IMPORTANT: For time-sensitive queries (e.g., "recent news", "latest updates", "today's events"),
-        you MUST first obtain the current date/time using an available time/datetime tool before
-        constructing your search query. As an LLM, you have no inherent sense of current time - your
-        training data may be outdated. Always verify the current date when temporal context matters.
+        IMPORTANT: For time-sensitive queries (e.g., "recent news", "latest
+        updates", "today's events"), you MUST first obtain the current
+        date/time using an available time/datetime tool before constructing
+        your search query. As an LLM, you have no inherent sense of current
+        time - your training data may be outdated. Always verify the current
+        date when temporal context matters.
 
         Args:
             query: The search query string
-            max_results: Maximum number of results to return (1~20 recommended, 180 at max)
-            timeout: Request timeout in seconds
+            max_results: Maximum number of results to return
+                (1~20 recommended, 180 at max)
+            timeout: Request timeout in seconds (default: 60s, higher
+                than other providers due to proxy/scraping latency)
             cursor: Pagination cursor (page number, 0-based). Defaults to 0.
             **kwargs: Additional parameters (currently unused)
 
@@ -188,7 +401,10 @@ class BrightDataSearch(BaseSearch):
                 page_cursor = str(page) if cursor is None else str(int(cursor) + page)
                 results.extend(
                     self._search_impl(
-                        query=query, timeout=timeout, cursor=page_cursor, **kwargs
+                        query=query,
+                        timeout=timeout,
+                        cursor=page_cursor,
+                        **kwargs,
                     )
                 )
 
@@ -215,8 +431,8 @@ class BrightDataSearch(BaseSearch):
         page_num = int(cursor or 0)
         search_params = {
             "q": query,
-            "start": page_num * 10,  # Google uses 'start' parameter for pagination
-            "brd_json": "1",  # Bright Data specific flag for JSON response
+            "start": page_num * 10,  # Google uses 'start' for pagination
+            "brd_json": "1",  # Bright Data flag for JSON response
         }
         google_url = f"https://www.google.com/search?{urlencode(search_params)}"
 
@@ -228,7 +444,7 @@ class BrightDataSearch(BaseSearch):
             "data_format": "parsed",  # Request parsed/structured data
         }
 
-        timeout = kwargs.get("timeout", TIMEOUT_DEFAULT)
+        timeout = kwargs.get("timeout", _BRIGHTDATA_TIMEOUT_DEFAULT)
 
         max_attempts = max(self.api_key_parser.key_count, 1)
 
@@ -250,35 +466,54 @@ class BrightDataSearch(BaseSearch):
                     )
                     response.raise_for_status()
 
+                    # Check BrightData-specific error headers (may be
+                    # present even on HTTP 200)
+                    self._check_brd_error(response)
+
                     raw_data = response.text
+                    if not raw_data or not raw_data.strip():
+                        raise SearchBackendError(
+                            "BrightData API returned HTTP 200 with empty "
+                            "body. The account may be suspended or the "
+                            "zone may be misconfigured."
+                        )
+
                     data = json.loads(raw_data)
                     results = self.parser.parse(data)
 
                     logger.info(
-                        f"Bright Data search for '{query}' (page {page_num}) returned {len(results)} results"
+                        f"Bright Data search for '{query}' (page "
+                        f"{page_num}) returned {len(results)} results"
                     )
                     return results
 
+            except SearchBackendError:
+                raise
             except HttpTimeoutError:
                 logger.error(f"Bright Data API request timed out after {timeout}s")
                 return []
             except HTTPError as e:
                 if e.status_code == 422:
-                    logger.error(
-                        f"Zone '{self.zone}' does not exist. Check your BRIGHTDATA_ZONE configuration"
-                    )
-                    return []
+                    raise SearchBackendError(
+                        f"BrightData zone '{self.zone}' does not exist or "
+                        f"account is in invalid state (HTTP 422). Check "
+                        f"your BRIGHTDATA_ZONE configuration."
+                    ) from e
                 if self._handle_http_error(e, api_key, "Bright Data"):
                     continue
-                return []
+                raise SearchBackendError(
+                    f"BrightData API returned HTTP {e.status_code}: {str(e.body)[:200]}"
+                ) from e
             except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse Bright Data API response: {e}")
-                return []
+                raise SearchBackendError(
+                    f"Failed to parse BrightData API response as JSON: {e}"
+                ) from e
             except Exception as e:
-                logger.error(f"Bright Data API request failed: {e}")
-                return []
+                raise SearchBackendError(f"BrightData API request failed: {e}") from e
 
-        return []
+        raise SearchBackendError(
+            "All BrightData API keys exhausted without a successful response"
+        )
 
     def _parse_results(self, raw_results: dict[str, Any]) -> list[SearchResult]:
         """Parse Bright Data API response into standardized format.

--- a/src/toolregistry_hub/websearch/websearch_brightdata.py
+++ b/src/toolregistry_hub/websearch/websearch_brightdata.py
@@ -28,7 +28,7 @@ API Documentation: https://docs.brightdata.com/
 
 import json
 import os
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlencode
 
 from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError, Response
@@ -75,7 +75,7 @@ def _get_mcp_version() -> str:
 
     try:
         with Client(timeout=5.0) as client:
-            resp = client.get(_NPM_REGISTRY_URL)
+            resp = cast(Response, client.get(_NPM_REGISTRY_URL))
             resp.raise_for_status()
             version = resp.json().get("version", _MCP_FALLBACK_VERSION)
             _mcp_version_cache = version
@@ -163,9 +163,12 @@ class BrightDataSearch(BaseSearch):
                 headers = self._zone_api_headers(api_key)
 
                 with Client(timeout=30.0) as client:
-                    response = client.get(
-                        "https://api.brightdata.com/zone/get_active_zones",
-                        headers=headers,
+                    response = cast(
+                        Response,
+                        client.get(
+                            "https://api.brightdata.com/zone/get_active_zones",
+                            headers=headers,
+                        ),
                     )
                     response.raise_for_status()
                     zones = response.json() or []
@@ -310,26 +313,29 @@ class BrightDataSearch(BaseSearch):
         """
         try:
             with Client(timeout=timeout) as client:
-                response = client.post(
-                    f"{_MCP_REMOTE_URL}?token={api_key}",
-                    headers={
-                        "Content-Type": "application/json",
-                        "Accept": "text/event-stream, application/json",
-                    },
-                    data=json.dumps(
-                        {
-                            "jsonrpc": "2.0",
-                            "id": 1,
-                            "method": "initialize",
-                            "params": {
-                                "protocolVersion": "2024-11-05",
-                                "capabilities": {},
-                                "clientInfo": {
-                                    "name": _MCP_PACKAGE_NAME,
-                                    "version": _get_mcp_version(),
+                response = cast(
+                    Response,
+                    client.post(
+                        f"{_MCP_REMOTE_URL}?token={api_key}",
+                        headers={
+                            "Content-Type": "application/json",
+                            "Accept": "text/event-stream, application/json",
+                        },
+                        data=json.dumps(
+                            {
+                                "jsonrpc": "2.0",
+                                "id": 1,
+                                "method": "initialize",
+                                "params": {
+                                    "protocolVersion": "2024-11-05",
+                                    "capabilities": {},
+                                    "clientInfo": {
+                                        "name": _MCP_PACKAGE_NAME,
+                                        "version": _get_mcp_version(),
+                                    },
                                 },
-                            },
-                        }
+                            }
+                        ),
                     ),
                 )
                 if response.status_code == 200 and response.text:
@@ -459,10 +465,13 @@ class BrightDataSearch(BaseSearch):
 
             try:
                 with Client(timeout=timeout) as client:
-                    response = client.post(
-                        self.base_url,
-                        headers=self._build_headers(api_key),
-                        json=payload,
+                    response = cast(
+                        Response,
+                        client.post(
+                            self.base_url,
+                            headers=self._build_headers(api_key),
+                            json=payload,
+                        ),
                     )
                     response.raise_for_status()
 

--- a/tests/websearch/test_websearch_brightdata.py
+++ b/tests/websearch/test_websearch_brightdata.py
@@ -3,9 +3,22 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from toolregistry_hub._vendor.httpclient import HTTPError, HttpTimeoutError
+from toolregistry_hub.websearch.base import SearchBackendError
 from toolregistry_hub.websearch.search_result import SearchResult
 from toolregistry_hub.websearch.websearch_brightdata import BrightDataSearch
+
+
+def _make_mock_response(text="", headers=None, status_code=200):
+    """Create a mock response with proper headers dict."""
+    mock = MagicMock()
+    mock.text = text
+    mock.status_code = status_code
+    mock.headers = headers or {}
+    mock.raise_for_status = MagicMock()
+    return mock
 
 
 class TestBrightDataSearch:
@@ -60,13 +73,15 @@ class TestBrightDataSearch:
         "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
     )
     def test_build_headers(self, mock_ensure):
-        """Test _build_headers method."""
+        """Test _build_headers method includes official MCP headers."""
         search = BrightDataSearch(api_keys="test_token")
         headers = search._build_headers("test_token")
 
         assert headers["Authorization"] == "Bearer test_token"
         assert headers["Content-Type"] == "application/json"
         assert headers["Accept"] == "application/json"
+        assert headers["user-agent"].startswith("@brightdata/mcp/")
+        assert headers["x-mcp-tool"] == "search_engine"
 
     @patch(
         "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
@@ -74,38 +89,34 @@ class TestBrightDataSearch:
     @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
     def test_search_basic(self, mock_client, mock_ensure):
         """Test basic search functionality."""
-        # Mock response
-        mock_response = MagicMock()
-        mock_response.text = json.dumps(
-            {
-                "organic": [
-                    {
-                        "title": "Test Result 1",
-                        "url": "https://example1.com",
-                        "description": "Description 1",
-                    },
-                    {
-                        "title": "Test Result 2",
-                        "url": "https://example2.com",
-                        "description": "Description 2",
-                    },
-                ]
-            }
+        mock_response = _make_mock_response(
+            text=json.dumps(
+                {
+                    "organic": [
+                        {
+                            "title": "Test Result 1",
+                            "url": "https://example1.com",
+                            "description": "Description 1",
+                        },
+                        {
+                            "title": "Test Result 2",
+                            "url": "https://example2.com",
+                            "description": "Description 2",
+                        },
+                    ]
+                }
+            )
         )
-        mock_response.raise_for_status = MagicMock()
 
-        # Setup mock client
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.__exit__.return_value = None
         mock_client_instance.post.return_value = mock_response
         mock_client.return_value = mock_client_instance
 
-        # Perform search
         search = BrightDataSearch(api_keys="test_token")
         results = search.search("test query", max_results=5)
 
-        # Assertions
         assert len(results) == 2
         assert isinstance(results[0], SearchResult)
         assert results[0].title == "Test Result 1"
@@ -119,9 +130,7 @@ class TestBrightDataSearch:
     @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
     def test_search_with_pagination(self, mock_client, mock_ensure):
         """Test search with pagination cursor."""
-        mock_response = MagicMock()
-        mock_response.text = json.dumps({"organic": []})
-        mock_response.raise_for_status = MagicMock()
+        mock_response = _make_mock_response(text=json.dumps({"organic": []}))
 
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
@@ -132,7 +141,6 @@ class TestBrightDataSearch:
         search = BrightDataSearch(api_keys="test_token")
         search.search("test query", cursor="2")
 
-        # Verify the URL contains correct start parameter
         call_args = mock_client_instance.post.call_args
         payload = call_args[1]["json"]
         assert "start=20" in payload["url"]  # Page 2 = start at 20
@@ -171,11 +179,7 @@ class TestBrightDataSearch:
     )
     @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
     def test_search_http_401_error(self, mock_client, mock_ensure):
-        """Test search with 401 authentication error."""
-        mock_response = MagicMock()
-        mock_response.status_code = 401
-        mock_response.text = "Unauthorized"
-
+        """Test search with 401 authentication error raises SearchBackendError."""
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.__exit__.return_value = None
@@ -185,20 +189,15 @@ class TestBrightDataSearch:
         mock_client.return_value = mock_client_instance
 
         search = BrightDataSearch(api_keys="invalid_token")
-        results = search.search("test query")
-
-        assert results == []
+        with pytest.raises(SearchBackendError, match="keys exhausted"):
+            search.search("test query")
 
     @patch(
         "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
     )
     @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
     def test_search_http_422_error(self, mock_client, mock_ensure):
-        """Test search with 422 zone error."""
-        mock_response = MagicMock()
-        mock_response.status_code = 422
-        mock_response.text = "Zone not found"
-
+        """Test search with 422 zone error raises SearchBackendError."""
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.__exit__.return_value = None
@@ -208,20 +207,15 @@ class TestBrightDataSearch:
         mock_client.return_value = mock_client_instance
 
         search = BrightDataSearch(api_keys="test_token", zone="invalid_zone")
-        results = search.search("test query")
-
-        assert results == []
+        with pytest.raises(SearchBackendError, match="HTTP 422"):
+            search.search("test query")
 
     @patch(
         "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
     )
     @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
     def test_search_http_429_error(self, mock_client, mock_ensure):
-        """Test search with 429 rate limit error."""
-        mock_response = MagicMock()
-        mock_response.status_code = 429
-        mock_response.text = "Rate limit exceeded"
-
+        """Test search with 429 rate limit error raises SearchBackendError."""
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.__exit__.return_value = None
@@ -231,19 +225,16 @@ class TestBrightDataSearch:
         mock_client.return_value = mock_client_instance
 
         search = BrightDataSearch(api_keys="test_token")
-        results = search.search("test query")
-
-        assert results == []
+        with pytest.raises(SearchBackendError, match="keys exhausted"):
+            search.search("test query")
 
     @patch(
         "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
     )
     @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
     def test_search_json_decode_error(self, mock_client, mock_ensure):
-        """Test search with invalid JSON response."""
-        mock_response = MagicMock()
-        mock_response.text = "Invalid JSON"
-        mock_response.raise_for_status = MagicMock()
+        """Test search with invalid JSON response raises SearchBackendError."""
+        mock_response = _make_mock_response(text="Invalid JSON")
 
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
@@ -252,9 +243,74 @@ class TestBrightDataSearch:
         mock_client.return_value = mock_client_instance
 
         search = BrightDataSearch(api_keys="test_token")
-        results = search.search("test query")
+        with pytest.raises(SearchBackendError, match="JSON"):
+            search.search("test query")
 
-        assert results == []
+    @patch(
+        "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
+    )
+    @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
+    def test_search_brd_err_suspended(self, mock_client, mock_ensure):
+        """Test that x-brd-err-code: client_10020 raises SearchBackendError."""
+        mock_response = _make_mock_response(
+            text="",
+            headers={
+                "x-brd-err-code": "client_10020",
+                "x-brd-err-msg": "Account is suspended",
+            },
+        )
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = None
+        mock_client_instance.post.return_value = mock_response
+        mock_client.return_value = mock_client_instance
+
+        search = BrightDataSearch(api_keys="test_token")
+        with pytest.raises(SearchBackendError, match="suspended"):
+            search.search("test query")
+
+    @patch(
+        "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
+    )
+    @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
+    def test_search_brd_err_usage_limit(self, mock_client, mock_ensure):
+        """Test that x-brd-err-code: client_10100 raises SearchBackendError."""
+        mock_response = _make_mock_response(
+            text="",
+            headers={
+                "x-brd-err-code": "client_10100",
+                "x-brd-err-msg": "Monthly limit reached",
+            },
+        )
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = None
+        mock_client_instance.post.return_value = mock_response
+        mock_client.return_value = mock_client_instance
+
+        search = BrightDataSearch(api_keys="test_token")
+        with pytest.raises(SearchBackendError, match="free tier limit"):
+            search.search("test query")
+
+    @patch(
+        "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
+    )
+    @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
+    def test_search_empty_body(self, mock_client, mock_ensure):
+        """Test that HTTP 200 with empty body raises SearchBackendError."""
+        mock_response = _make_mock_response(text="")
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = None
+        mock_client_instance.post.return_value = mock_response
+        mock_client.return_value = mock_client_instance
+
+        search = BrightDataSearch(api_keys="test_token")
+        with pytest.raises(SearchBackendError, match="empty body"):
+            search.search("test query")
 
     @patch(
         "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
@@ -324,9 +380,7 @@ class TestBrightDataSearch:
     @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
     def test_search_max_results_pagination(self, mock_client, mock_ensure):
         """Test search with max_results > 20 triggers pagination."""
-        mock_response = MagicMock()
-        mock_response.text = json.dumps({"organic": []})
-        mock_response.raise_for_status = MagicMock()
+        mock_response = _make_mock_response(text=json.dumps({"organic": []}))
 
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
@@ -346,9 +400,7 @@ class TestBrightDataSearch:
     @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
     def test_search_max_results_cap(self, mock_client, mock_ensure):
         """Test that max_results is capped at 180."""
-        mock_response = MagicMock()
-        mock_response.text = json.dumps({"organic": []})
-        mock_response.raise_for_status = MagicMock()
+        mock_response = _make_mock_response(text=json.dumps({"organic": []}))
 
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__.return_value = mock_client_instance
@@ -361,3 +413,56 @@ class TestBrightDataSearch:
 
         # Should make 9 calls (180 / 20 = 9)
         assert mock_client_instance.post.call_count == 9
+
+    @patch(
+        "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
+    )
+    def test_check_brd_error_no_error(self, mock_ensure):
+        """Test _check_brd_error passes when no error header is present."""
+        mock_response = _make_mock_response(headers={})
+        # Should not raise
+        BrightDataSearch._check_brd_error(mock_response)
+
+    @patch(
+        "toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch._ensure_zone_exists_for_all_keys"
+    )
+    def test_check_brd_error_unknown_code(self, mock_ensure):
+        """Test _check_brd_error raises on unknown error code."""
+        mock_response = _make_mock_response(
+            headers={
+                "x-brd-err-code": "client_99999",
+                "x-brd-err-msg": "Some unknown error",
+            }
+        )
+        with pytest.raises(SearchBackendError, match="client_99999"):
+            BrightDataSearch._check_brd_error(mock_response)
+
+    @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
+    def test_activate_account_success(self, mock_client):
+        """Test activate_account returns True on success."""
+        mock_response = _make_mock_response(
+            text='data: {"result": {}}', status_code=200
+        )
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = None
+        mock_client_instance.post.return_value = mock_response
+        mock_client.return_value = mock_client_instance
+
+        result = BrightDataSearch.activate_account("test_key")
+        assert result is True
+
+    @patch("toolregistry_hub.websearch.websearch_brightdata.Client")
+    def test_activate_account_failure(self, mock_client):
+        """Test activate_account returns False on failure."""
+        mock_response = _make_mock_response(text="", status_code=401)
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = None
+        mock_client_instance.post.return_value = mock_response
+        mock_client.return_value = mock_client_instance
+
+        result = BrightDataSearch.activate_account("bad_key")
+        assert result is False


### PR DESCRIPTION
## Summary

- Align BrightData search client with the official `@brightdata/mcp` npm package:
  - Match request headers (`user-agent`, `x-mcp-tool`) to official implementation
  - Auto-provision both `mcp_unlocker` and `mcp_browser` zones on init
  - Add `activate_account()` for one-time account initialization via MCP remote
  - Cache npm version lookup at module level (one fetch per process lifetime)
- Check BrightData-specific error headers (`x-brd-err-code`) and raise `SearchBackendError` instead of silently returning empty results
- Increase default timeout from 10s to 60s — Bright Data's SERP API routes through a proxy/scraping layer with significantly higher latency than direct API providers
- Update `.env` to replace expired API key

## Test plan

- [x] 26/26 unit tests passing
- [x] Live search verified with all 5 API keys (no 401 errors)
- [x] Multiple real queries tested (`latest AI news 2026`, `rust vs go`, `best mechanical keyboards 2026`)
- [x] Compared `parsed` vs `parsed_light` response formats — confirmed `parsed` is the right choice