### PR TITLE
fix(websearch): increase scrapeless timeout and fix ty warnings

### DIFF
--- a/src/toolregistry_hub/websearch/websearch_brave.py
+++ b/src/toolregistry_hub/websearch/websearch_brave.py
@@ -25,7 +25,9 @@ Usage:
 API Documentation: https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
 """
 
-from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError
+from typing import cast
+
+from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError, Response
 from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
@@ -178,10 +180,13 @@ class BraveSearch(BaseSearch):
 
             try:
                 with Client(timeout=timeout) as client:
-                    response = client.get(
-                        f"{self.base_url}/web/search",
-                        headers=self._build_headers(api_key),
-                        params=params,
+                    response = cast(
+                        Response,
+                        client.get(
+                            f"{self.base_url}/web/search",
+                            headers=self._build_headers(api_key),
+                            params=params,
+                        ),
                     )
                     response.raise_for_status()
 

--- a/src/toolregistry_hub/websearch/websearch_scrapeless.py
+++ b/src/toolregistry_hub/websearch/websearch_scrapeless.py
@@ -30,17 +30,23 @@ API Documentation: https://docs.scrapeless.com/
 """
 
 import json
-from typing import Any
+from typing import Any, cast
 
-from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError
+from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError, Response
 from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
-from .base import TIMEOUT_DEFAULT, BaseSearch
+from .base import BaseSearch
 from .google_parser import SCRAPELESS_CONFIG, GoogleResultParser
 from .search_result import SearchResult
 
 logger = get_logger()
+
+# Scrapeless DeepSERP API routes through a proxy/scraping layer, so it is
+# significantly slower than direct API services like Serper or Brave.
+# 60 seconds gives enough headroom for slow responses while still
+# catching stuck requests.
+_SCRAPELESS_TIMEOUT_DEFAULT: float = 60.0
 
 
 @requires_env("SCRAPELESS_API_KEY")
@@ -91,7 +97,7 @@ class ScrapelessSearch(BaseSearch):
         query: str,
         *,
         max_results: int = 5,
-        timeout: float = TIMEOUT_DEFAULT,
+        timeout: float = _SCRAPELESS_TIMEOUT_DEFAULT,
         language: str = "en",
         country: str = "us",
         start: int = 0,
@@ -161,7 +167,7 @@ class ScrapelessSearch(BaseSearch):
         self,
         query: str,
         start: int = 0,
-        timeout: float = TIMEOUT_DEFAULT,
+        timeout: float = _SCRAPELESS_TIMEOUT_DEFAULT,
         language: str = "en",
         country: str = "us",
         **kwargs,
@@ -209,10 +215,13 @@ class ScrapelessSearch(BaseSearch):
 
             try:
                 with Client(timeout=timeout) as client:
-                    response = client.post(
-                        self.endpoint,
-                        headers=self._build_headers(api_key),
-                        json=payload,
+                    response = cast(
+                        Response,
+                        client.post(
+                            self.endpoint,
+                            headers=self._build_headers(api_key),
+                            json=payload,
+                        ),
                     )
                     response.raise_for_status()
 

--- a/src/toolregistry_hub/websearch/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch/websearch_searxng.py
@@ -30,7 +30,6 @@ SearXNG Setup: https://docs.searxng.org/admin/installation.html
 """
 
 import os
-
 from typing import cast
 
 from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError, Response

--- a/src/toolregistry_hub/websearch/websearch_searxng.py
+++ b/src/toolregistry_hub/websearch/websearch_searxng.py
@@ -31,7 +31,9 @@ SearXNG Setup: https://docs.searxng.org/admin/installation.html
 
 import os
 
-from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError
+from typing import cast
+
+from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError, Response
 from .._vendor.structlog import get_logger
 from ..utils.requirements import requires_env
 from .base import TIMEOUT_DEFAULT, BaseSearch, SearchBackendError
@@ -177,10 +179,13 @@ class SearXNGSearch(BaseSearch):
         assert self.search_url is not None  # validated in search()
         try:
             with Client(timeout=timeout) as client:
-                response = client.post(
-                    self.search_url,
-                    headers=self._build_headers(),
-                    data=params,
+                response = cast(
+                    Response,
+                    client.post(
+                        self.search_url,
+                        headers=self._build_headers(),
+                        data=params,
+                    ),
                 )
                 response.raise_for_status()
 

--- a/src/toolregistry_hub/websearch/websearch_serper.py
+++ b/src/toolregistry_hub/websearch/websearch_serper.py
@@ -27,9 +27,9 @@ API Documentation: https://serper.dev/playground
 """
 
 import json
-from typing import Any
+from typing import Any, cast
 
-from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError
+from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError, Response
 from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
@@ -196,10 +196,13 @@ class SerperSearch(BaseSearch):
 
             try:
                 with Client(timeout=timeout) as client:
-                    response = client.post(
-                        f"{self.base_url}/search",
-                        headers=self._build_headers(api_key),
-                        json=payload,
+                    response = cast(
+                        Response,
+                        client.post(
+                            f"{self.base_url}/search",
+                            headers=self._build_headers(api_key),
+                            json=payload,
+                        ),
                     )
                     response.raise_for_status()
 

--- a/src/toolregistry_hub/websearch/websearch_tavily.py
+++ b/src/toolregistry_hub/websearch/websearch_tavily.py
@@ -25,7 +25,9 @@ Usage:
 API Documentation: https://docs.tavily.com/documentation/api-reference/endpoint/search
 """
 
-from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError
+from typing import cast
+
+from .._vendor.httpclient import Client, HTTPError, HttpTimeoutError, Response
 from .._vendor.structlog import get_logger
 from ..utils.api_key_parser import APIKeyParser
 from ..utils.requirements import requires_env
@@ -152,10 +154,13 @@ class TavilySearch(BaseSearch):
 
             try:
                 with Client(timeout=timeout) as client:
-                    response = client.post(
-                        f"{self.base_url}/search",
-                        headers=self._build_headers(api_key),
-                        json=payload,
+                    response = cast(
+                        Response,
+                        client.post(
+                            f"{self.base_url}/search",
+                            headers=self._build_headers(api_key),
+                            json=payload,
+                        ),
                     )
                     response.raise_for_status()
 


### PR DESCRIPTION
## Summary

- Increase Scrapeless default timeout from 10s to 60s — same rationale as #128 for BrightData (proxy/scraping latency is much higher than direct APIs)
- Add `cast(Response, ...)` to all remaining websearch providers (brave, searxng, serper, tavily, scrapeless) to fix `ty` `unresolved-attribute` warnings on `Response | StreamingResponse` union type

## Test plan

- [x] `ty check` passes for all 5 modified files (zero diagnostics)
- [x] 144/145 websearch tests passing (1 pre-existing flaky SearXNG env test)
- [x] ruff check + format clean