### PR TITLE
feat(fetch): add CDP rendering stage for SPA content extraction

### DIFF
--- a/src/toolregistry_hub/_vendor/cdp/__init__.py
+++ b/src/toolregistry_hub/_vendor/cdp/__init__.py
@@ -1,0 +1,1 @@
+from .cdp import *  # noqa: F401,F403

--- a/src/toolregistry_hub/_vendor/cdp/cdp.py
+++ b/src/toolregistry_hub/_vendor/cdp/cdp.py
@@ -1,0 +1,976 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = ["websocket"]
+# tier = "medium"
+# category = "protocol"
+# ///
+"""Zero-dependency Chrome DevTools Protocol (CDP) client.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Provides sync and async CDP clients for communicating with CDP-compatible
+browsers (Chrome, Chromium, Lightpanda, etc.) over WebSocket. Supports
+tab management, page navigation, JavaScript evaluation, and high-level
+rendered content extraction.
+
+Usage::
+
+    # High-level: extract rendered text from an SPA
+    from cdp import CDPClient
+
+    with CDPClient("ws://localhost:9222") as client:
+        text = client.get_rendered_text("https://react.dev", timeout=15)
+        print(text)
+
+    # Low-level: manage targets and evaluate JS
+    from cdp import CDPClient
+
+    with CDPClient("ws://localhost:9222") as client:
+        target_id = client.create_target("https://example.com")
+        client.wait_for_load(target_id, timeout=10)
+        html = client.evaluate(target_id, "document.documentElement.outerHTML")
+        client.close_target(target_id)
+
+    # Async
+    from cdp import AsyncCDPClient
+
+    async with AsyncCDPClient("ws://localhost:9222") as client:
+        text = await client.get_rendered_text("https://example.com")
+
+Requires Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import collections
+import itertools
+import json
+import logging
+import os
+import sys
+import time
+
+__all__ = [
+    # Constants
+    "DEFAULT_TIMEOUT",
+    "DEFAULT_PAGE_LOAD_TIMEOUT",
+    # Exceptions
+    "CDPError",
+    "CDPConnectionError",
+    "CDPTimeoutError",
+    "CDPProtocolError",
+    # Clients
+    "CDPClient",
+    "AsyncCDPClient",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# ── Sibling websocket import (guarded) ─────────────────────────────────────
+
+
+def _ensure_sibling_path(name: str) -> str:
+    """Return the sibling module directory and prepend it to ``sys.path``."""
+    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
+    if sibling_dir not in sys.path:
+        sys.path.insert(0, sibling_dir)
+    return sibling_dir
+
+
+try:
+    _websocket_dir = _ensure_sibling_path("websocket")
+    from websocket import AsyncWebSocketClient as _AsyncWebSocketClient
+    from websocket import WebSocketClient as _WebSocketClient
+    from websocket import WebSocketConnectionError as _WebSocketConnectionError
+    from websocket import WebSocketError as _WebSocketError
+    from websocket import WebSocketTimeoutError as _WebSocketTimeoutError
+
+    _HAS_WEBSOCKET = True
+except (ImportError, AttributeError):
+    _HAS_WEBSOCKET = False
+
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+DEFAULT_TIMEOUT: float = 30.0
+DEFAULT_PAGE_LOAD_TIMEOUT: float = 30.0
+
+
+# ── Exceptions ─────────────────────────────────────────────────────────────
+
+
+class CDPError(Exception):
+    """Base exception for all CDP operations."""
+
+
+class CDPConnectionError(CDPError):
+    """Raised on WebSocket connection failures to the CDP endpoint."""
+
+    def __init__(self, message: str, *, url: str = "") -> None:
+        self.url = url
+        super().__init__(message)
+
+
+class CDPTimeoutError(CDPError):
+    """Raised when a CDP operation times out."""
+
+    def __init__(self, message: str, *, timeout: float = 0.0) -> None:
+        self.timeout = timeout
+        super().__init__(message)
+
+
+class CDPProtocolError(CDPError):
+    """Raised on CDP error responses."""
+
+    def __init__(
+        self,
+        code: int,
+        message: str,
+        *,
+        data: str | None = None,
+    ) -> None:
+        self.code = code
+        self.error_message = message
+        self.data = data
+        super().__init__(f"CDP error {code}: {message}")
+
+
+# ── Sync CDP Client ───────────────────────────────────────────────────────
+
+
+class CDPClient:
+    """Synchronous Chrome DevTools Protocol client.
+
+    Args:
+        url: CDP WebSocket endpoint URL (e.g. ``ws://localhost:9222``).
+            If the URL does not contain a path, the client will auto-discover
+            the browser's debugger WebSocket URL via the ``/json/version``
+            endpoint.
+        timeout: Default timeout for CDP commands in seconds.
+
+    Example::
+
+        with CDPClient("ws://localhost:9222") as client:
+            text = client.get_rendered_text("https://example.com")
+            print(text)
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self._url = url
+        self._timeout = timeout
+        self._ws: _WebSocketClient | None = None
+        self._cmd_id = itertools.count(1)
+        self._targets: dict[str, str] = {}  # target_id -> session_id
+        self._event_buffer: collections.deque[dict] = collections.deque()
+
+    def connect(self, *, timeout: float | None = None) -> None:
+        """Open the WebSocket connection to the CDP endpoint.
+
+        Args:
+            timeout: Connection timeout in seconds. Defaults to the
+                client's default timeout.
+
+        Raises:
+            CDPConnectionError: If the connection fails.
+            ImportError: If the websocket module is not available.
+        """
+        if self._ws is not None:
+            return
+
+        if not _HAS_WEBSOCKET:
+            raise ImportError(
+                "cdp module requires sibling 'websocket' module; "
+                "install it with: zerodep add websocket"
+            )
+
+        ws_url = self._resolve_ws_url(self._url, timeout=timeout or self._timeout)
+
+        try:
+            ws = _WebSocketClient(ws_url)
+            ws.connect(timeout=timeout or self._timeout)
+            self._ws = ws
+        except _WebSocketConnectionError as exc:
+            raise CDPConnectionError(
+                f"failed to connect to CDP endpoint: {exc}",
+                url=ws_url,
+            ) from exc
+        except _WebSocketTimeoutError as exc:
+            raise CDPTimeoutError(
+                f"connection to CDP endpoint timed out: {exc}",
+                timeout=timeout or self._timeout,
+            ) from exc
+
+    def send_command(
+        self,
+        method: str,
+        params: dict | None = None,
+        *,
+        session_id: str | None = None,
+        timeout: float | None = None,
+    ) -> dict:
+        """Send a CDP command and wait for the response.
+
+        Args:
+            method: CDP method name (e.g. ``Page.navigate``).
+            params: Optional command parameters.
+            session_id: Optional session ID for target-specific commands.
+            timeout: Command timeout in seconds.
+
+        Returns:
+            The ``result`` dict from the CDP response.
+
+        Raises:
+            CDPTimeoutError: If the command times out.
+            CDPProtocolError: If the CDP response contains an error.
+            CDPError: If not connected.
+        """
+        self._ensure_connected()
+        assert self._ws is not None
+
+        cmd_id = next(self._cmd_id)
+        msg: dict = {"id": cmd_id, "method": method}
+        if params:
+            msg["params"] = params
+        if session_id:
+            msg["sessionId"] = session_id
+
+        self._ws.send(json.dumps(msg))
+        return self._recv_response(cmd_id, timeout=timeout or self._timeout)
+
+    def create_target(self, url: str = "about:blank") -> str:
+        """Create a new browser target (tab) and attach to it.
+
+        Args:
+            url: Initial URL to load in the new target.
+
+        Returns:
+            The target ID.
+        """
+        result = self.send_command("Target.createTarget", {"url": url})
+        target_id = result["targetId"]
+
+        attach_result = self.send_command(
+            "Target.attachToTarget",
+            {"targetId": target_id, "flatten": True},
+        )
+        session_id = attach_result["sessionId"]
+        self._targets[target_id] = session_id
+        logger.debug("created target %s with session %s", target_id, session_id)
+        return target_id
+
+    def close_target(self, target_id: str) -> None:
+        """Close a browser target (tab).
+
+        Args:
+            target_id: The target ID to close.
+        """
+        if target_id not in self._targets:
+            return
+        try:
+            self.send_command("Target.closeTarget", {"targetId": target_id})
+        except CDPError:
+            logger.debug("failed to close target %s", target_id, exc_info=True)
+        self._targets.pop(target_id, None)
+
+    def navigate(
+        self,
+        target_id: str,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        """Navigate a target to a URL and wait for the page to load.
+
+        Args:
+            target_id: The target ID.
+            url: URL to navigate to.
+            timeout: Page load timeout in seconds.
+        """
+        session_id = self._get_session_id(target_id)
+        load_timeout = timeout or DEFAULT_PAGE_LOAD_TIMEOUT
+
+        self.send_command("Page.enable", session_id=session_id)
+        self.send_command("Page.navigate", {"url": url}, session_id=session_id)
+        self._wait_for_event(
+            "Page.loadEventFired",
+            session_id=session_id,
+            timeout=load_timeout,
+        )
+
+    def wait_for_load(
+        self,
+        target_id: str,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        """Wait for a target's page to finish loading.
+
+        Args:
+            target_id: The target ID.
+            timeout: Page load timeout in seconds.
+        """
+        session_id = self._get_session_id(target_id)
+        self.send_command("Page.enable", session_id=session_id)
+        self._wait_for_event(
+            "Page.loadEventFired",
+            session_id=session_id,
+            timeout=timeout or DEFAULT_PAGE_LOAD_TIMEOUT,
+        )
+
+    def evaluate(self, target_id: str, expression: str) -> object:
+        """Evaluate a JavaScript expression in a target.
+
+        Args:
+            target_id: The target ID.
+            expression: JavaScript expression to evaluate.
+
+        Returns:
+            The result value.
+
+        Raises:
+            CDPProtocolError: If the evaluation throws an exception.
+        """
+        session_id = self._get_session_id(target_id)
+        result = self.send_command(
+            "Runtime.evaluate",
+            {"expression": expression, "returnByValue": True},
+            session_id=session_id,
+        )
+
+        if "exceptionDetails" in result:
+            exc_details = result["exceptionDetails"]
+            text = exc_details.get("text", "evaluation failed")
+            raise CDPProtocolError(-1, text)
+
+        return result.get("result", {}).get("value")
+
+    def get_rendered_text(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """Navigate to a URL and extract the rendered text content.
+
+        Creates a temporary target, navigates to the URL, waits for load,
+        extracts ``document.body.innerText``, and closes the target.
+
+        Args:
+            url: URL to render.
+            timeout: Page load timeout in seconds.
+
+        Returns:
+            The rendered text content of the page.
+        """
+        target_id = self.create_target()
+        try:
+            self.navigate(target_id, url, timeout=timeout)
+            result = self.evaluate(target_id, "document.body.innerText")
+            return result if isinstance(result, str) else str(result or "")
+        finally:
+            self.close_target(target_id)
+
+    def get_rendered_html(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """Navigate to a URL and extract the rendered HTML.
+
+        Creates a temporary target, navigates to the URL, waits for load,
+        extracts ``document.documentElement.outerHTML``, and closes the target.
+
+        Args:
+            url: URL to render.
+            timeout: Page load timeout in seconds.
+
+        Returns:
+            The rendered outer HTML of the page.
+        """
+        target_id = self.create_target()
+        try:
+            self.navigate(target_id, url, timeout=timeout)
+            result = self.evaluate(target_id, "document.documentElement.outerHTML")
+            return result if isinstance(result, str) else str(result or "")
+        finally:
+            self.close_target(target_id)
+
+    def set_user_agent(self, target_id: str, user_agent: str) -> None:
+        """Override the User-Agent for a target.
+
+        Args:
+            target_id: The target ID.
+            user_agent: The User-Agent string to set.
+        """
+        session_id = self._get_session_id(target_id)
+        self.send_command(
+            "Network.setUserAgentOverride",
+            {"userAgent": user_agent},
+            session_id=session_id,
+        )
+
+    def close(self) -> None:
+        """Close all targets and the WebSocket connection."""
+        if self._ws is None:
+            return
+
+        # Close all targets (best-effort)
+        for target_id in list(self._targets):
+            try:
+                self.send_command("Target.closeTarget", {"targetId": target_id})
+            except (CDPError, _WebSocketError):
+                pass
+        self._targets.clear()
+        self._event_buffer.clear()
+
+        try:
+            self._ws.close()
+        except _WebSocketError:
+            pass
+        self._ws = None
+
+    def __enter__(self) -> CDPClient:
+        self.connect()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # ── Sync internal helpers ──
+
+    def _ensure_connected(self) -> None:
+        if self._ws is None:
+            raise CDPError("not connected")
+
+    def _get_session_id(self, target_id: str) -> str:
+        session_id = self._targets.get(target_id)
+        if session_id is None:
+            raise CDPError(f"unknown target: {target_id}")
+        return session_id
+
+    def _recv_response(self, cmd_id: int, *, timeout: float) -> dict:
+        """Receive messages until the response matching *cmd_id* arrives.
+
+        Non-matching messages (events or other responses) are buffered.
+        """
+        assert self._ws is not None
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise CDPTimeoutError(
+                    f"command {cmd_id} timed out after {timeout}s",
+                    timeout=timeout,
+                )
+            try:
+                raw = self._ws.recv(timeout=remaining)
+            except _WebSocketTimeoutError as exc:
+                raise CDPTimeoutError(
+                    f"command {cmd_id} timed out after {timeout}s",
+                    timeout=timeout,
+                ) from exc
+
+            msg = json.loads(raw)
+            if msg.get("id") == cmd_id:
+                if "error" in msg:
+                    err = msg["error"]
+                    raise CDPProtocolError(
+                        err.get("code", -1),
+                        err.get("message", "unknown error"),
+                        data=err.get("data"),
+                    )
+                return msg.get("result", {})
+            # Not our response -- buffer it
+            self._event_buffer.append(msg)
+
+    def _wait_for_event(
+        self,
+        event_name: str,
+        *,
+        session_id: str | None = None,
+        timeout: float,
+    ) -> dict:
+        """Wait for a specific CDP event.
+
+        First checks the event buffer, then reads from the WebSocket.
+        """
+        assert self._ws is not None
+        # Check buffer first
+        for i, msg in enumerate(self._event_buffer):
+            if self._matches_event(msg, event_name, session_id):
+                del self._event_buffer[i]
+                return msg.get("params", {})
+
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise CDPTimeoutError(
+                    f"event {event_name} timed out after {timeout}s",
+                    timeout=timeout,
+                )
+            try:
+                raw = self._ws.recv(timeout=remaining)
+            except _WebSocketTimeoutError as exc:
+                raise CDPTimeoutError(
+                    f"event {event_name} timed out after {timeout}s",
+                    timeout=timeout,
+                ) from exc
+
+            msg = json.loads(raw)
+            if self._matches_event(msg, event_name, session_id):
+                return msg.get("params", {})
+            self._event_buffer.append(msg)
+
+    @staticmethod
+    def _matches_event(
+        msg: dict,
+        event_name: str,
+        session_id: str | None,
+    ) -> bool:
+        """Check if a message matches the expected event."""
+        if msg.get("method") != event_name:
+            return False
+        if session_id is not None and msg.get("sessionId") != session_id:
+            return False
+        return True
+
+    @staticmethod
+    def _resolve_ws_url(url: str, *, timeout: float) -> str:
+        """Resolve the browser's debugger WebSocket URL.
+
+        If the URL already has a path (e.g. ``/devtools/browser/...``),
+        return it as-is. Otherwise, query the ``/json/version`` endpoint
+        to discover the WebSocket debugger URL.
+        """
+        import urllib.parse
+
+        parsed = urllib.parse.urlparse(url)
+        if parsed.path and parsed.path != "/":
+            return url
+
+        # Auto-discover via /json/version
+        host = parsed.hostname or "localhost"
+        port = parsed.port or 9222
+        http_url = f"http://{host}:{port}/json/version"
+
+        import http.client
+
+        try:
+            conn = http.client.HTTPConnection(host, port, timeout=timeout)
+            conn.request("GET", "/json/version")
+            resp = conn.getresponse()
+            data = json.loads(resp.read())
+            conn.close()
+            ws_url = data.get("webSocketDebuggerUrl", "")
+            if ws_url:
+                logger.debug("auto-discovered CDP endpoint: %s", ws_url)
+                return ws_url
+        except Exception:
+            logger.debug(
+                "failed to auto-discover CDP endpoint from %s",
+                http_url,
+                exc_info=True,
+            )
+
+        return url
+
+
+# ── Async CDP Client ──────────────────────────────────────────────────────
+
+
+class AsyncCDPClient:
+    """Asynchronous Chrome DevTools Protocol client.
+
+    Args:
+        url: CDP WebSocket endpoint URL (e.g. ``ws://localhost:9222``).
+        timeout: Default timeout for CDP commands in seconds.
+
+    Example::
+
+        async with AsyncCDPClient("ws://localhost:9222") as client:
+            text = await client.get_rendered_text("https://example.com")
+            print(text)
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self._url = url
+        self._timeout = timeout
+        self._ws: _AsyncWebSocketClient | None = None
+        self._cmd_id = itertools.count(1)
+        self._targets: dict[str, str] = {}
+        self._event_buffer: collections.deque[dict] = collections.deque()
+
+    async def connect(self, *, timeout: float | None = None) -> None:
+        """Open the WebSocket connection to the CDP endpoint.
+
+        Args:
+            timeout: Connection timeout in seconds.
+
+        Raises:
+            CDPConnectionError: If the connection fails.
+            ImportError: If the websocket module is not available.
+        """
+        if self._ws is not None:
+            return
+
+        if not _HAS_WEBSOCKET:
+            raise ImportError(
+                "cdp module requires sibling 'websocket' module; "
+                "install it with: zerodep add websocket"
+            )
+
+        ws_url = self._resolve_ws_url(self._url, timeout=timeout or self._timeout)
+
+        try:
+            ws = _AsyncWebSocketClient(ws_url)
+            await ws.connect(timeout=timeout or self._timeout)
+            self._ws = ws
+        except _WebSocketConnectionError as exc:
+            raise CDPConnectionError(
+                f"failed to connect to CDP endpoint: {exc}",
+                url=ws_url,
+            ) from exc
+        except _WebSocketTimeoutError as exc:
+            raise CDPTimeoutError(
+                f"connection to CDP endpoint timed out: {exc}",
+                timeout=timeout or self._timeout,
+            ) from exc
+
+    async def send_command(
+        self,
+        method: str,
+        params: dict | None = None,
+        *,
+        session_id: str | None = None,
+        timeout: float | None = None,
+    ) -> dict:
+        """Send a CDP command and wait for the response.
+
+        Args:
+            method: CDP method name.
+            params: Optional command parameters.
+            session_id: Optional session ID for target-specific commands.
+            timeout: Command timeout in seconds.
+
+        Returns:
+            The ``result`` dict from the CDP response.
+        """
+        self._ensure_connected()
+        assert self._ws is not None
+
+        cmd_id = next(self._cmd_id)
+        msg: dict = {"id": cmd_id, "method": method}
+        if params:
+            msg["params"] = params
+        if session_id:
+            msg["sessionId"] = session_id
+
+        await self._ws.send(json.dumps(msg))
+        return await self._recv_response(cmd_id, timeout=timeout or self._timeout)
+
+    async def create_target(self, url: str = "about:blank") -> str:
+        """Create a new browser target (tab) and attach to it.
+
+        Args:
+            url: Initial URL to load in the new target.
+
+        Returns:
+            The target ID.
+        """
+        result = await self.send_command("Target.createTarget", {"url": url})
+        target_id = result["targetId"]
+
+        attach_result = await self.send_command(
+            "Target.attachToTarget",
+            {"targetId": target_id, "flatten": True},
+        )
+        session_id = attach_result["sessionId"]
+        self._targets[target_id] = session_id
+        logger.debug("created target %s with session %s", target_id, session_id)
+        return target_id
+
+    async def close_target(self, target_id: str) -> None:
+        """Close a browser target (tab).
+
+        Args:
+            target_id: The target ID to close.
+        """
+        if target_id not in self._targets:
+            return
+        try:
+            await self.send_command("Target.closeTarget", {"targetId": target_id})
+        except CDPError:
+            logger.debug("failed to close target %s", target_id, exc_info=True)
+        self._targets.pop(target_id, None)
+
+    async def navigate(
+        self,
+        target_id: str,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        """Navigate a target to a URL and wait for the page to load.
+
+        Args:
+            target_id: The target ID.
+            url: URL to navigate to.
+            timeout: Page load timeout in seconds.
+        """
+        session_id = self._get_session_id(target_id)
+        load_timeout = timeout or DEFAULT_PAGE_LOAD_TIMEOUT
+
+        await self.send_command("Page.enable", session_id=session_id)
+        await self.send_command("Page.navigate", {"url": url}, session_id=session_id)
+        await self._wait_for_event(
+            "Page.loadEventFired",
+            session_id=session_id,
+            timeout=load_timeout,
+        )
+
+    async def wait_for_load(
+        self,
+        target_id: str,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        """Wait for a target's page to finish loading.
+
+        Args:
+            target_id: The target ID.
+            timeout: Page load timeout in seconds.
+        """
+        session_id = self._get_session_id(target_id)
+        await self.send_command("Page.enable", session_id=session_id)
+        await self._wait_for_event(
+            "Page.loadEventFired",
+            session_id=session_id,
+            timeout=timeout or DEFAULT_PAGE_LOAD_TIMEOUT,
+        )
+
+    async def evaluate(self, target_id: str, expression: str) -> object:
+        """Evaluate a JavaScript expression in a target.
+
+        Args:
+            target_id: The target ID.
+            expression: JavaScript expression to evaluate.
+
+        Returns:
+            The result value.
+
+        Raises:
+            CDPProtocolError: If the evaluation throws an exception.
+        """
+        session_id = self._get_session_id(target_id)
+        result = await self.send_command(
+            "Runtime.evaluate",
+            {"expression": expression, "returnByValue": True},
+            session_id=session_id,
+        )
+
+        if "exceptionDetails" in result:
+            exc_details = result["exceptionDetails"]
+            text = exc_details.get("text", "evaluation failed")
+            raise CDPProtocolError(-1, text)
+
+        return result.get("result", {}).get("value")
+
+    async def get_rendered_text(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """Navigate to a URL and extract the rendered text content.
+
+        Args:
+            url: URL to render.
+            timeout: Page load timeout in seconds.
+
+        Returns:
+            The rendered text content of the page.
+        """
+        target_id = await self.create_target()
+        try:
+            await self.navigate(target_id, url, timeout=timeout)
+            result = await self.evaluate(target_id, "document.body.innerText")
+            return result if isinstance(result, str) else str(result or "")
+        finally:
+            await self.close_target(target_id)
+
+    async def get_rendered_html(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """Navigate to a URL and extract the rendered HTML.
+
+        Args:
+            url: URL to render.
+            timeout: Page load timeout in seconds.
+
+        Returns:
+            The rendered outer HTML of the page.
+        """
+        target_id = await self.create_target()
+        try:
+            await self.navigate(target_id, url, timeout=timeout)
+            result = await self.evaluate(
+                target_id, "document.documentElement.outerHTML"
+            )
+            return result if isinstance(result, str) else str(result or "")
+        finally:
+            await self.close_target(target_id)
+
+    async def set_user_agent(self, target_id: str, user_agent: str) -> None:
+        """Override the User-Agent for a target.
+
+        Args:
+            target_id: The target ID.
+            user_agent: The User-Agent string to set.
+        """
+        session_id = self._get_session_id(target_id)
+        await self.send_command(
+            "Network.setUserAgentOverride",
+            {"userAgent": user_agent},
+            session_id=session_id,
+        )
+
+    async def close(self) -> None:
+        """Close all targets and the WebSocket connection."""
+        if self._ws is None:
+            return
+
+        for target_id in list(self._targets):
+            try:
+                await self.send_command("Target.closeTarget", {"targetId": target_id})
+            except (CDPError, _WebSocketError):
+                pass
+        self._targets.clear()
+        self._event_buffer.clear()
+
+        try:
+            await self._ws.close()
+        except _WebSocketError:
+            pass
+        self._ws = None
+
+    async def __aenter__(self) -> AsyncCDPClient:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+    # ── Async internal helpers ──
+
+    def _ensure_connected(self) -> None:
+        if self._ws is None:
+            raise CDPError("not connected")
+
+    def _get_session_id(self, target_id: str) -> str:
+        session_id = self._targets.get(target_id)
+        if session_id is None:
+            raise CDPError(f"unknown target: {target_id}")
+        return session_id
+
+    async def _recv_response(self, cmd_id: int, *, timeout: float) -> dict:
+        """Receive messages until the response matching *cmd_id* arrives."""
+        assert self._ws is not None
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise CDPTimeoutError(
+                    f"command {cmd_id} timed out after {timeout}s",
+                    timeout=timeout,
+                )
+            try:
+                raw = await self._ws.recv(timeout=remaining)
+            except _WebSocketTimeoutError as exc:
+                raise CDPTimeoutError(
+                    f"command {cmd_id} timed out after {timeout}s",
+                    timeout=timeout,
+                ) from exc
+
+            msg = json.loads(raw)
+            if msg.get("id") == cmd_id:
+                if "error" in msg:
+                    err = msg["error"]
+                    raise CDPProtocolError(
+                        err.get("code", -1),
+                        err.get("message", "unknown error"),
+                        data=err.get("data"),
+                    )
+                return msg.get("result", {})
+            self._event_buffer.append(msg)
+
+    async def _wait_for_event(
+        self,
+        event_name: str,
+        *,
+        session_id: str | None = None,
+        timeout: float,
+    ) -> dict:
+        """Wait for a specific CDP event."""
+        assert self._ws is not None
+        # Check buffer first
+        for i, msg in enumerate(self._event_buffer):
+            if self._matches_event(msg, event_name, session_id):
+                del self._event_buffer[i]
+                return msg.get("params", {})
+
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise CDPTimeoutError(
+                    f"event {event_name} timed out after {timeout}s",
+                    timeout=timeout,
+                )
+            try:
+                raw = await self._ws.recv(timeout=remaining)
+            except _WebSocketTimeoutError as exc:
+                raise CDPTimeoutError(
+                    f"event {event_name} timed out after {timeout}s",
+                    timeout=timeout,
+                ) from exc
+
+            msg = json.loads(raw)
+            if self._matches_event(msg, event_name, session_id):
+                return msg.get("params", {})
+            self._event_buffer.append(msg)
+
+    @staticmethod
+    def _matches_event(
+        msg: dict,
+        event_name: str,
+        session_id: str | None,
+    ) -> bool:
+        """Check if a message matches the expected event."""
+        if msg.get("method") != event_name:
+            return False
+        if session_id is not None and msg.get("sessionId") != session_id:
+            return False
+        return True
+
+    @staticmethod
+    def _resolve_ws_url(url: str, *, timeout: float) -> str:
+        """Resolve the browser's debugger WebSocket URL."""
+        # Reuse the sync implementation
+        return CDPClient._resolve_ws_url(url, timeout=timeout)

--- a/src/toolregistry_hub/_vendor/websocket/__init__.py
+++ b/src/toolregistry_hub/_vendor/websocket/__init__.py
@@ -1,0 +1,1 @@
+from .websocket import *  # noqa: F401,F403

--- a/src/toolregistry_hub/_vendor/websocket/websocket.py
+++ b/src/toolregistry_hub/_vendor/websocket/websocket.py
@@ -1,0 +1,1058 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = []
+# tier = "medium"
+# category = "network"
+# ///
+"""Zero-dependency WebSocket client (RFC 6455).
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Provides sync and async WebSocket clients for ``ws://`` and ``wss://``
+connections. Implements the core WebSocket protocol including text frames,
+ping/pong, close handshake, and client-side masking.
+
+Usage::
+
+    # Sync
+    from websocket import WebSocketClient
+
+    with WebSocketClient("ws://localhost:9222/") as ws:
+        ws.send("hello")
+        response = ws.recv()
+        print(response)
+
+    # Async
+    from websocket import AsyncWebSocketClient
+
+    async with AsyncWebSocketClient("wss://example.com/ws") as ws:
+        await ws.send('{"type": "subscribe"}')
+        data = await ws.recv()
+        print(data)
+
+Requires Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import logging
+import os
+import socket
+import ssl
+import struct
+import urllib.parse
+
+__all__ = [
+    # Constants
+    "DEFAULT_TIMEOUT",
+    # Exceptions
+    "WebSocketError",
+    "WebSocketConnectionError",
+    "WebSocketTimeoutError",
+    "WebSocketProtocolError",
+    # Clients
+    "WebSocketClient",
+    "AsyncWebSocketClient",
+]
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+DEFAULT_TIMEOUT: float = 30.0
+
+_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+_OPCODE_CONT = 0x0
+_OPCODE_TEXT = 0x1
+_OPCODE_BINARY = 0x2
+_OPCODE_CLOSE = 0x8
+_OPCODE_PING = 0x9
+_OPCODE_PONG = 0xA
+_MAX_PAYLOAD_SIZE = 2**23  # 8 MiB default max payload
+
+
+# ── Exceptions ─────────────────────────────────────────────────────────────
+
+
+class WebSocketError(Exception):
+    """Base exception for all websocket operations."""
+
+
+class WebSocketConnectionError(WebSocketError):
+    """Raised on connection failures (TCP connect, handshake reject)."""
+
+    def __init__(self, message: str, *, host: str = "", port: int = 0) -> None:
+        self.host = host
+        self.port = port
+        super().__init__(message)
+
+
+class WebSocketTimeoutError(WebSocketError):
+    """Raised when an operation times out."""
+
+    def __init__(self, message: str, *, url: str = "", timeout: float = 0.0) -> None:
+        self.url = url
+        self.timeout = timeout
+        super().__init__(message)
+
+
+class WebSocketProtocolError(WebSocketError):
+    """Raised on protocol violations (bad frame, unexpected opcode)."""
+
+
+# ── Shared protocol helpers (sync/async) ───────────────────────────────────
+
+
+def _parse_ws_url(url: str) -> tuple[str, int, str, bool]:
+    """Parse a WebSocket URL into (host, port, path, is_secure).
+
+    Args:
+        url: WebSocket URL (ws:// or wss://).
+
+    Returns:
+        Tuple of (host, port, resource_path, is_secure).
+
+    Raises:
+        ValueError: If the URL scheme is not ws or wss.
+    """
+    parsed = urllib.parse.urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in ("ws", "wss"):
+        raise ValueError(f"unsupported scheme: {scheme!r} (expected ws or wss)")
+    is_secure = scheme == "wss"
+    host = parsed.hostname or "localhost"
+    default_port = 443 if is_secure else 80
+    port = parsed.port or default_port
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return host, port, path, is_secure
+
+
+def _make_ssl_context(verify: bool) -> ssl.SSLContext:
+    """Create an SSL context based on verification setting."""
+    if verify:
+        return ssl.create_default_context()
+    return ssl._create_unverified_context()
+
+
+def _build_handshake_request(
+    host: str,
+    port: int,
+    path: str,
+    key: str,
+    *,
+    headers: dict[str, str] | None = None,
+    subprotocols: list[str] | None = None,
+    is_secure: bool = False,
+) -> bytes:
+    """Build the HTTP/1.1 WebSocket upgrade request.
+
+    Args:
+        host: Server hostname.
+        port: Server port.
+        path: Resource path.
+        key: Base64-encoded 16-byte random key.
+        headers: Optional extra headers to include.
+        subprotocols: Optional list of subprotocols to negotiate.
+        is_secure: Whether the connection uses TLS.
+
+    Returns:
+        The raw HTTP upgrade request as bytes.
+    """
+    default_port = 443 if is_secure else 80
+    if port == default_port:
+        host_header = host
+    else:
+        host_header = f"{host}:{port}"
+
+    lines = [
+        f"GET {path} HTTP/1.1",
+        f"Host: {host_header}",
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        f"Sec-WebSocket-Key: {key}",
+        "Sec-WebSocket-Version: 13",
+    ]
+    if subprotocols:
+        lines.append(f"Sec-WebSocket-Protocol: {', '.join(subprotocols)}")
+    if headers:
+        for k, v in headers.items():
+            lines.append(f"{k}: {v}")
+    lines.append("")
+    lines.append("")
+    return "\r\n".join(lines).encode("latin-1")
+
+
+def _compute_accept_key(key: str) -> str:
+    """Compute the expected Sec-WebSocket-Accept value."""
+    digest = hashlib.sha1((key + _WS_GUID).encode("ascii")).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def _validate_handshake_response(data: bytes, key: str) -> dict[str, str]:
+    """Parse and validate the HTTP upgrade response.
+
+    Args:
+        data: Raw HTTP response bytes (up to and including the blank line).
+        key: The Sec-WebSocket-Key sent in the request.
+
+    Returns:
+        Parsed response headers (lowercase keys).
+
+    Raises:
+        WebSocketConnectionError: If the handshake fails validation.
+    """
+    try:
+        text = data.decode("latin-1")
+    except UnicodeDecodeError as exc:
+        raise WebSocketConnectionError(
+            "handshake response is not valid latin-1"
+        ) from exc
+
+    header_end = text.find("\r\n\r\n")
+    if header_end < 0:
+        raise WebSocketConnectionError("incomplete handshake response")
+    header_block = text[: header_end + 2]  # include trailing \r\n
+
+    lines = header_block.split("\r\n")
+    if not lines:
+        raise WebSocketConnectionError("empty handshake response")
+
+    # Status line
+    status_line = lines[0]
+    parts = status_line.split(" ", 2)
+    if len(parts) < 2:
+        raise WebSocketConnectionError(f"malformed status line: {status_line!r}")
+    try:
+        status_code = int(parts[1])
+    except ValueError:
+        raise WebSocketConnectionError(f"non-integer status code: {parts[1]!r}")
+    if status_code != 101:
+        raise WebSocketConnectionError(
+            f"server rejected upgrade with status {status_code}"
+        )
+
+    # Headers
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if not line:
+            continue
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        headers[k.strip().lower()] = v.strip()
+
+    # Validate required headers
+    upgrade = headers.get("upgrade", "")
+    if upgrade.lower() != "websocket":
+        raise WebSocketConnectionError(
+            f"missing or invalid Upgrade header: {upgrade!r}"
+        )
+    connection = headers.get("connection", "")
+    if "upgrade" not in connection.lower():
+        raise WebSocketConnectionError(
+            f"missing or invalid Connection header: {connection!r}"
+        )
+    expected_accept = _compute_accept_key(key)
+    actual_accept = headers.get("sec-websocket-accept", "")
+    if actual_accept != expected_accept:
+        raise WebSocketConnectionError(
+            f"Sec-WebSocket-Accept mismatch: "
+            f"expected {expected_accept!r}, got {actual_accept!r}"
+        )
+
+    return headers
+
+
+def _make_frame(opcode: int, payload: bytes, *, mask: bool = True) -> bytes:
+    """Build a WebSocket frame.
+
+    Args:
+        opcode: Frame opcode (text, close, ping, pong, etc.).
+        payload: Frame payload bytes.
+        mask: Whether to apply client-side masking (required for client→server).
+
+    Returns:
+        The complete frame as bytes.
+    """
+    header = bytearray()
+    # First byte: FIN=1, RSV=0, opcode
+    header.append(0x80 | opcode)
+
+    length = len(payload)
+    mask_bit = 0x80 if mask else 0x00
+
+    if length < 126:
+        header.append(mask_bit | length)
+    elif length < 65536:
+        header.append(mask_bit | 126)
+        header.extend(struct.pack(">H", length))
+    else:
+        header.append(mask_bit | 127)
+        header.extend(struct.pack(">Q", length))
+
+    if mask:
+        mask_key = os.urandom(4)
+        header.extend(mask_key)
+        masked = _mask_payload(mask_key, payload)
+        return bytes(header) + masked
+    return bytes(header) + payload
+
+
+def _mask_payload(mask_key: bytes, data: bytes) -> bytes:
+    """Apply XOR masking to payload data.
+
+    Args:
+        mask_key: 4-byte mask key.
+        data: Payload bytes to mask/unmask.
+
+    Returns:
+        Masked/unmasked payload bytes.
+    """
+    result = bytearray(len(data))
+    for i, b in enumerate(data):
+        result[i] = b ^ mask_key[i & 3]
+    return bytes(result)
+
+
+def _parse_frame_header(
+    header_bytes: bytes,
+) -> tuple[bool, int, bool, int]:
+    """Parse the first 2 bytes of a WebSocket frame.
+
+    Args:
+        header_bytes: Exactly 2 bytes of frame header.
+
+    Returns:
+        Tuple of (fin, opcode, is_masked, payload_length_indicator).
+    """
+    b0 = header_bytes[0]
+    b1 = header_bytes[1]
+    fin = bool(b0 & 0x80)
+    opcode = b0 & 0x0F
+    is_masked = bool(b1 & 0x80)
+    length = b1 & 0x7F
+    return fin, opcode, is_masked, length
+
+
+def _make_close_payload(code: int, reason: str) -> bytes:
+    """Build the payload for a close frame.
+
+    Args:
+        code: Close status code (e.g. 1000 for normal closure).
+        reason: Human-readable close reason.
+
+    Returns:
+        Close frame payload bytes.
+    """
+    payload = struct.pack(">H", code)
+    if reason:
+        payload += reason.encode("utf-8")
+    return payload
+
+
+# ── Sync WebSocket Client ──────────────────────────────────────────────────
+
+
+class WebSocketClient:
+    """Synchronous WebSocket client.
+
+    Args:
+        url: WebSocket URL (``ws://`` or ``wss://``).
+        headers: Optional extra headers for the upgrade request.
+        subprotocols: Optional list of subprotocols to negotiate.
+
+    Example::
+
+        with WebSocketClient("ws://localhost:9222/") as ws:
+            ws.send("hello")
+            print(ws.recv())
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        subprotocols: list[str] | None = None,
+    ) -> None:
+        self._url = url
+        self._headers = headers
+        self._subprotocols = subprotocols
+        self._host, self._port, self._path, self._is_secure = _parse_ws_url(url)
+        self._sock: socket.socket | None = None
+        self._connected = False
+        self._closing = False
+        self._accepted_subprotocol: str | None = None
+
+    @property
+    def connected(self) -> bool:
+        """Whether the WebSocket connection is active."""
+        return self._connected
+
+    @property
+    def accepted_subprotocol(self) -> str | None:
+        """The subprotocol accepted by the server, if any."""
+        return self._accepted_subprotocol
+
+    def connect(
+        self,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        verify: bool = True,
+    ) -> None:
+        """Open the WebSocket connection.
+
+        Args:
+            timeout: Connection timeout in seconds.
+            verify: Whether to verify TLS certificates (for ``wss://``).
+
+        Raises:
+            WebSocketConnectionError: If the TCP connection or handshake fails.
+            WebSocketTimeoutError: If the connection times out.
+        """
+        if self._connected:
+            return
+
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            sock.connect((self._host, self._port))
+
+            if self._is_secure:
+                ctx = _make_ssl_context(verify)
+                sock = ctx.wrap_socket(sock, server_hostname=self._host)
+
+            # Send upgrade request
+            key = base64.b64encode(os.urandom(16)).decode("ascii")
+            request = _build_handshake_request(
+                self._host,
+                self._port,
+                self._path,
+                key,
+                headers=self._headers,
+                subprotocols=self._subprotocols,
+                is_secure=self._is_secure,
+            )
+            sock.sendall(request)
+
+            # Read response until \r\n\r\n
+            response = self._read_handshake_response(sock)
+            resp_headers = _validate_handshake_response(response, key)
+
+            # Check subprotocol
+            if self._subprotocols:
+                accepted = resp_headers.get("sec-websocket-protocol", "")
+                if accepted:
+                    self._accepted_subprotocol = accepted
+
+            self._sock = sock
+            self._connected = True
+            self._closing = False
+
+        except socket.timeout as exc:
+            raise WebSocketTimeoutError(
+                f"connection to {self._url} timed out after {timeout}s",
+                url=self._url,
+                timeout=timeout,
+            ) from exc
+        except OSError as exc:
+            raise WebSocketConnectionError(
+                f"failed to connect to {self._host}:{self._port}: {exc}",
+                host=self._host,
+                port=self._port,
+            ) from exc
+
+    def send(self, data: str) -> None:
+        """Send a text message.
+
+        Args:
+            data: Text message to send.
+
+        Raises:
+            WebSocketError: If not connected.
+        """
+        self._ensure_connected()
+        payload = data.encode("utf-8")
+        frame = _make_frame(_OPCODE_TEXT, payload, mask=True)
+        assert self._sock is not None
+        self._sock.sendall(frame)
+
+    def recv(self, *, timeout: float | None = None) -> str:
+        """Receive a text message.
+
+        Automatically handles ping frames by sending pong responses.
+        Raises on close frames.
+
+        Args:
+            timeout: Receive timeout in seconds. ``None`` uses the socket's
+                current timeout.
+
+        Returns:
+            The received text message.
+
+        Raises:
+            WebSocketTimeoutError: If the receive times out.
+            WebSocketProtocolError: On protocol errors.
+            WebSocketConnectionError: If the connection is closed.
+        """
+        self._ensure_connected()
+        assert self._sock is not None
+        old_timeout = self._sock.gettimeout()
+        if timeout is not None:
+            self._sock.settimeout(timeout)
+        try:
+            return self._recv_message()
+        except socket.timeout as exc:
+            raise WebSocketTimeoutError(
+                f"recv timed out after {timeout}s",
+                url=self._url,
+                timeout=timeout or 0.0,
+            ) from exc
+        finally:
+            if timeout is not None:
+                self._sock.settimeout(old_timeout)
+
+    def ping(self, data: bytes = b"") -> None:
+        """Send a ping frame.
+
+        Args:
+            data: Optional ping payload (max 125 bytes).
+        """
+        self._ensure_connected()
+        assert self._sock is not None
+        frame = _make_frame(_OPCODE_PING, data, mask=True)
+        self._sock.sendall(frame)
+
+    def close(self, code: int = 1000, reason: str = "") -> None:
+        """Close the WebSocket connection.
+
+        Sends a close frame, waits for the server's close frame response,
+        then closes the underlying socket.
+
+        Args:
+            code: Close status code (default 1000 for normal closure).
+            reason: Human-readable close reason.
+        """
+        if not self._connected or self._sock is None:
+            return
+
+        try:
+            if not self._closing:
+                self._closing = True
+                payload = _make_close_payload(code, reason)
+                frame = _make_frame(_OPCODE_CLOSE, payload, mask=True)
+                self._sock.sendall(frame)
+
+                # Try to receive server's close frame
+                old_timeout = self._sock.gettimeout()
+                self._sock.settimeout(2.0)
+                try:
+                    while True:
+                        opcode, _, _ = self._read_frame()
+                        if opcode == _OPCODE_CLOSE:
+                            break
+                except (socket.timeout, WebSocketError, OSError):
+                    pass
+                finally:
+                    try:
+                        self._sock.settimeout(old_timeout)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+        finally:
+            self._shutdown()
+
+    def __enter__(self) -> WebSocketClient:
+        self.connect()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # ── Sync internal helpers ──
+
+    def _ensure_connected(self) -> None:
+        if not self._connected or self._sock is None:
+            raise WebSocketError("not connected")
+
+    def _shutdown(self) -> None:
+        """Close the socket and reset state."""
+        if self._sock is not None:
+            try:
+                self._sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+        self._connected = False
+        self._closing = False
+
+    def _recv_message(self) -> str:
+        """Read frames until a complete text message is received."""
+        assert self._sock is not None
+        while True:
+            opcode, payload, fin = self._read_frame()
+
+            if opcode == _OPCODE_TEXT:
+                if not fin:
+                    raise WebSocketProtocolError(
+                        "fragmented messages are not supported"
+                    )
+                return payload.decode("utf-8")
+
+            if opcode == _OPCODE_PING:
+                pong = _make_frame(_OPCODE_PONG, payload, mask=True)
+                self._sock.sendall(pong)
+                continue
+
+            if opcode == _OPCODE_PONG:
+                continue
+
+            if opcode == _OPCODE_CLOSE:
+                close_code = 1005
+                close_reason = ""
+                if len(payload) >= 2:
+                    close_code = struct.unpack(">H", payload[:2])[0]
+                    close_reason = payload[2:].decode("utf-8", errors="replace")
+                # Send close response if we didn't initiate
+                if not self._closing:
+                    self._closing = True
+                    resp_payload = _make_close_payload(close_code, "")
+                    resp_frame = _make_frame(_OPCODE_CLOSE, resp_payload, mask=True)
+                    try:
+                        self._sock.sendall(resp_frame)
+                    except OSError:
+                        pass
+                self._shutdown()
+                raise WebSocketConnectionError(
+                    f"connection closed by server: {close_code} {close_reason}",
+                    host=self._host,
+                    port=self._port,
+                )
+
+            if opcode == _OPCODE_BINARY:
+                raise WebSocketProtocolError("binary frames are not supported")
+
+            raise WebSocketProtocolError(f"unexpected opcode: {opcode:#x}")
+
+    def _read_frame(self) -> tuple[int, bytes, bool]:
+        """Read a single WebSocket frame from the socket.
+
+        Returns:
+            Tuple of (opcode, payload, fin).
+        """
+        assert self._sock is not None
+        header = _recv_exact(self._sock, 2)
+        fin, opcode, is_masked, length = _parse_frame_header(header)
+
+        # Extended payload length
+        if length == 126:
+            ext = _recv_exact(self._sock, 2)
+            length = struct.unpack(">H", ext)[0]
+        elif length == 127:
+            ext = _recv_exact(self._sock, 8)
+            length = struct.unpack(">Q", ext)[0]
+
+        if length > _MAX_PAYLOAD_SIZE:
+            raise WebSocketProtocolError(
+                f"payload too large: {length} bytes (max {_MAX_PAYLOAD_SIZE})"
+            )
+
+        # Mask key (server should not mask, but handle it)
+        mask_key = None
+        if is_masked:
+            mask_key = _recv_exact(self._sock, 4)
+
+        # Payload
+        payload = _recv_exact(self._sock, length) if length > 0 else b""
+        if mask_key:
+            payload = _mask_payload(mask_key, payload)
+
+        return opcode, payload, fin
+
+    @staticmethod
+    def _read_handshake_response(sock: socket.socket) -> bytes:
+        """Read the HTTP handshake response until \\r\\n\\r\\n."""
+        buf = bytearray()
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                raise WebSocketConnectionError("connection closed during handshake")
+            buf.extend(chunk)
+            if b"\r\n\r\n" in buf:
+                return bytes(buf)
+            if len(buf) > 65536:
+                raise WebSocketConnectionError("handshake response too large")
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    """Read exactly *n* bytes from a socket, handling partial reads.
+
+    Args:
+        sock: Connected socket.
+        n: Number of bytes to read.
+
+    Returns:
+        Exactly *n* bytes.
+
+    Raises:
+        WebSocketConnectionError: If the socket closes before *n* bytes arrive.
+    """
+    if n == 0:
+        return b""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise WebSocketConnectionError(
+                f"connection closed: expected {n} bytes, got {len(buf)}"
+            )
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+# ── Async WebSocket Client ─────────────────────────────────────────────────
+
+
+class AsyncWebSocketClient:
+    """Asynchronous WebSocket client.
+
+    Args:
+        url: WebSocket URL (``ws://`` or ``wss://``).
+        headers: Optional extra headers for the upgrade request.
+        subprotocols: Optional list of subprotocols to negotiate.
+
+    Example::
+
+        async with AsyncWebSocketClient("wss://example.com/ws") as ws:
+            await ws.send("hello")
+            print(await ws.recv())
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        subprotocols: list[str] | None = None,
+    ) -> None:
+        self._url = url
+        self._headers = headers
+        self._subprotocols = subprotocols
+        self._host, self._port, self._path, self._is_secure = _parse_ws_url(url)
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._connected = False
+        self._closing = False
+        self._accepted_subprotocol: str | None = None
+
+    @property
+    def connected(self) -> bool:
+        """Whether the WebSocket connection is active."""
+        return self._connected
+
+    @property
+    def accepted_subprotocol(self) -> str | None:
+        """The subprotocol accepted by the server, if any."""
+        return self._accepted_subprotocol
+
+    async def connect(
+        self,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        verify: bool = True,
+    ) -> None:
+        """Open the WebSocket connection.
+
+        Args:
+            timeout: Connection timeout in seconds.
+            verify: Whether to verify TLS certificates (for ``wss://``).
+
+        Raises:
+            WebSocketConnectionError: If the TCP connection or handshake fails.
+            WebSocketTimeoutError: If the connection times out.
+        """
+        if self._connected:
+            return
+
+        try:
+            ssl_ctx = _make_ssl_context(verify) if self._is_secure else None
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(self._host, self._port, ssl=ssl_ctx),
+                timeout=timeout,
+            )
+
+            # Send upgrade request
+            key = base64.b64encode(os.urandom(16)).decode("ascii")
+            request = _build_handshake_request(
+                self._host,
+                self._port,
+                self._path,
+                key,
+                headers=self._headers,
+                subprotocols=self._subprotocols,
+                is_secure=self._is_secure,
+            )
+            writer.write(request)
+            await writer.drain()
+
+            # Read response until \r\n\r\n
+            response = await asyncio.wait_for(
+                self._async_read_handshake_response(reader),
+                timeout=timeout,
+            )
+            resp_headers = _validate_handshake_response(response, key)
+
+            # Check subprotocol
+            if self._subprotocols:
+                accepted = resp_headers.get("sec-websocket-protocol", "")
+                if accepted:
+                    self._accepted_subprotocol = accepted
+
+            self._reader = reader
+            self._writer = writer
+            self._connected = True
+            self._closing = False
+
+        except asyncio.TimeoutError as exc:
+            raise WebSocketTimeoutError(
+                f"connection to {self._url} timed out after {timeout}s",
+                url=self._url,
+                timeout=timeout,
+            ) from exc
+        except OSError as exc:
+            raise WebSocketConnectionError(
+                f"failed to connect to {self._host}:{self._port}: {exc}",
+                host=self._host,
+                port=self._port,
+            ) from exc
+
+    async def send(self, data: str) -> None:
+        """Send a text message.
+
+        Args:
+            data: Text message to send.
+
+        Raises:
+            WebSocketError: If not connected.
+        """
+        self._ensure_connected()
+        assert self._writer is not None
+        payload = data.encode("utf-8")
+        frame = _make_frame(_OPCODE_TEXT, payload, mask=True)
+        self._writer.write(frame)
+        await self._writer.drain()
+
+    async def recv(self, *, timeout: float | None = None) -> str:
+        """Receive a text message.
+
+        Automatically handles ping frames by sending pong responses.
+        Raises on close frames.
+
+        Args:
+            timeout: Receive timeout in seconds. ``None`` waits indefinitely.
+
+        Returns:
+            The received text message.
+
+        Raises:
+            WebSocketTimeoutError: If the receive times out.
+            WebSocketProtocolError: On protocol errors.
+            WebSocketConnectionError: If the connection is closed.
+        """
+        self._ensure_connected()
+        try:
+            if timeout is not None:
+                return await asyncio.wait_for(self._recv_message(), timeout=timeout)
+            return await self._recv_message()
+        except asyncio.TimeoutError as exc:
+            raise WebSocketTimeoutError(
+                f"recv timed out after {timeout}s",
+                url=self._url,
+                timeout=timeout or 0.0,
+            ) from exc
+
+    async def ping(self, data: bytes = b"") -> None:
+        """Send a ping frame.
+
+        Args:
+            data: Optional ping payload (max 125 bytes).
+        """
+        self._ensure_connected()
+        assert self._writer is not None
+        frame = _make_frame(_OPCODE_PING, data, mask=True)
+        self._writer.write(frame)
+        await self._writer.drain()
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        """Close the WebSocket connection.
+
+        Sends a close frame, waits for the server's close frame response,
+        then closes the underlying transport.
+
+        Args:
+            code: Close status code (default 1000 for normal closure).
+            reason: Human-readable close reason.
+        """
+        if not self._connected or self._writer is None:
+            return
+
+        try:
+            if not self._closing:
+                self._closing = True
+                payload = _make_close_payload(code, reason)
+                frame = _make_frame(_OPCODE_CLOSE, payload, mask=True)
+                self._writer.write(frame)
+                await self._writer.drain()
+
+                # Try to receive server's close frame
+                try:
+                    while True:
+                        opcode, _, _ = await asyncio.wait_for(
+                            self._read_frame(), timeout=2.0
+                        )
+                        if opcode == _OPCODE_CLOSE:
+                            break
+                except (asyncio.TimeoutError, WebSocketError, OSError):
+                    pass
+        except OSError:
+            pass
+        finally:
+            await self._shutdown()
+
+    async def __aenter__(self) -> AsyncWebSocketClient:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+    # ── Async internal helpers ──
+
+    def _ensure_connected(self) -> None:
+        if not self._connected or self._reader is None or self._writer is None:
+            raise WebSocketError("not connected")
+
+    async def _shutdown(self) -> None:
+        """Close the transport and reset state."""
+        if self._writer is not None:
+            try:
+                self._writer.close()
+                await self._writer.wait_closed()
+            except OSError:
+                pass
+            self._writer = None
+        self._reader = None
+        self._connected = False
+        self._closing = False
+
+    async def _recv_message(self) -> str:
+        """Read frames until a complete text message is received."""
+        assert self._writer is not None
+        while True:
+            opcode, payload, fin = await self._read_frame()
+
+            if opcode == _OPCODE_TEXT:
+                if not fin:
+                    raise WebSocketProtocolError(
+                        "fragmented messages are not supported"
+                    )
+                return payload.decode("utf-8")
+
+            if opcode == _OPCODE_PING:
+                pong = _make_frame(_OPCODE_PONG, payload, mask=True)
+                self._writer.write(pong)
+                await self._writer.drain()
+                continue
+
+            if opcode == _OPCODE_PONG:
+                continue
+
+            if opcode == _OPCODE_CLOSE:
+                close_code = 1005
+                close_reason = ""
+                if len(payload) >= 2:
+                    close_code = struct.unpack(">H", payload[:2])[0]
+                    close_reason = payload[2:].decode("utf-8", errors="replace")
+                # Send close response if we didn't initiate
+                if not self._closing:
+                    self._closing = True
+                    resp_payload = _make_close_payload(close_code, "")
+                    resp_frame = _make_frame(_OPCODE_CLOSE, resp_payload, mask=True)
+                    try:
+                        self._writer.write(resp_frame)
+                        await self._writer.drain()
+                    except OSError:
+                        pass
+                await self._shutdown()
+                raise WebSocketConnectionError(
+                    f"connection closed by server: {close_code} {close_reason}",
+                    host=self._host,
+                    port=self._port,
+                )
+
+            if opcode == _OPCODE_BINARY:
+                raise WebSocketProtocolError("binary frames are not supported")
+
+            raise WebSocketProtocolError(f"unexpected opcode: {opcode:#x}")
+
+    async def _read_frame(self) -> tuple[int, bytes, bool]:
+        """Read a single WebSocket frame from the stream.
+
+        Returns:
+            Tuple of (opcode, payload, fin).
+        """
+        assert self._reader is not None
+        header = await self._reader.readexactly(2)
+        fin, opcode, is_masked, length = _parse_frame_header(header)
+
+        # Extended payload length
+        if length == 126:
+            ext = await self._reader.readexactly(2)
+            length = struct.unpack(">H", ext)[0]
+        elif length == 127:
+            ext = await self._reader.readexactly(8)
+            length = struct.unpack(">Q", ext)[0]
+
+        if length > _MAX_PAYLOAD_SIZE:
+            raise WebSocketProtocolError(
+                f"payload too large: {length} bytes (max {_MAX_PAYLOAD_SIZE})"
+            )
+
+        # Mask key (server should not mask, but handle it)
+        mask_key = None
+        if is_masked:
+            mask_key = await self._reader.readexactly(4)
+
+        # Payload
+        payload = await self._reader.readexactly(length) if length > 0 else b""
+        if mask_key:
+            payload = _mask_payload(mask_key, payload)
+
+        return opcode, payload, fin
+
+    @staticmethod
+    async def _async_read_handshake_response(
+        reader: asyncio.StreamReader,
+    ) -> bytes:
+        """Read the HTTP handshake response until \\r\\n\\r\\n."""
+        buf = bytearray()
+        while True:
+            chunk = await reader.read(4096)
+            if not chunk:
+                raise WebSocketConnectionError("connection closed during handshake")
+            buf.extend(chunk)
+            if b"\r\n\r\n" in buf:
+                return bytes(buf)
+            if len(buf) > 65536:
+                raise WebSocketConnectionError("handshake response too large")

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import os
 import re
 import time
 import unicodedata
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 from ._vendor.httpclient import (
     HttpConnectionError,
     HTTPError,
     HttpTimeoutError,
+    Response,
 )
 from ._vendor.httpclient import (
     get as _http_get,
@@ -132,14 +134,22 @@ class Fetch:
     failure tracking.
     """
 
-    def __init__(self, api_keys: str | None = None):
-        """Initialize Fetch with optional Jina Reader API keys.
+    def __init__(
+        self,
+        api_keys: str | None = None,
+        cdp_endpoint: str | None = None,
+    ):
+        """Initialize Fetch with optional Jina Reader API keys and CDP endpoint.
 
         Args:
             api_keys: Comma-separated Jina API keys. Falls back to
                 the ``JINA_API_KEY`` environment variable if not provided.
                 When set, requests to the Jina Reader API include an
                 ``Authorization: Bearer <key>`` header.
+            cdp_endpoint: WebSocket URL of a CDP-compatible browser
+                (e.g. ``ws://localhost:9222``).  Falls back to the
+                ``CDP_ENDPOINT`` environment variable.  When set, SPA
+                pages are rendered via CDP before falling back to Jina.
         """
         from .utils.api_key_parser import APIKeyParser
 
@@ -149,6 +159,7 @@ class Fetch:
             rate_limit_delay=0.0,
         )
         self.api_key_parser: APIKeyParser | None = parser if parser.api_keys else None
+        self.cdp_endpoint: str | None = cdp_endpoint or os.environ.get("CDP_ENDPOINT")
 
     def _is_configured(self) -> bool:
         """Check if Fetch is configured.
@@ -190,6 +201,7 @@ class Fetch:
                 timeout=timeout,
                 proxy=proxy,
                 api_key_parser=self.api_key_parser,
+                cdp_endpoint=self.cdp_endpoint,
             )
         except FetchError:
             raise
@@ -277,11 +289,129 @@ def _pick_local_content(
     return ""
 
 
+def _render_with_cdp(
+    url: str,
+    cdp_endpoint: str,
+    timeout: float = 15.0,
+) -> str:
+    """Render a page via CDP and return the rendered HTML.
+
+    Connects to a CDP-compatible browser, navigates to the URL,
+    waits for page load, and extracts the fully-rendered HTML
+    (post-JavaScript execution).
+
+    Args:
+        url: The URL to render.
+        cdp_endpoint: WebSocket URL of the CDP browser
+            (e.g. ``ws://localhost:9222``).
+        timeout: Maximum time in seconds to wait for page load.
+
+    Returns:
+        Rendered HTML string, or empty string on any failure.
+    """
+    try:
+        from ._vendor.cdp import CDPClient
+
+        with CDPClient(cdp_endpoint, timeout=timeout) as client:
+            html = client.get_rendered_html(url, timeout=timeout)
+            if html:
+                logger.debug(f"CDP rendered {url}: {len(html)} chars of HTML")
+            return html or ""
+    except Exception as e:
+        logger.debug(f"CDP rendering failed for {url}: {e}")
+        return ""
+
+
+def _try_cdp_extraction(
+    url: str,
+    cdp_endpoint: str,
+    timeout: float,
+) -> tuple[str, str]:
+    """Render a page with CDP and attempt readability/soup extraction.
+
+    Args:
+        url: The URL to render.
+        cdp_endpoint: WebSocket endpoint for the CDP browser.
+        timeout: Budget in seconds for the CDP render.
+
+    Returns:
+        A ``(best_content, local_content)`` tuple.  ``best_content`` is non-empty
+        when extraction produced sufficient content; ``local_content`` is the best
+        partial result for final-fallback stashing.
+    """
+    rendered_html = _render_with_cdp(url, cdp_endpoint, timeout=timeout)
+    if not rendered_html:
+        return "", ""
+
+    cdp_readability = _extract_with_readability(rendered_html, url)
+    cdp_soup = _extract_with_soup(rendered_html)
+    cdp_best = _pick_local_content(cdp_readability, cdp_soup, url)
+    if cdp_best:
+        logger.info(f"Successfully fetched {url} using strategy: cdp")
+        return cdp_best, ""
+    return "", cdp_readability or cdp_soup or ""
+
+
+def _try_jina_extraction(
+    url: str,
+    *,
+    local_content: str,
+    timeout: float,
+    remaining: float,
+    proxy: str | None,
+    api_key_parser: APIKeyParser | None,
+    deadline: float,
+) -> str:
+    """Attempt Jina Reader extraction as the final network strategy.
+
+    Args:
+        url: The URL to extract content from.
+        local_content: Best local extraction result so far (for logging).
+        timeout: Original total timeout.
+        remaining: Time remaining in the budget.
+        proxy: Proxy to use for the request.
+        api_key_parser: Optional API key parser for Jina Reader.
+        deadline: Absolute wall-clock deadline.
+
+    Returns:
+        Sufficient Jina content, or empty string on failure.
+    """
+    reason = "low_quality_content" if local_content else "no_content"
+    if remaining <= _MIN_STRATEGY_BUDGET:
+        logger.debug(
+            f"Skipping Jina Reader for {url}: deadline exceeded "
+            f"(reason: {reason}, length: {len(local_content)})"
+        )
+        return ""
+
+    logger.debug(
+        f"Local extraction insufficient for {url} (reason: {reason}, "
+        f"length: {len(local_content)}), trying Jina Reader"
+    )
+
+    jina_content = _get_content_with_jina_reader(
+        url,
+        timeout=min(timeout, remaining),
+        proxy=proxy,
+        api_key_parser=api_key_parser,
+        deadline=deadline,
+    )
+
+    if jina_content and _is_content_sufficient(jina_content):
+        logger.info(
+            f"Successfully fetched {url} using strategy: jina_reader "
+            f"(local reason: {reason})"
+        )
+        return jina_content
+    return ""
+
+
 def _extract(
     url: str,
     timeout: float = TIMEOUT_DEFAULT,
     proxy: str | None = None,
     api_key_parser: APIKeyParser | None = None,
+    cdp_endpoint: str | None = None,
 ) -> str:
     """Extract content from a given URL using available methods.
 
@@ -289,7 +419,8 @@ def _extract(
     1. Cloudflare Content Negotiation (zero-cost markdown attempt)
     2. Readability extraction (intelligent article scoring, local)
     3. Simple soup extraction (CSS selector fallback, local)
-    4. Jina Reader (external API fallback for SPA / JS-heavy pages)
+    4. CDP rendering (self-hosted browser, re-parsed with readability/soup)
+    5. Jina Reader (external API fallback for SPA / JS-heavy pages)
 
     HTML is fetched once and reused by stages 2 and 3.  ``timeout`` is a
     wall-clock budget for the *whole* operation; strategies are skipped once
@@ -362,36 +493,29 @@ def _extract(
         # Stash best local result for final fallback
         local_content = readability_content or soup_content or ""
 
-    # 4. Local extraction insufficient — try Jina Reader
-    reason = "low_quality_content" if local_content else "no_content"
-    jina_content = ""
-    if _remaining() > _MIN_STRATEGY_BUDGET:
-        logger.debug(
-            f"Local extraction insufficient for {url} (reason: {reason}, "
-            f"length: {len(local_content)}), trying Jina Reader"
-        )
+    # 4. Try CDP rendering (self-hosted browser) if configured
+    if cdp_endpoint and _remaining() > _MIN_STRATEGY_BUDGET:
+        cdp_budget = min(_remaining(), 15.0)
+        cdp_result, cdp_local = _try_cdp_extraction(url, cdp_endpoint, cdp_budget)
+        if cdp_result:
+            return _format_text(cdp_result)
+        if len(cdp_local) > len(local_content):
+            local_content = cdp_local
 
-        jina_content = _get_content_with_jina_reader(
-            url,
-            timeout=min(timeout, _remaining()),
-            proxy=proxy,
-            api_key_parser=api_key_parser,
-            deadline=deadline,
-        )
+    # 5. Local extraction insufficient — try Jina Reader
+    jina_content = _try_jina_extraction(
+        url,
+        local_content=local_content,
+        timeout=timeout,
+        remaining=_remaining(),
+        proxy=proxy,
+        api_key_parser=api_key_parser,
+        deadline=deadline,
+    )
+    if jina_content:
+        return _format_text(jina_content)
 
-        if jina_content and _is_content_sufficient(jina_content):
-            logger.info(
-                f"Successfully fetched {url} using strategy: jina_reader "
-                f"(local reason: {reason})"
-            )
-            return _format_text(jina_content)
-    else:
-        logger.debug(
-            f"Skipping Jina Reader for {url}: deadline exceeded "
-            f"(reason: {reason}, length: {len(local_content)})"
-        )
-
-    # 5. Fall back to best local result if available
+    # 6. Fall back to best local result if available
     if local_content:
         logger.info(
             f"Successfully fetched {url} using strategy: local_fallback "
@@ -429,11 +553,14 @@ def _get_content_with_markdown_negotiation(
         ua.headers.accept_ch("Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List")
         headers = ua.headers.get()
         headers["Accept"] = "text/markdown"
-        response = _http_get(
-            url,
-            headers=headers,
-            timeout=timeout,
-            proxy=proxy,
+        response = cast(
+            Response,
+            _http_get(
+                url,
+                headers=headers,
+                timeout=timeout,
+                proxy=proxy,
+            ),
         )
         response.raise_for_status()
 
@@ -596,12 +723,15 @@ def _jina_reader_request(
 
         jina_reader_url = "https://r.jina.ai/"
         logger.debug(f"Jina Reader request for {url} (engine: {engine})")
-        response = _http_post(
-            jina_reader_url,
-            json={"url": url},
-            headers=headers,
-            timeout=transport_timeout,
-            proxy=proxy,
+        response = cast(
+            Response,
+            _http_post(
+                jina_reader_url,
+                json={"url": url},
+                headers=headers,
+                timeout=transport_timeout,
+                proxy=proxy,
+            ),
         )
         response.raise_for_status()
 
@@ -673,11 +803,14 @@ def _fetch_raw(
             ua.headers.accept_ch(
                 "Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List"
             )
-            response = _http_get(
-                url,
-                headers=ua.headers.get(),
-                timeout=per_attempt_timeout,
-                proxy=proxy,
+            response = cast(
+                Response,
+                _http_get(
+                    url,
+                    headers=ua.headers.get(),
+                    timeout=per_attempt_timeout,
+                    proxy=proxy,
+                ),
             )
             response.raise_for_status()
             # Extract the MIME type (drop charset and parameters).

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -28,6 +28,7 @@ from toolregistry_hub.fetch import (
     _get_content_with_markdown_negotiation,
     _is_content_sufficient,
     _jina_reader_request,
+    _render_with_cdp,
 )
 from toolregistry_hub.utils.api_key_parser import APIKeyParser
 
@@ -1232,3 +1233,193 @@ class TestExtractBudget:
         call_kwargs = mock_fetch.call_args
         assert "deadline" in call_kwargs.kwargs
         assert isinstance(call_kwargs.kwargs["deadline"], float)
+
+
+# ============================================================
+# _render_with_cdp tests
+# ============================================================
+
+
+class TestRenderWithCDP:
+    """Tests for the _render_with_cdp helper."""
+
+    @patch("toolregistry_hub._vendor.cdp.CDPClient")
+    def test_success_returns_html(self, mock_cdp_cls):
+        ctx = MagicMock()
+        ctx.get_rendered_html.return_value = "<html><body>Rendered</body></html>"
+        mock_cdp_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+        mock_cdp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = _render_with_cdp("https://spa.example.com", "ws://localhost:9222")
+        assert result == "<html><body>Rendered</body></html>"
+        ctx.get_rendered_html.assert_called_once_with(
+            "https://spa.example.com", timeout=15.0
+        )
+
+    @patch("toolregistry_hub._vendor.cdp.CDPClient")
+    def test_connection_error_returns_empty(self, mock_cdp_cls):
+        mock_cdp_cls.return_value.__enter__ = MagicMock(
+            side_effect=ConnectionError("refused")
+        )
+        mock_cdp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = _render_with_cdp("https://spa.example.com", "ws://localhost:9222")
+        assert result == ""
+
+    @patch("toolregistry_hub._vendor.cdp.CDPClient")
+    def test_timeout_returns_empty(self, mock_cdp_cls):
+        ctx = MagicMock()
+        ctx.get_rendered_html.side_effect = TimeoutError("page load timed out")
+        mock_cdp_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+        mock_cdp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = _render_with_cdp("https://spa.example.com", "ws://localhost:9222")
+        assert result == ""
+
+    @patch("toolregistry_hub._vendor.cdp.CDPClient")
+    def test_none_html_returns_empty(self, mock_cdp_cls):
+        ctx = MagicMock()
+        ctx.get_rendered_html.return_value = None
+        mock_cdp_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+        mock_cdp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = _render_with_cdp("https://spa.example.com", "ws://localhost:9222")
+        assert result == ""
+
+    @patch("toolregistry_hub._vendor.cdp.CDPClient")
+    def test_custom_timeout(self, mock_cdp_cls):
+        ctx = MagicMock()
+        ctx.get_rendered_html.return_value = "<html>OK</html>"
+        mock_cdp_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+        mock_cdp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        _render_with_cdp("https://example.com", "ws://localhost:9222", timeout=5.0)
+        mock_cdp_cls.assert_called_once_with("ws://localhost:9222", timeout=5.0)
+        ctx.get_rendered_html.assert_called_once_with(
+            "https://example.com", timeout=5.0
+        )
+
+
+# ============================================================
+# CDP integration in _extract tests
+# ============================================================
+
+
+class TestExtractWithCDP:
+    """Tests for CDP rendering stage in _extract."""
+
+    @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
+    @patch("toolregistry_hub.fetch._try_cdp_extraction")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_raw")
+    @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
+    def test_cdp_renders_spa_successfully(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_cdp, mock_jina
+    ):
+        """CDP renders a SPA shell into usable content."""
+        mock_md.return_value = ""
+        mock_fetch.return_value = ("<html><div id='root'></div></html>", "text/html")
+        mock_readability.return_value = ""
+        mock_soup.return_value = ""
+
+        # _try_cdp_extraction returns (best_content, local_content)
+        mock_cdp.return_value = ("Full article content. " * 10, "")
+
+        result = _extract("https://spa.example.com", cdp_endpoint="ws://localhost:9222")
+        assert "Full article content" in result
+        mock_cdp.assert_called_once()
+        mock_jina.assert_not_called()
+
+    @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
+    @patch("toolregistry_hub.fetch._try_cdp_extraction")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_raw")
+    @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
+    def test_cdp_fails_falls_through_to_jina(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_cdp, mock_jina
+    ):
+        """When CDP fails, pipeline falls through to Jina."""
+        mock_md.return_value = ""
+        mock_fetch.return_value = ("<html></html>", "text/html")
+        mock_readability.return_value = ""
+        mock_soup.return_value = ""
+        mock_cdp.return_value = ("", "")  # CDP failed
+        mock_jina.return_value = "# Jina Content\nFull article from Jina. " * 10
+
+        result = _extract("https://spa.example.com", cdp_endpoint="ws://localhost:9222")
+        assert "Jina Content" in result
+        mock_cdp.assert_called_once()
+        mock_jina.assert_called_once()
+
+    @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
+    @patch("toolregistry_hub.fetch._try_cdp_extraction")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_raw")
+    @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
+    def test_cdp_unconfigured_skips_to_jina(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_cdp, mock_jina
+    ):
+        """When cdp_endpoint is None, CDP is skipped entirely."""
+        mock_md.return_value = ""
+        mock_fetch.return_value = ("<html></html>", "text/html")
+        mock_readability.return_value = ""
+        mock_soup.return_value = ""
+        # Must be long enough to pass _is_content_sufficient
+        sufficient = (
+            "# Jina Content\nThis is a full article with detailed information "
+            "about the topic at hand, providing comprehensive coverage. " * 5
+        )
+        mock_jina.return_value = sufficient
+
+        result = _extract("https://spa.example.com")  # No cdp_endpoint
+        assert "Jina Content" in result
+        mock_cdp.assert_not_called()
+        mock_jina.assert_called_once()
+
+    @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
+    @patch("toolregistry_hub.fetch._try_cdp_extraction")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_raw")
+    @patch("toolregistry_hub.fetch._get_content_with_markdown_negotiation")
+    def test_cdp_renders_but_content_still_insufficient(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_cdp, mock_jina
+    ):
+        """CDP renders HTML but content is still insufficient → falls through to Jina."""
+        mock_md.return_value = ""
+        mock_fetch.return_value = ("<html></html>", "text/html")
+        mock_readability.return_value = ""
+        mock_soup.return_value = ""
+
+        # CDP rendered but content insufficient — returns partial in local_content
+        mock_cdp.return_value = ("", "Still too short")
+
+        mock_jina.return_value = "# Full Jina Content\nComplete article. " * 10
+
+        result = _extract("https://spa.example.com", cdp_endpoint="ws://localhost:9222")
+        assert "Full Jina Content" in result
+        mock_cdp.assert_called_once()
+        mock_jina.assert_called_once()
+
+    def test_fetch_instance_accepts_cdp_endpoint(self):
+        """Fetch constructor accepts cdp_endpoint parameter."""
+        fetcher = Fetch(cdp_endpoint="ws://localhost:9222")
+        assert fetcher.cdp_endpoint == "ws://localhost:9222"
+
+    def test_fetch_instance_cdp_endpoint_default_none(self):
+        """Without cdp_endpoint, it defaults to None (or env var)."""
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("CDP_ENDPOINT", None)
+            fetcher = Fetch()
+            assert fetcher.cdp_endpoint is None
+
+    @patch.dict("os.environ", {"CDP_ENDPOINT": "ws://env-browser:9222"})
+    def test_fetch_instance_cdp_endpoint_from_env(self):
+        """CDP endpoint can be configured via CDP_ENDPOINT env var."""
+        fetcher = Fetch()
+        assert fetcher.cdp_endpoint == "ws://env-browser:9222"


### PR DESCRIPTION
## Summary

- Integrates CDP (Chrome DevTools Protocol) as a self-hosted rendering fallback in the fetch pipeline, between local extraction (readability/soup) and Jina Reader
- Vendors `cdp` and `websocket` modules with `--nested` layout to fix the sibling import mechanism (`_ensure_sibling_path`)
- Adds `cdp_endpoint` parameter to `Fetch.__init__` (also configurable via `CDP_ENDPOINT` env var)
- Fixes pre-existing `ty` type checker warnings in fetch.py with `cast(Response, ...)`

## Pipeline

```
markdown negotiation → raw HTML → readability+soup → CDP render → Jina Reader
```

When local extraction fails (SPA shell / too short), and a CDP endpoint is configured, the page is rendered via headless browser and re-parsed with readability+soup. If CDP is unconfigured or fails, falls through silently to Jina.

## Test plan

- [x] 132 tests pass (120 existing + 12 new CDP tests)
- [x] `ruff check` clean
- [x] `ty check` clean (0 diagnostics)
- [x] Live tested with headless Chromium on react.dev, angular.dev, vuejs.org

Closes #105