### PR TITLE
feat(fetch): VeilRender fallback + structured strategy results

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -13,6 +13,9 @@ services:
 
   openapi:
     image: oaklight/toolregistry-hub-server:${IMAGE_TAG:-latest}
+    ports:
+      - "55093:8000"
+      # - "55193:8001"
     expose:
       - "8000"
     env_file:
@@ -31,6 +34,9 @@ services:
 
   mcp-streamable-http:
     image: oaklight/toolregistry-hub-server:${IMAGE_TAG:-latest}
+    ports:
+      - "55094:8000"
+      # - "55194:8001"
     expose:
       - "8000"
     env_file:
@@ -50,6 +56,9 @@ services:
 
   mcp-sse:
     image: oaklight/toolregistry-hub-server:${IMAGE_TAG:-latest}
+    ports:
+      - "55095:8000"
+      # - "55195:8001"
     expose:
       - "8000"
     env_file:

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -282,6 +282,8 @@ class Fetch:
         self,
         api_keys: str | None = None,
         cdp_endpoint: str | None = None,
+        veilrender_endpoint: str | None = None,
+        veilrender_token: str | None = None,
         cache_ttl: float = _CACHE_TTL_DEFAULT,
         cache_maxsize: int = _CACHE_MAXSIZE_DEFAULT,
     ):
@@ -296,6 +298,13 @@ class Fetch:
                 (e.g. ``ws://localhost:9222``).  Falls back to the
                 ``CDP_ENDPOINT`` environment variable.  When set, SPA
                 pages are rendered via CDP before falling back to Jina.
+            veilrender_endpoint: Base URL of a VeilRender instance
+                (e.g. ``https://oaklight-veilrender.hf.space``).  Falls
+                back to ``VEILRENDER_ENDPOINT`` env var.  Used as a
+                browser-rendering fallback via REST API when CDP is
+                unavailable.
+            veilrender_token: Bearer token for VeilRender auth.  Falls
+                back to ``VEILRENDER_TOKEN`` env var.
             cache_ttl: Time-to-live in seconds for cached URL results.
                 Set to ``0`` to disable caching.  Defaults to 300 (5 min).
             cache_maxsize: Maximum number of entries in the URL cache.
@@ -310,6 +319,12 @@ class Fetch:
         )
         self.api_key_parser: APIKeyParser | None = parser if parser.api_keys else None
         self.cdp_endpoint: str | None = cdp_endpoint or os.environ.get("CDP_ENDPOINT")
+        self.veilrender_endpoint: str | None = veilrender_endpoint or os.environ.get(
+            "VEILRENDER_ENDPOINT"
+        )
+        self.veilrender_token: str | None = veilrender_token or os.environ.get(
+            "VEILRENDER_TOKEN"
+        )
         self._cache: _URLCache | None = (
             _URLCache(ttl=cache_ttl, maxsize=cache_maxsize) if cache_ttl > 0 else None
         )
@@ -367,6 +382,8 @@ class Fetch:
                 proxy=proxy,
                 api_key_parser=self.api_key_parser,
                 cdp_endpoint=self.cdp_endpoint,
+                veilrender_endpoint=self.veilrender_endpoint,
+                veilrender_token=self.veilrender_token,
             )
             # Cache successful results only.
             if self._cache is not None:
@@ -611,6 +628,89 @@ def _try_cdp_extraction(
     return "", cdp_readability or cdp_soup or ""
 
 
+def _render_with_veilrender(
+    url: str,
+    endpoint: str,
+    token: str | None = None,
+    timeout: float = 30.0,
+) -> str:
+    """Render a page via VeilRender REST API and return the HTML.
+
+    Args:
+        url: The URL to render.
+        endpoint: Base URL of the VeilRender instance.
+        token: Optional Bearer token for authentication.
+        timeout: Maximum time in seconds for the request.
+
+    Returns:
+        Rendered HTML string, or empty string on any failure.
+    """
+    try:
+        import json
+
+        render_url = f"{endpoint.rstrip('/')}/render"
+        payload = json.dumps(
+            {
+                "url": url,
+                "formats": ["html"],
+                "timeout": int(timeout * 1000),
+            }
+        ).encode()
+
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        resp = _http_post(
+            render_url,
+            body=payload,
+            headers=headers,
+            timeout=timeout,
+        )
+
+        data = resp.json()
+        html = data.get("content", {}).get("html", "")
+        if html:
+            logger.debug(f"VeilRender rendered {url}: {len(html)} chars of HTML")
+        return html
+    except Exception as e:
+        logger.debug(f"VeilRender rendering failed for {url}: {e}")
+        return ""
+
+
+def _try_veilrender_extraction(
+    url: str,
+    endpoint: str,
+    token: str | None,
+    timeout: float,
+) -> tuple[str, str]:
+    """Render a page with VeilRender and attempt readability/soup extraction.
+
+    Args:
+        url: The URL to render.
+        endpoint: Base URL of the VeilRender instance.
+        token: Optional Bearer token for authentication.
+        timeout: Budget in seconds for the VeilRender request.
+
+    Returns:
+        A ``(best_content, local_content)`` tuple.
+    """
+    rendered_html = _render_with_veilrender(url, endpoint, token, timeout=timeout)
+    if not rendered_html:
+        return "", ""
+
+    vr_readability, vr_score = _extract_with_readability(rendered_html, url)
+    if _should_skip_soup(vr_readability, vr_score, url):
+        vr_soup = ""
+    else:
+        vr_soup = _extract_with_soup(rendered_html)
+    vr_best = _pick_local_content(vr_readability, vr_score, vr_soup, url)
+    if vr_best:
+        logger.info(f"Successfully fetched {url} using strategy: veilrender")
+        return vr_best, ""
+    return "", vr_readability or vr_soup or ""
+
+
 def _try_jina_extraction(
     url: str,
     *,
@@ -744,6 +844,8 @@ def _extract(
     proxy: str | None = None,
     api_key_parser: APIKeyParser | None = None,
     cdp_endpoint: str | None = None,
+    veilrender_endpoint: str | None = None,
+    veilrender_token: str | None = None,
 ) -> str:
     """Extract content from a given URL using available methods.
 
@@ -752,7 +854,8 @@ def _extract(
     2. Readability extraction (intelligent article scoring, local)
     3. Simple soup extraction (CSS selector fallback, local)
     4. CDP rendering (self-hosted browser, re-parsed with readability/soup)
-    5. Jina Reader (external API fallback for SPA / JS-heavy pages)
+    5. VeilRender (remote browser rendering via REST API)
+    6. Jina Reader (external API fallback for SPA / JS-heavy pages)
 
     HTML is fetched once and reused by stages 2 and 3.  ``timeout`` is a
     wall-clock budget for the *whole* operation; strategies are skipped once
@@ -811,7 +914,18 @@ def _extract(
         if len(cdp_local) > len(local_content):
             local_content = cdp_local
 
-    # 5. Local extraction insufficient — try Jina Reader.
+    # 5. Try VeilRender (remote browser rendering via REST API).
+    if veilrender_endpoint and _remaining() > _MIN_STRATEGY_BUDGET:
+        vr_budget = min(_remaining(), 30.0)
+        vr_result, vr_local = _try_veilrender_extraction(
+            url, veilrender_endpoint, veilrender_token, vr_budget
+        )
+        if vr_result:
+            return _format_text(vr_result)
+        if len(vr_local) > len(local_content):
+            local_content = vr_local
+
+    # 6. Local extraction insufficient — try Jina Reader.
     jina_content = _try_jina_extraction(
         url,
         local_content=local_content,

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -853,8 +853,8 @@ def _extract(
     1. Cloudflare Content Negotiation (zero-cost markdown attempt)
     2. Readability extraction (intelligent article scoring, local)
     3. Simple soup extraction (CSS selector fallback, local)
-    4. CDP rendering (self-hosted browser, re-parsed with readability/soup)
-    5. VeilRender (remote browser rendering via REST API)
+    4. VeilRender (remote browser rendering via REST API)
+    5. CDP rendering (self-hosted browser, re-parsed with readability/soup)
     6. Jina Reader (external API fallback for SPA / JS-heavy pages)
 
     HTML is fetched once and reused by stages 2 and 3.  ``timeout`` is a
@@ -905,16 +905,7 @@ def _extract(
         if best:
             return _format_text(best)
 
-    # 4. Try CDP rendering (self-hosted browser) if configured.
-    if cdp_endpoint and _remaining() > _MIN_STRATEGY_BUDGET:
-        cdp_budget = min(_remaining(), 15.0)
-        cdp_result, cdp_local = _try_cdp_extraction(url, cdp_endpoint, cdp_budget)
-        if cdp_result:
-            return _format_text(cdp_result)
-        if len(cdp_local) > len(local_content):
-            local_content = cdp_local
-
-    # 5. Try VeilRender (remote browser rendering via REST API).
+    # 4. Try VeilRender (remote browser rendering via REST API).
     if veilrender_endpoint and _remaining() > _MIN_STRATEGY_BUDGET:
         vr_budget = min(_remaining(), 30.0)
         vr_result, vr_local = _try_veilrender_extraction(
@@ -924,6 +915,15 @@ def _extract(
             return _format_text(vr_result)
         if len(vr_local) > len(local_content):
             local_content = vr_local
+
+    # 5. Try CDP rendering (self-hosted browser) if configured.
+    if cdp_endpoint and _remaining() > _MIN_STRATEGY_BUDGET:
+        cdp_budget = min(_remaining(), 15.0)
+        cdp_result, cdp_local = _try_cdp_extraction(url, cdp_endpoint, cdp_budget)
+        if cdp_result:
+            return _format_text(cdp_result)
+        if len(cdp_local) > len(local_content):
+            local_content = cdp_local
 
     # 6. Local extraction insufficient — try Jina Reader.
     jina_content = _try_jina_extraction(

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -1208,8 +1208,11 @@ def _try_browser_rendering(
         if vr_result:
             content = _format_text(vr_result)
             return _make_result(
-                content=content, url=url, strategy="veilrender",
-                content_type="text/html", started_at=started_at,
+                content=content,
+                url=url,
+                strategy="veilrender",
+                content_type="text/html",
+                started_at=started_at,
                 metadata={"content_length": len(content)},
             ), local_content
         if len(vr_local) > len(local_content):
@@ -1222,8 +1225,11 @@ def _try_browser_rendering(
         if cdp_result:
             content = _format_text(cdp_result)
             return _make_result(
-                content=content, url=url, strategy="cdp",
-                content_type="text/html", started_at=started_at,
+                content=content,
+                url=url,
+                strategy="cdp",
+                content_type="text/html",
+                started_at=started_at,
                 metadata={"content_length": len(content)},
             ), local_content
         if len(cdp_local) > len(local_content):

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -950,6 +950,136 @@ def _try_local_extraction(html: str, url: str) -> tuple[str, str, str, float]:
     return best, local_content, strategy, score
 
 
+def _strategy_markdown(
+    url: str,
+    timeout: float,
+    proxy: str | None,
+    remaining: float,
+    started_at: float,
+    **_kw: object,
+) -> FetchResult:
+    md_content, _fb, _ct = _try_markdown_negotiation(
+        url, timeout=min(timeout, remaining), proxy=proxy
+    )
+    if not md_content:
+        raise FetchError(f"Markdown negotiation did not return content for {url}")
+    content = _format_text(md_content)
+    return _make_result(
+        content=content,
+        url=url,
+        strategy="markdown",
+        content_type="text/markdown",
+        started_at=started_at,
+        metadata={"content_length": len(content)},
+    )
+
+
+def _strategy_local(
+    url: str,
+    strategy: str,
+    timeout: float,
+    proxy: str | None,
+    deadline: float,
+    remaining: float,
+    started_at: float,
+    **_kw: object,
+) -> FetchResult:
+    body, content_type = _fetch_raw(
+        url, timeout=min(timeout, remaining), proxy=proxy, deadline=deadline
+    )
+    if content_type and _is_binary_content_type(content_type):
+        raise FetchError(f"Unsupported binary content type for {url}: {content_type}")
+    if strategy == "readability":
+        text, score = _extract_with_readability(body, url)
+        content = _format_text(text)
+        quality = "high" if _is_content_sufficient(text, score) else "low"
+        return _make_result(
+            content=content,
+            url=url,
+            strategy="readability",
+            quality=quality,
+            content_type=content_type,
+            started_at=started_at,
+            metadata={"readability_score": score, "content_length": len(content)},
+        )
+    text = _extract_with_soup(body)
+    content = _format_text(text)
+    quality = "high" if _is_content_sufficient(text) else "low"
+    return _make_result(
+        content=content,
+        url=url,
+        strategy="soup",
+        quality=quality,
+        content_type=content_type,
+        started_at=started_at,
+        metadata={"content_length": len(content)},
+    )
+
+
+def _strategy_browser(
+    url: str,
+    strategy: str,
+    remaining: float,
+    started_at: float,
+    cdp_endpoint: str | None = None,
+    veilrender_endpoint: str | None = None,
+    veilrender_token: str | None = None,
+    **_kw: object,
+) -> FetchResult:
+    if strategy == "veilrender":
+        if not veilrender_endpoint:
+            raise FetchError("VeilRender is not configured")
+        result, local = _try_veilrender_extraction(
+            url, veilrender_endpoint, veilrender_token, min(remaining, 30.0)
+        )
+    else:
+        if not cdp_endpoint:
+            raise FetchError("CDP is not configured")
+        result, local = _try_cdp_extraction(url, cdp_endpoint, min(remaining, 15.0))
+    content = _format_text(result or local)
+    return _make_result(
+        content=content,
+        url=url,
+        strategy=strategy,
+        quality="high" if result else "low",
+        content_type="text/html",
+        started_at=started_at,
+        metadata={"content_length": len(content)},
+    )
+
+
+def _strategy_jina(
+    url: str,
+    timeout: float,
+    proxy: str | None,
+    api_key_parser: APIKeyParser | None,
+    deadline: float,
+    remaining: float,
+    started_at: float,
+    **_kw: object,
+) -> FetchResult:
+    content = _try_jina_extraction(
+        url,
+        local_content="",
+        timeout=timeout,
+        remaining=remaining,
+        proxy=proxy,
+        api_key_parser=api_key_parser,
+        deadline=deadline,
+    )
+    if not content:
+        raise FetchError(f"Jina Reader did not return content for {url}")
+    formatted = _format_text(content)
+    return _make_result(
+        content=formatted,
+        url=url,
+        strategy="jina",
+        content_type="text/markdown",
+        started_at=started_at,
+        metadata={"content_length": len(formatted)},
+    )
+
+
 def _extract_with_strategy(
     url: str,
     *,
@@ -964,115 +1094,32 @@ def _extract_with_strategy(
     started_at: float,
 ) -> FetchResult:
     """Run one explicit fetch strategy."""
-
-    def _remaining() -> float:
-        return max(0.0, deadline - time.monotonic())
-
-    if strategy == "markdown":
-        md_content, _fallback_body, _fallback_ct = _try_markdown_negotiation(
-            url, timeout=min(timeout, _remaining()), proxy=proxy
-        )
-        if not md_content:
-            raise FetchError(f"Markdown negotiation did not return content for {url}")
-        content = _format_text(md_content)
-        return _make_result(
-            content=content,
-            url=url,
-            strategy="markdown",
-            content_type="text/markdown",
-            started_at=started_at,
-            metadata={"content_length": len(content)},
-        )
-
-    if strategy in {"readability", "soup"}:
-        body, content_type = _fetch_raw(
-            url, timeout=min(timeout, _remaining()), proxy=proxy, deadline=deadline
-        )
-        if content_type and _is_binary_content_type(content_type):
-            raise FetchError(
-                f"Unsupported binary content type for {url}: {content_type}"
-            )
-        if strategy == "readability":
-            text, score = _extract_with_readability(body, url)
-            content = _format_text(text)
-            quality = "high" if _is_content_sufficient(text, score) else "low"
-            return _make_result(
-                content=content,
-                url=url,
-                strategy="readability",
-                quality=quality,
-                content_type=content_type,
-                started_at=started_at,
-                metadata={"readability_score": score, "content_length": len(content)},
-            )
-        text = _extract_with_soup(body)
-        content = _format_text(text)
-        quality = "high" if _is_content_sufficient(text) else "low"
-        return _make_result(
-            content=content,
-            url=url,
-            strategy="soup",
-            quality=quality,
-            content_type=content_type,
-            started_at=started_at,
-            metadata={"content_length": len(content)},
-        )
-
-    if strategy == "veilrender":
-        if not veilrender_endpoint:
-            raise FetchError("VeilRender is not configured")
-        result, local = _try_veilrender_extraction(
-            url, veilrender_endpoint, veilrender_token, min(_remaining(), 30.0)
-        )
-        content = _format_text(result or local)
-        return _make_result(
-            content=content,
-            url=url,
-            strategy="veilrender",
-            quality="high" if result else "low",
-            content_type="text/html",
-            started_at=started_at,
-            metadata={"content_length": len(content)},
-        )
-
-    if strategy == "cdp":
-        if not cdp_endpoint:
-            raise FetchError("CDP is not configured")
-        result, local = _try_cdp_extraction(url, cdp_endpoint, min(_remaining(), 15.0))
-        content = _format_text(result or local)
-        return _make_result(
-            content=content,
-            url=url,
-            strategy="cdp",
-            quality="high" if result else "low",
-            content_type="text/html",
-            started_at=started_at,
-            metadata={"content_length": len(content)},
-        )
-
-    if strategy == "jina":
-        content = _try_jina_extraction(
-            url,
-            local_content="",
-            timeout=timeout,
-            remaining=_remaining(),
-            proxy=proxy,
-            api_key_parser=api_key_parser,
-            deadline=deadline,
-        )
-        if not content:
-            raise FetchError(f"Jina Reader did not return content for {url}")
-        formatted = _format_text(content)
-        return _make_result(
-            content=formatted,
-            url=url,
-            strategy="jina",
-            content_type="text/markdown",
-            started_at=started_at,
-            metadata={"content_length": len(formatted)},
-        )
-
-    raise ValueError(f"Unknown strategy: {strategy}")
+    remaining = max(0.0, deadline - time.monotonic())
+    kwargs = {
+        "url": url,
+        "strategy": strategy,
+        "timeout": timeout,
+        "proxy": proxy,
+        "api_key_parser": api_key_parser,
+        "cdp_endpoint": cdp_endpoint,
+        "veilrender_endpoint": veilrender_endpoint,
+        "veilrender_token": veilrender_token,
+        "deadline": deadline,
+        "remaining": remaining,
+        "started_at": started_at,
+    }
+    dispatch = {
+        "markdown": _strategy_markdown,
+        "readability": _strategy_local,
+        "soup": _strategy_local,
+        "veilrender": _strategy_browser,
+        "cdp": _strategy_browser,
+        "jina": _strategy_jina,
+    }
+    handler = dispatch.get(strategy)
+    if handler is None:
+        raise ValueError(f"Unknown strategy: {strategy}")
+    return handler(**kwargs)
 
 
 def _extract(
@@ -1116,9 +1163,6 @@ def _extract(
     started_at = started_at or time.monotonic()
     deadline = time.monotonic() + max(0.0, timeout)
 
-    def _remaining() -> float:
-        return max(0.0, deadline - time.monotonic())
-
     if strategy != "auto":
         return _extract_with_strategy(
             url,
@@ -1132,6 +1176,78 @@ def _extract(
             deadline=deadline,
             started_at=started_at,
         )
+
+    return _extract_auto(
+        url,
+        timeout=timeout,
+        proxy=proxy,
+        api_key_parser=api_key_parser,
+        cdp_endpoint=cdp_endpoint,
+        veilrender_endpoint=veilrender_endpoint,
+        veilrender_token=veilrender_token,
+        deadline=deadline,
+        started_at=started_at,
+    )
+
+
+def _try_browser_rendering(
+    url: str,
+    *,
+    local_content: str,
+    veilrender_endpoint: str | None,
+    veilrender_token: str | None,
+    cdp_endpoint: str | None,
+    remaining: float,
+    started_at: float,
+) -> tuple[FetchResult | None, str]:
+    """Try VeilRender then CDP; return (result, updated_local_content)."""
+    if veilrender_endpoint and remaining > _MIN_STRATEGY_BUDGET:
+        vr_result, vr_local = _try_veilrender_extraction(
+            url, veilrender_endpoint, veilrender_token, min(remaining, 30.0)
+        )
+        if vr_result:
+            content = _format_text(vr_result)
+            return _make_result(
+                content=content, url=url, strategy="veilrender",
+                content_type="text/html", started_at=started_at,
+                metadata={"content_length": len(content)},
+            ), local_content
+        if len(vr_local) > len(local_content):
+            local_content = vr_local
+
+    if cdp_endpoint and remaining > _MIN_STRATEGY_BUDGET:
+        cdp_result, cdp_local = _try_cdp_extraction(
+            url, cdp_endpoint, min(remaining, 15.0)
+        )
+        if cdp_result:
+            content = _format_text(cdp_result)
+            return _make_result(
+                content=content, url=url, strategy="cdp",
+                content_type="text/html", started_at=started_at,
+                metadata={"content_length": len(content)},
+            ), local_content
+        if len(cdp_local) > len(local_content):
+            local_content = cdp_local
+
+    return None, local_content
+
+
+def _extract_auto(
+    url: str,
+    *,
+    timeout: float,
+    proxy: str | None,
+    api_key_parser: APIKeyParser | None,
+    cdp_endpoint: str | None,
+    veilrender_endpoint: str | None,
+    veilrender_token: str | None,
+    deadline: float,
+    started_at: float,
+) -> FetchResult:
+    """Auto pipeline: try strategies in order."""
+
+    def _remaining() -> float:
+        return max(0.0, deadline - time.monotonic())
 
     # 1. Fetch body (tries markdown negotiation, then raw fetch).
     body, content_type = _fetch_body(url, timeout, proxy, deadline)
@@ -1189,41 +1305,18 @@ def _extract(
                 },
             )
 
-    # 4. Try VeilRender (remote browser rendering via REST API).
-    if veilrender_endpoint and _remaining() > _MIN_STRATEGY_BUDGET:
-        vr_budget = min(_remaining(), 30.0)
-        vr_result, vr_local = _try_veilrender_extraction(
-            url, veilrender_endpoint, veilrender_token, vr_budget
-        )
-        if vr_result:
-            content = _format_text(vr_result)
-            return _make_result(
-                content=content,
-                url=url,
-                strategy="veilrender",
-                content_type="text/html",
-                started_at=started_at,
-                metadata={"content_length": len(content)},
-            )
-        if len(vr_local) > len(local_content):
-            local_content = vr_local
-
-    # 5. Try CDP rendering (self-hosted browser) if configured.
-    if cdp_endpoint and _remaining() > _MIN_STRATEGY_BUDGET:
-        cdp_budget = min(_remaining(), 15.0)
-        cdp_result, cdp_local = _try_cdp_extraction(url, cdp_endpoint, cdp_budget)
-        if cdp_result:
-            content = _format_text(cdp_result)
-            return _make_result(
-                content=content,
-                url=url,
-                strategy="cdp",
-                content_type="text/html",
-                started_at=started_at,
-                metadata={"content_length": len(content)},
-            )
-        if len(cdp_local) > len(local_content):
-            local_content = cdp_local
+    # 4-5. Try browser rendering (VeilRender, then CDP).
+    browser_result, local_content = _try_browser_rendering(
+        url,
+        local_content=local_content,
+        veilrender_endpoint=veilrender_endpoint,
+        veilrender_token=veilrender_token,
+        cdp_endpoint=cdp_endpoint,
+        remaining=_remaining(),
+        started_at=started_at,
+    )
+    if browser_result is not None:
+        return browser_result
 
     # 6. Local extraction insufficient — try Jina Reader.
     jina_content = _try_jina_extraction(

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -440,9 +440,21 @@ class Fetch:
                 Defaults to TIMEOUT_DEFAULT.
             proxy (str, optional): Proxy to use for the request. Defaults to None.
             strategy: Strategy to use. Leave as ``"auto"`` for normal use.
-                Only set this when retrying after auto returned low-quality or
-                unsuitable content. Available choices are narrowed at runtime;
-                ``veilrender`` and ``cdp`` appear only when configured.
+                Auto already tries the best available fallback chain. Only set
+                a specific strategy when retrying after auto returned low-quality
+                or unsuitable content.
+
+                Retry hints:
+                - ``"markdown"``: fast check for sites that support Markdown
+                  content negotiation.
+                - ``"readability"``: local article extraction for normal HTML.
+                - ``"soup"``: local fallback when readability misses content.
+                - ``"veilrender"`` / ``"cdp"``: JS-heavy pages or SPA shells.
+                - ``"jina"``: external reader fallback when local/browser
+                  rendering is poor.
+
+                Available choices are narrowed at runtime; ``veilrender`` and
+                ``cdp`` appear only when configured.
 
         Returns:
             Structured result with content, strategy, quality, cache status,

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -6,8 +6,9 @@ import os
 import re
 import threading
 import time
+import types
 import unicodedata
-from typing import TYPE_CHECKING, Literal, NamedTuple, cast
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypedDict, cast
 
 from ._vendor.httpclient import (
     HttpConnectionError,
@@ -33,6 +34,30 @@ logger = get_logger()
 
 TIMEOUT_DEFAULT = 30.0
 
+StrategyName = Literal[
+    "auto",
+    "markdown",
+    "readability",
+    "soup",
+    "veilrender",
+    "cdp",
+    "jina",
+]
+
+
+class FetchResult(TypedDict):
+    """Structured result returned by Fetch.fetch_content."""
+
+    content: str
+    url: str
+    strategy: str
+    quality: str
+    content_type: str
+    cached: bool
+    elapsed_ms: int
+    metadata: dict[str, object]
+
+
 # Minimum remaining budget (in seconds) before attempting another network
 # strategy.  Strategies are skipped when the deadline is closer than this so
 # callers with very small ``timeout`` values get an answer quickly.
@@ -48,7 +73,7 @@ _CACHE_MAXSIZE_DEFAULT = 128
 class _CacheEntry(NamedTuple):
     """A cached extraction result with its expiry timestamp."""
 
-    content: str
+    content: FetchResult
     expires_at: float  # time.monotonic() deadline
 
 
@@ -75,7 +100,7 @@ class _URLCache:
 
     # ── public API ───────────────────────────────────────────────────────
 
-    def get(self, url: str) -> str | None:
+    def get(self, url: str) -> FetchResult | None:
         """Return cached content for *url*, or ``None`` on miss/expiry."""
         with self._lock:
             entry = self._data.get(url)
@@ -88,7 +113,7 @@ class _URLCache:
             self._data[url] = self._data.pop(url)
             return entry.content
 
-    def put(self, url: str, content: str) -> None:
+    def put(self, url: str, content: FetchResult) -> None:
         """Store *content* for *url* with the configured TTL."""
         with self._lock:
             # Remove first so re-insertion lands at the end.
@@ -119,6 +144,30 @@ class FetchError(RuntimeError):
     lets MCP and other tool harnesses set the ``isError`` flag on the
     response automatically.
     """
+
+
+def _make_result(
+    *,
+    content: str,
+    url: str,
+    strategy: str,
+    quality: str = "high",
+    content_type: str = "",
+    cached: bool = False,
+    started_at: float,
+    metadata: dict[str, object] | None = None,
+) -> FetchResult:
+    """Build a structured fetch result."""
+    return {
+        "content": content,
+        "url": url,
+        "strategy": strategy,
+        "quality": quality,
+        "content_type": content_type,
+        "cached": cached,
+        "elapsed_ms": int((time.monotonic() - started_at) * 1000),
+        "metadata": metadata or {},
+    }
 
 
 # Minimum content length (in characters) to consider extraction sufficient.
@@ -328,6 +377,35 @@ class Fetch:
         self._cache: _URLCache | None = (
             _URLCache(ttl=cache_ttl, maxsize=cache_maxsize) if cache_ttl > 0 else None
         )
+        self._narrow_strategy_annotation()
+
+    def _available_strategies(self) -> tuple[str, ...]:
+        """Return strategies available in this instance."""
+        strategies = ["auto", "markdown", "readability", "soup", "jina"]
+        if self.veilrender_endpoint:
+            strategies.append("veilrender")
+        if self.cdp_endpoint:
+            strategies.append("cdp")
+        return tuple(strategies)
+
+    def _narrow_strategy_annotation(self) -> None:
+        """Narrow strategy Literal to strategies available in this instance."""
+        original = type(self).fetch_content
+        new_func = types.FunctionType(
+            original.__code__,
+            original.__globals__,
+            name=original.__name__,
+            argdefs=original.__defaults__,
+            closure=original.__closure__,
+        )
+        new_func.__doc__ = original.__doc__
+        new_func.__qualname__ = original.__qualname__
+        new_func.__kwdefaults__ = original.__kwdefaults__
+        new_func.__annotations__ = dict(original.__annotations__)
+        new_func.__annotations__["strategy"] = Literal.__getitem__(
+            self._available_strategies()
+        )
+        self.fetch_content = types.MethodType(new_func, self)  # type: ignore[method-assign]
 
     def _is_configured(self) -> bool:
         """Check if Fetch is configured.
@@ -347,7 +425,8 @@ class Fetch:
         url: str,
         timeout: float = TIMEOUT_DEFAULT,
         proxy: str | None = None,
-    ) -> str:
+        strategy: StrategyName = "auto",
+    ) -> FetchResult:
         """Fetch and extract content from a given URL.
 
         The ``timeout`` is treated as a wall-clock budget for the whole
@@ -360,23 +439,39 @@ class Fetch:
             timeout (float, optional): Total wall-clock timeout in seconds.
                 Defaults to TIMEOUT_DEFAULT.
             proxy (str, optional): Proxy to use for the request. Defaults to None.
+            strategy: Strategy to use. Leave as ``"auto"`` for normal use.
+                Only set this when retrying after auto returned low-quality or
+                unsuitable content. Available choices are narrowed at runtime;
+                ``veilrender`` and ``cdp`` appear only when configured.
 
         Returns:
-            str: Extracted content from the URL.
+            Structured result with content, strategy, quality, cache status,
+            elapsed time, and metadata.
 
         Raises:
             FetchError: If every extraction strategy fails or the deadline
                 is exceeded before any content can be retrieved.
         """
-        # Check cache first.
+        started_at = time.monotonic()
+        strategy = strategy.lower().strip()  # type: ignore[assignment]
+        if strategy not in self._available_strategies():
+            raise ValueError(
+                f"Strategy {strategy!r} is not available. "
+                f"Available: {self._available_strategies()}"
+            )
+
+        cache_key = f"{strategy}:{url}"
         if self._cache is not None:
-            cached = self._cache.get(url)
+            cached = self._cache.get(cache_key)
             if cached is not None:
-                logger.debug(f"Cache hit for {url}")
-                return cached
+                logger.debug(f"Cache hit for {cache_key}")
+                cached = dict(cached)
+                cached["cached"] = True
+                cached["elapsed_ms"] = int((time.monotonic() - started_at) * 1000)
+                return cast(FetchResult, cached)
 
         try:
-            content = _extract(
+            result = _extract(
                 url,
                 timeout=timeout,
                 proxy=proxy,
@@ -384,11 +479,12 @@ class Fetch:
                 cdp_endpoint=self.cdp_endpoint,
                 veilrender_endpoint=self.veilrender_endpoint,
                 veilrender_token=self.veilrender_token,
+                strategy=strategy,
+                started_at=started_at,
             )
-            # Cache successful results only.
             if self._cache is not None:
-                self._cache.put(url, content)
-            return content
+                self._cache.put(cache_key, result)
+            return result
         except FetchError:
             raise
         except Exception as e:
@@ -522,7 +618,7 @@ def _pick_local_content(
     readability_score: float,
     soup_content: str,
     url: str,
-) -> str:
+) -> tuple[str, str, float]:
     """Choose the best local extraction result.
 
     Prefers readability unless soup produced substantially more content
@@ -558,8 +654,8 @@ def _pick_local_content(
             )
             continue
         logger.info(f"Successfully fetched {url} using strategy: {strategy}")
-        return candidate
-    return ""
+        return candidate, strategy, score
+    return "", "", 0.0
 
 
 def _render_with_cdp(
@@ -621,7 +717,9 @@ def _try_cdp_extraction(
         cdp_soup = ""
     else:
         cdp_soup = _extract_with_soup(rendered_html)
-    cdp_best = _pick_local_content(cdp_readability, cdp_score, cdp_soup, url)
+    cdp_best, _strategy, _score = _pick_local_content(
+        cdp_readability, cdp_score, cdp_soup, url
+    )
     if cdp_best:
         logger.info(f"Successfully fetched {url} using strategy: cdp")
         return cdp_best, ""
@@ -704,7 +802,9 @@ def _try_veilrender_extraction(
         vr_soup = ""
     else:
         vr_soup = _extract_with_soup(rendered_html)
-    vr_best = _pick_local_content(vr_readability, vr_score, vr_soup, url)
+    vr_best, _strategy, _score = _pick_local_content(
+        vr_readability, vr_score, vr_soup, url
+    )
     if vr_best:
         logger.info(f"Successfully fetched {url} using strategy: veilrender")
         return vr_best, ""
@@ -813,7 +913,7 @@ def _fetch_body(
     return body, content_type
 
 
-def _try_local_extraction(html: str, url: str) -> tuple[str, str]:
+def _try_local_extraction(html: str, url: str) -> tuple[str, str, str, float]:
     """Run readability and (optionally) soup on *html*.
 
     Returns:
@@ -828,14 +928,139 @@ def _try_local_extraction(html: str, url: str) -> tuple[str, str]:
     else:
         soup_content = _extract_with_soup(html)
 
-    best = _pick_local_content(
+    best, strategy, score = _pick_local_content(
         readability_content,
         readability_score,
         soup_content,
         url,
     )
     local_content = readability_content or soup_content or ""
-    return best, local_content
+    return best, local_content, strategy, score
+
+
+def _extract_with_strategy(
+    url: str,
+    *,
+    strategy: str,
+    timeout: float,
+    proxy: str | None,
+    api_key_parser: APIKeyParser | None,
+    cdp_endpoint: str | None,
+    veilrender_endpoint: str | None,
+    veilrender_token: str | None,
+    deadline: float,
+    started_at: float,
+) -> FetchResult:
+    """Run one explicit fetch strategy."""
+
+    def _remaining() -> float:
+        return max(0.0, deadline - time.monotonic())
+
+    if strategy == "markdown":
+        md_content, _fallback_body, _fallback_ct = _try_markdown_negotiation(
+            url, timeout=min(timeout, _remaining()), proxy=proxy
+        )
+        if not md_content:
+            raise FetchError(f"Markdown negotiation did not return content for {url}")
+        content = _format_text(md_content)
+        return _make_result(
+            content=content,
+            url=url,
+            strategy="markdown",
+            content_type="text/markdown",
+            started_at=started_at,
+            metadata={"content_length": len(content)},
+        )
+
+    if strategy in {"readability", "soup"}:
+        body, content_type = _fetch_raw(
+            url, timeout=min(timeout, _remaining()), proxy=proxy, deadline=deadline
+        )
+        if content_type and _is_binary_content_type(content_type):
+            raise FetchError(
+                f"Unsupported binary content type for {url}: {content_type}"
+            )
+        if strategy == "readability":
+            text, score = _extract_with_readability(body, url)
+            content = _format_text(text)
+            quality = "high" if _is_content_sufficient(text, score) else "low"
+            return _make_result(
+                content=content,
+                url=url,
+                strategy="readability",
+                quality=quality,
+                content_type=content_type,
+                started_at=started_at,
+                metadata={"readability_score": score, "content_length": len(content)},
+            )
+        text = _extract_with_soup(body)
+        content = _format_text(text)
+        quality = "high" if _is_content_sufficient(text) else "low"
+        return _make_result(
+            content=content,
+            url=url,
+            strategy="soup",
+            quality=quality,
+            content_type=content_type,
+            started_at=started_at,
+            metadata={"content_length": len(content)},
+        )
+
+    if strategy == "veilrender":
+        if not veilrender_endpoint:
+            raise FetchError("VeilRender is not configured")
+        result, local = _try_veilrender_extraction(
+            url, veilrender_endpoint, veilrender_token, min(_remaining(), 30.0)
+        )
+        content = _format_text(result or local)
+        return _make_result(
+            content=content,
+            url=url,
+            strategy="veilrender",
+            quality="high" if result else "low",
+            content_type="text/html",
+            started_at=started_at,
+            metadata={"content_length": len(content)},
+        )
+
+    if strategy == "cdp":
+        if not cdp_endpoint:
+            raise FetchError("CDP is not configured")
+        result, local = _try_cdp_extraction(url, cdp_endpoint, min(_remaining(), 15.0))
+        content = _format_text(result or local)
+        return _make_result(
+            content=content,
+            url=url,
+            strategy="cdp",
+            quality="high" if result else "low",
+            content_type="text/html",
+            started_at=started_at,
+            metadata={"content_length": len(content)},
+        )
+
+    if strategy == "jina":
+        content = _try_jina_extraction(
+            url,
+            local_content="",
+            timeout=timeout,
+            remaining=_remaining(),
+            proxy=proxy,
+            api_key_parser=api_key_parser,
+            deadline=deadline,
+        )
+        if not content:
+            raise FetchError(f"Jina Reader did not return content for {url}")
+        formatted = _format_text(content)
+        return _make_result(
+            content=formatted,
+            url=url,
+            strategy="jina",
+            content_type="text/markdown",
+            started_at=started_at,
+            metadata={"content_length": len(formatted)},
+        )
+
+    raise ValueError(f"Unknown strategy: {strategy}")
 
 
 def _extract(
@@ -846,7 +1071,9 @@ def _extract(
     cdp_endpoint: str | None = None,
     veilrender_endpoint: str | None = None,
     veilrender_token: str | None = None,
-) -> str:
+    strategy: str = "auto",
+    started_at: float | None = None,
+) -> FetchResult:
     """Extract content from a given URL using available methods.
 
     Strategies are tried in order:
@@ -874,17 +1101,40 @@ def _extract(
         FetchError: If every extraction strategy fails or the deadline is
             exceeded before any content is retrieved.
     """
+    started_at = started_at or time.monotonic()
     deadline = time.monotonic() + max(0.0, timeout)
 
     def _remaining() -> float:
         return max(0.0, deadline - time.monotonic())
+
+    if strategy != "auto":
+        return _extract_with_strategy(
+            url,
+            strategy=strategy,
+            timeout=timeout,
+            proxy=proxy,
+            api_key_parser=api_key_parser,
+            cdp_endpoint=cdp_endpoint,
+            veilrender_endpoint=veilrender_endpoint,
+            veilrender_token=veilrender_token,
+            deadline=deadline,
+            started_at=started_at,
+        )
 
     # 1. Fetch body (tries markdown negotiation, then raw fetch).
     body, content_type = _fetch_body(url, timeout, proxy, deadline)
 
     # Markdown negotiation succeeded — return directly.
     if content_type == "_markdown":
-        return _format_text(body)
+        content = _format_text(body)
+        return _make_result(
+            content=content,
+            url=url,
+            strategy="markdown",
+            content_type="text/markdown",
+            started_at=started_at,
+            metadata={"content_length": len(content)},
+        )
 
     # Short-circuit: binary content types (images, PDFs, archives, etc.)
     if body and content_type and _is_binary_content_type(content_type):
@@ -896,14 +1146,36 @@ def _extract(
             f"Successfully fetched {url} using strategy: direct "
             f"(content_type: {content_type})"
         )
-        return _format_text(body)
+        content = _format_text(body)
+        return _make_result(
+            content=content,
+            url=url,
+            strategy="direct",
+            content_type=content_type,
+            started_at=started_at,
+            metadata={"content_length": len(content)},
+        )
 
     # 2-3. Local extraction (readability + optional soup).
     local_content = ""
     if body:
-        best, local_content = _try_local_extraction(body, url)
+        best, local_content, local_strategy, local_score = _try_local_extraction(
+            body, url
+        )
         if best:
-            return _format_text(best)
+            content = _format_text(best)
+            return _make_result(
+                content=content,
+                url=url,
+                strategy=local_strategy,
+                quality="high",
+                content_type=content_type,
+                started_at=started_at,
+                metadata={
+                    "readability_score": local_score,
+                    "content_length": len(content),
+                },
+            )
 
     # 4. Try VeilRender (remote browser rendering via REST API).
     if veilrender_endpoint and _remaining() > _MIN_STRATEGY_BUDGET:
@@ -912,7 +1184,15 @@ def _extract(
             url, veilrender_endpoint, veilrender_token, vr_budget
         )
         if vr_result:
-            return _format_text(vr_result)
+            content = _format_text(vr_result)
+            return _make_result(
+                content=content,
+                url=url,
+                strategy="veilrender",
+                content_type="text/html",
+                started_at=started_at,
+                metadata={"content_length": len(content)},
+            )
         if len(vr_local) > len(local_content):
             local_content = vr_local
 
@@ -921,7 +1201,15 @@ def _extract(
         cdp_budget = min(_remaining(), 15.0)
         cdp_result, cdp_local = _try_cdp_extraction(url, cdp_endpoint, cdp_budget)
         if cdp_result:
-            return _format_text(cdp_result)
+            content = _format_text(cdp_result)
+            return _make_result(
+                content=content,
+                url=url,
+                strategy="cdp",
+                content_type="text/html",
+                started_at=started_at,
+                metadata={"content_length": len(content)},
+            )
         if len(cdp_local) > len(local_content):
             local_content = cdp_local
 
@@ -936,7 +1224,15 @@ def _extract(
         deadline=deadline,
     )
     if jina_content:
-        return _format_text(jina_content)
+        content = _format_text(jina_content)
+        return _make_result(
+            content=content,
+            url=url,
+            strategy="jina",
+            content_type="text/markdown",
+            started_at=started_at,
+            metadata={"content_length": len(content)},
+        )
 
     # 6. Fall back to best local result if available.
     if local_content:
@@ -944,7 +1240,16 @@ def _extract(
             f"Successfully fetched {url} using strategy: local_fallback "
             f"(low_quality, length: {len(local_content)})"
         )
-        return _format_text(local_content)
+        content = _format_text(local_content)
+        return _make_result(
+            content=content,
+            url=url,
+            strategy="local_fallback",
+            quality="low",
+            content_type=content_type,
+            started_at=started_at,
+            metadata={"content_length": len(content)},
+        )
 
     logger.warning(f"All extraction strategies failed for {url}")
     raise FetchError(f"Unable to fetch content from {url}")

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -167,7 +167,8 @@ class BaseSearch(ABC):
             raise ValueError("Result missing URL")
 
         try:
-            result = Fetch().fetch_content(
+            fetcher = Fetch()
+            result = fetcher.fetch_content(  # ty: ignore[missing-argument]
                 url,
                 timeout=timeout,
                 proxy=proxy,

--- a/src/toolregistry_hub/websearch/base.py
+++ b/src/toolregistry_hub/websearch/base.py
@@ -167,11 +167,12 @@ class BaseSearch(ABC):
             raise ValueError("Result missing URL")
 
         try:
-            content = Fetch().fetch_content(
+            result = Fetch().fetch_content(
                 url,
                 timeout=timeout,
                 proxy=proxy,
             )
+            content = result["content"]
         except Exception as e:
             content = _UNABLE_TO_FETCH_CONTENT
             logger.debug(f"Error retrieving webpage content: {e}")

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -39,6 +39,20 @@ from toolregistry_hub.fetch import (
 )
 from toolregistry_hub.utils.api_key_parser import APIKeyParser
 
+
+def _fetch_result(content: str) -> dict:
+    return {
+        "content": content,
+        "url": "https://example.com",
+        "strategy": "test",
+        "quality": "high",
+        "content_type": "text/html",
+        "cached": False,
+        "elapsed_ms": 0,
+        "metadata": {},
+    }
+
+
 # ============================================================
 # _is_content_sufficient tests
 # ============================================================
@@ -890,12 +904,31 @@ class TestExtract:
     @patch("toolregistry_hub.fetch._extract_with_readability")
     @patch("toolregistry_hub.fetch._fetch_raw")
     @patch("toolregistry_hub.fetch._try_markdown_negotiation")
+    def test_structured_result_shape(
+        self, mock_md, mock_fetch, mock_readability, mock_soup, mock_jina
+    ):
+        mock_md.return_value = ("# Markdown Content\nSome text here.", "", "")
+        result = _extract("https://example.com")
+        assert result["content"] == "# Markdown Content\nSome text here."
+        assert result["url"] == "https://example.com"
+        assert result["strategy"] == "markdown"
+        assert result["quality"] == "high"
+        assert result["content_type"] == "text/markdown"
+        assert result["cached"] is False
+        assert isinstance(result["elapsed_ms"], int)
+        assert result["metadata"]["content_length"] == len(result["content"])
+
+    @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
+    @patch("toolregistry_hub.fetch._extract_with_soup")
+    @patch("toolregistry_hub.fetch._extract_with_readability")
+    @patch("toolregistry_hub.fetch._fetch_raw")
+    @patch("toolregistry_hub.fetch._try_markdown_negotiation")
     def test_markdown_negotiation_success(
         self, mock_md, mock_fetch, mock_readability, mock_soup, mock_jina
     ):
         mock_md.return_value = ("# Markdown Content\nSome text here.", "", "")
         result = _extract("https://example.com")
-        assert "Markdown Content" in result
+        assert "Markdown Content" in result["content"]
         mock_fetch.assert_not_called()
         mock_jina.assert_not_called()
 
@@ -912,7 +945,7 @@ class TestExtract:
         mock_readability.return_value = ("This is a long enough article. " * 10, 25.0)
         mock_soup.return_value = "Short soup."
         result = _extract("https://example.com")
-        assert "long enough article" in result
+        assert "long enough article" in result["content"]
         mock_jina.assert_not_called()
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
@@ -929,7 +962,7 @@ class TestExtract:
         high_quality = "Detailed article content. " * 200  # ~5200 chars
         mock_readability.return_value = (high_quality, 150.0)
         result = _extract("https://example.com")
-        assert "Detailed article content" in result
+        assert "Detailed article content" in result["content"]
         mock_soup.assert_not_called()
         mock_jina.assert_not_called()
 
@@ -980,7 +1013,7 @@ class TestExtract:
         mock_readability.return_value = ("", 0.0)
         mock_soup.return_value = "Soup extracted content is good enough. " * 10
         result = _extract("https://example.com")
-        assert "Soup extracted" in result
+        assert "Soup extracted" in result["content"]
         mock_jina.assert_not_called()
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
@@ -1003,7 +1036,7 @@ class TestExtract:
         mock_jina.return_value = "# Real Content\nActual article text here. " * 10
 
         result = _extract("https://example.com")
-        assert "Real Content" in result
+        assert "Real Content" in result["content"]
         mock_jina.assert_called_once()
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
@@ -1019,7 +1052,7 @@ class TestExtract:
         mock_jina.return_value = "# Jina Content\nFetched via Jina. " * 10
 
         result = _extract("https://example.com")
-        assert "Jina Content" in result
+        assert "Jina Content" in result["content"]
         mock_readability.assert_not_called()
         mock_soup.assert_not_called()
 
@@ -1038,7 +1071,7 @@ class TestExtract:
         mock_jina.return_value = ""
 
         result = _extract("https://example.com")
-        assert "Short low quality" in result
+        assert "Short low quality" in result["content"]
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
     @patch("toolregistry_hub.fetch._extract_with_soup")
@@ -1070,7 +1103,7 @@ class TestExtract:
         mock_fetch.return_value = (json_body, "application/json")
 
         result = _extract("https://api.example.com/data")
-        assert "results" in result
+        assert "results" in result["content"]
         # HTML extraction should be skipped entirely
         mock_readability.assert_not_called()
         mock_soup.assert_not_called()
@@ -1090,7 +1123,7 @@ class TestExtract:
         mock_fetch.return_value = (plain_body, "text/plain")
 
         result = _extract("https://example.com/readme.txt")
-        assert "plain text file" in result
+        assert "plain text file" in result["content"]
         mock_readability.assert_not_called()
         mock_soup.assert_not_called()
         mock_jina.assert_not_called()
@@ -1115,7 +1148,7 @@ class TestExtract:
         mock_fetch.return_value = ("some content body", content_type)
 
         result = _extract("https://example.com/file")
-        assert "some content body" in result
+        assert "some content body" in result["content"]
         mock_readability.assert_not_called()
         mock_soup.assert_not_called()
 
@@ -1134,7 +1167,7 @@ class TestExtract:
         mock_soup.return_value = ""
 
         result = _extract("https://example.com")
-        assert "Extracted article" in result
+        assert "Extracted article" in result["content"]
         mock_readability.assert_called_once()
 
     @patch("toolregistry_hub.fetch._get_content_with_jina_reader")
@@ -1154,7 +1187,7 @@ class TestExtract:
         mock_soup.return_value = ""
 
         result = _extract("https://example.com")
-        assert "Real content" in result
+        assert "Real content" in result["content"]
         # Key assertion: _fetch_raw should NOT have been called
         mock_fetch.assert_not_called()
 
@@ -1173,7 +1206,7 @@ class TestExtract:
         mock_soup.return_value = ""
 
         result = _extract("https://example.com")
-        assert "Fallback content" in result
+        assert "Fallback content" in result["content"]
         mock_fetch.assert_called_once()
 
     @patch("toolregistry_hub.fetch._try_markdown_negotiation")
@@ -1326,17 +1359,18 @@ class TestFetchCache:
 
     @patch("toolregistry_hub.fetch._extract")
     def test_second_call_uses_cache(self, mock_extract):
-        mock_extract.return_value = "Extracted content"
+        mock_extract.return_value = _fetch_result("Extracted content")
         fetcher = Fetch()
         result1 = fetcher.fetch_content("https://example.com")
         result2 = fetcher.fetch_content("https://example.com")
-        assert result1 == result2 == "Extracted content"
+        assert result1["content"] == result2["content"] == "Extracted content"
+        assert result2["cached"] is True
         # _extract should only be called once
         mock_extract.assert_called_once()
 
     @patch("toolregistry_hub.fetch._extract")
     def test_different_urls_not_cached(self, mock_extract):
-        mock_extract.return_value = "content"
+        mock_extract.return_value = _fetch_result("content")
         fetcher = Fetch()
         fetcher.fetch_content("https://a.com")
         fetcher.fetch_content("https://b.com")
@@ -1344,18 +1378,18 @@ class TestFetchCache:
 
     @patch("toolregistry_hub.fetch._extract")
     def test_fetch_error_not_cached(self, mock_extract):
-        mock_extract.side_effect = [FetchError("fail"), "success"]
+        mock_extract.side_effect = [FetchError("fail"), _fetch_result("success")]
         fetcher = Fetch()
         with pytest.raises(FetchError):
             fetcher.fetch_content("https://fail.com")
         # Second call should retry (not cached)
         result = fetcher.fetch_content("https://fail.com")
-        assert result == "success"
+        assert result["content"] == "success"
         assert mock_extract.call_count == 2
 
     @patch("toolregistry_hub.fetch._extract")
     def test_clear_cache_forces_refetch(self, mock_extract):
-        mock_extract.return_value = "content"
+        mock_extract.return_value = _fetch_result("content")
         fetcher = Fetch()
         fetcher.fetch_content("https://example.com")
         fetcher._clear_cache()
@@ -1364,7 +1398,7 @@ class TestFetchCache:
 
     @patch("toolregistry_hub.fetch._extract")
     def test_no_cache_mode(self, mock_extract):
-        mock_extract.return_value = "content"
+        mock_extract.return_value = _fetch_result("content")
         fetcher = Fetch(cache_ttl=0)
         fetcher.fetch_content("https://example.com")
         fetcher.fetch_content("https://example.com")
@@ -1773,7 +1807,7 @@ class TestExtractWithCDP:
         mock_cdp.return_value = ("Full article content. " * 10, "")
 
         result = _extract("https://spa.example.com", cdp_endpoint="ws://localhost:9222")
-        assert "Full article content" in result
+        assert "Full article content" in result["content"]
         mock_cdp.assert_called_once()
         mock_jina.assert_not_called()
 
@@ -1795,7 +1829,7 @@ class TestExtractWithCDP:
         mock_jina.return_value = "# Jina Content\nFull article from Jina. " * 10
 
         result = _extract("https://spa.example.com", cdp_endpoint="ws://localhost:9222")
-        assert "Jina Content" in result
+        assert "Jina Content" in result["content"]
         mock_cdp.assert_called_once()
         mock_jina.assert_called_once()
 
@@ -1821,7 +1855,7 @@ class TestExtractWithCDP:
         mock_jina.return_value = sufficient
 
         result = _extract("https://spa.example.com")  # No cdp_endpoint
-        assert "Jina Content" in result
+        assert "Jina Content" in result["content"]
         mock_cdp.assert_not_called()
         mock_jina.assert_called_once()
 
@@ -1846,7 +1880,7 @@ class TestExtractWithCDP:
         mock_jina.return_value = "# Full Jina Content\nComplete article. " * 10
 
         result = _extract("https://spa.example.com", cdp_endpoint="ws://localhost:9222")
-        assert "Full Jina Content" in result
+        assert "Full Jina Content" in result["content"]
         mock_cdp.assert_called_once()
         mock_jina.assert_called_once()
 

--- a/tests/websearch/test_websearch.py
+++ b/tests/websearch/test_websearch.py
@@ -121,10 +121,12 @@ class TestBaseSearch:
 
         assert len(results) == 1
 
-    @patch("toolregistry_hub.websearch.base.Fetch.fetch_content")
+    @patch("toolregistry_hub.websearch.base.Fetch")
     def test_fetch_webpage_content_success(self, mock_fetch):
         """Test successful webpage content fetching."""
-        mock_fetch.return_value = "Fetched webpage content"
+        mock_fetch.return_value.fetch_content.return_value = {
+            "content": "Fetched webpage content",
+        }
 
         entry = SearchResult(
             title="Example Title",
@@ -139,12 +141,12 @@ class TestBaseSearch:
         assert result["content"] == "Fetched webpage content"
         assert result["excerpt"] == "Example excerpt"
 
-        mock_fetch.assert_called_once()
+        mock_fetch.return_value.fetch_content.assert_called_once()
 
-    @patch("toolregistry_hub.websearch.base.Fetch.fetch_content")
+    @patch("toolregistry_hub.websearch.base.Fetch")
     def test_fetch_webpage_content_failure(self, mock_fetch):
         """Test webpage content fetching failure."""
-        mock_fetch.side_effect = Exception("Network error")
+        mock_fetch.return_value.fetch_content.side_effect = Exception("Network error")
 
         entry = SearchResult(
             title="Example Title",
@@ -170,10 +172,10 @@ class TestBaseSearch:
         with pytest.raises(ValueError, match="Result missing URL"):
             BaseSearch._fetch_webpage_content(entry)
 
-    @patch("toolregistry_hub.websearch.base.Fetch.fetch_content")
+    @patch("toolregistry_hub.websearch.base.Fetch")
     def test_fetch_webpage_content_with_timeout(self, mock_fetch):
         """Test webpage content fetching with custom timeout."""
-        mock_fetch.return_value = "Content"
+        mock_fetch.return_value.fetch_content.return_value = {"content": "Content"}
 
         entry = SearchResult(
             title="Title",
@@ -183,14 +185,14 @@ class TestBaseSearch:
 
         BaseSearch._fetch_webpage_content(entry, timeout=30)
 
-        mock_fetch.assert_called_once_with(
+        mock_fetch.return_value.fetch_content.assert_called_once_with(
             "https://example.com", timeout=30, proxy=None
         )
 
-    @patch("toolregistry_hub.websearch.base.Fetch.fetch_content")
+    @patch("toolregistry_hub.websearch.base.Fetch")
     def test_fetch_webpage_content_with_proxy(self, mock_fetch):
         """Test webpage content fetching with proxy."""
-        mock_fetch.return_value = "Content"
+        mock_fetch.return_value.fetch_content.return_value = {"content": "Content"}
 
         entry = SearchResult(
             title="Title",
@@ -202,7 +204,7 @@ class TestBaseSearch:
             entry, timeout=10, proxy="http://proxy.example.com:8080"
         )
 
-        mock_fetch.assert_called_once_with(
+        mock_fetch.return_value.fetch_content.assert_called_once_with(
             "https://example.com", timeout=10, proxy="http://proxy.example.com:8080"
         )
 


### PR DESCRIPTION
## Summary

- Add VeilRender as an optional browser rendering fallback in the fetch pipeline
- VeilRender renders JS-heavy pages via REST API (`POST /render`) using a remote headless browser
- Configured via `VEILRENDER_ENDPOINT` and `VEILRENDER_TOKEN` env vars
- Rendered HTML is re-parsed with readability/soup like CDP results
- Add structured `fetch_content` return value: `content`, `url`, `strategy`, `quality`, `content_type`, `cached`, `elapsed_ms`, `metadata`
- Add optional `strategy` parameter for explicit retry after auto returns unsuitable/low-quality content
  - default `strategy="auto"` (recommended)
  - explicit choices: `markdown`, `readability`, `soup`, `jina`
  - `veilrender` / `cdp` are shown only when configured

## Fallback chain

```
1. Cloudflare Content Negotiation
2. Readability (local)
3. Soup (local fallback)
4. VeilRender (remote browser rendering)
5. CDP (self-hosted browser rendering)
6. Jina Reader
7. local fallback (low quality)
```

## Return shape

```json
{
  "content": "...",
  "url": "https://example.com",
  "strategy": "readability",
  "quality": "high",
  "content_type": "text/html",
  "cached": false,
  "elapsed_ms": 123,
  "metadata": {"readability_score": 174.3, "content_length": 12345}
}
```

## Test plan

- [x] `pytest tests/test_fetch.py` — 189 passed
- [x] `ruff check src/toolregistry_hub/fetch.py tests/test_fetch.py`