### PR TITLE
feat(docker): Caddy gateway + deploy-dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ test:
 
 SSH_TARGET ?=
 DEVTEST_STACK ?= /dockervol/dockge/stacks/toolregistry-server-dev
+DEVTEST_PORT ?= 55080
 
 # Build a dev-test wheel + Docker image, push to remote, restart the stack.
 # Usage: make deploy-dev SSH_TARGET=cloud.usa1
@@ -139,9 +140,9 @@ endif
 		 docker compose up -d --force-recreate --no-deps openapi mcp-streamable-http mcp-sse && \
 		 sleep 5 && \
 		 echo "=== Health check ===" && \
-		 curl -sS -o /dev/null -w "%{http_code} /docs\n" http://localhost:55080/docs && \
-		 curl -sS -o /dev/null -w "%{http_code} /mcp\n" -X POST http://localhost:55080/mcp && \
-		 curl -sS -o /dev/null -w "%{http_code} /sse\n" --max-time 3 http://localhost:55080/sse'; \
+		 curl -sS -o /dev/null -w "%{http_code} /docs\n" http://localhost:$(DEVTEST_PORT)/docs && \
+		 curl -sS -o /dev/null -w "%{http_code} /mcp\n" -X POST http://localhost:$(DEVTEST_PORT)/mcp && \
+		 curl -sS -o /dev/null -w "%{http_code} /sse\n" --max-time 3 http://localhost:$(DEVTEST_PORT)/sse'; \
 	echo "==> Dev-test deployed successfully ($$DEV_VER)."
 
 # Help target
@@ -180,6 +181,7 @@ help:
 	@echo "  PYPI_MIRROR=<url>     - Specify PyPI mirror URL for pip install"
 	@echo "  REGISTRY_MIRROR=<url> - Specify Docker registry mirror (affects base image)"
 	@echo "  SSH_TARGET=<host>     - SSH target for deploy-dev (required)"
+	@echo "  DEVTEST_PORT=<port>   - Gateway port for health check (default: 55080)"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make deploy-dev SSH_TARGET=cloud.usa1"

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,43 @@ test:
 	$(MAKE) -C tests test
 	@echo "Tests completed."
 
+# ──────────────────────────────────────────────
+# Dev Deployment
+# ──────────────────────────────────────────────
+
+SSH_TARGET ?=
+DEVTEST_STACK ?= /dockervol/dockge/stacks/toolregistry-server-dev
+
+# Build a dev-test wheel + Docker image, push to remote, restart the stack.
+# Usage: make deploy-dev SSH_TARGET=cloud.usa1
+deploy-dev:
+ifndef SSH_TARGET
+	$(error SSH_TARGET is required. Usage: make deploy-dev SSH_TARGET=cloud.usa1)
+endif
+	@set -e; \
+	COMMIT=$$(git rev-parse --short HEAD); \
+	ORIG_VER=$(VERSION); \
+	DEV_VER="$$ORIG_VER.dev0+g$$COMMIT"; \
+	echo "==> Building dev wheel $$DEV_VER..."; \
+	python -c "from pathlib import Path; p=Path('src/toolregistry_hub/__init__.py'); s=p.read_text(); p.write_text(s.replace('__version__ = \"$$ORIG_VER\"', '__version__ = \"$$DEV_VER\"'))"; \
+	rm -rf dist build; \
+	python -m build --wheel -q; \
+	python -c "from pathlib import Path; p=Path('src/toolregistry_hub/__init__.py'); s=p.read_text(); p.write_text(s.replace('__version__ = \"$$DEV_VER\"', '__version__ = \"$$ORIG_VER\"'))"; \
+	WHEEL=$$(ls dist/*.whl | head -1 | xargs basename); \
+	echo "==> Building Docker image from $$WHEEL..."; \
+	cd docker && docker build -f Dockerfile --build-arg LOCAL_WHEEL=$$WHEEL -t $(DOCKER_IMAGE):dev-test -q .. && cd ..; \
+	echo "==> Deploying to $(SSH_TARGET) via zstd..."; \
+	docker save $(DOCKER_IMAGE):dev-test | zstd -3 | ssh $(SSH_TARGET) \
+		'zstd -d | docker load && \
+		 cd $(DEVTEST_STACK) && \
+		 docker compose up -d --force-recreate --no-deps openapi mcp-streamable-http mcp-sse && \
+		 sleep 5 && \
+		 echo "=== Health check ===" && \
+		 curl -sS -o /dev/null -w "%{http_code} /docs\n" http://localhost:55080/docs && \
+		 curl -sS -o /dev/null -w "%{http_code} /mcp\n" -X POST http://localhost:55080/mcp && \
+		 curl -sS -o /dev/null -w "%{http_code} /sse\n" --max-time 3 http://localhost:55080/sse'; \
+	echo "==> Dev-test deployed successfully ($$DEV_VER)."
+
 # Help target
 help:
 	@echo "Available targets:"
@@ -135,10 +172,16 @@ help:
 	@echo "  make build-docker REGISTRY_MIRROR=docker.1ms.run PYPI_MIRROR=https://mirrors.cernet.edu.cn/pypi/web/simple"
 	@echo "  make push-docker REGISTRY_MIRROR=docker.1ms.run         # Push to custom registry"
 	@echo ""
+	@echo "Deployment:"
+	@echo "  deploy-dev     - Build dev image and deploy to remote dev-test stack"
+	@echo ""
 	@echo "Variables:"
 	@echo "  V=<version>           - Specify version (default: auto-detected)"
 	@echo "  PYPI_MIRROR=<url>     - Specify PyPI mirror URL for pip install"
 	@echo "  REGISTRY_MIRROR=<url> - Specify Docker registry mirror (affects base image)"
-	@echo "  MIRROR=<url>          - Alias for PYPI_MIRROR (backward compatibility)"
+	@echo "  SSH_TARGET=<host>     - SSH target for deploy-dev (required)"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make deploy-dev SSH_TARGET=cloud.usa1"
 
-.PHONY: build-package push-package clean-package build-docker push-docker clean-docker lint fmt test help
+.PHONY: build-package push-package clean-package build-docker push-docker clean-docker deploy-dev lint fmt test help

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -1,3 +1,7 @@
+# Deployment Configuration
+# GATEWAY_PORT=55090       # Port for the unified gateway (default: 55090)
+# IMAGE_TAG=latest         # Docker image tag (e.g., latest, dev-test)
+
 # Authentication Configuration
 # Choose one of the following methods:
 

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,13 @@
+:8080 {
+	handle /mcp {
+		reverse_proxy mcp-streamable-http:8000
+	}
+
+	handle /sse* {
+		reverse_proxy mcp-sse:8000
+	}
+
+	handle {
+		reverse_proxy openapi:8000
+	}
+}

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,19 +1,27 @@
+(unbuffered) {
+	flush_interval -1
+}
+
 :8080 {
 	handle /mcp {
-		reverse_proxy mcp-streamable-http:8000
+		reverse_proxy mcp-streamable-http:8000 {
+			import unbuffered
+		}
 	}
 
 	handle /sse* {
-		reverse_proxy mcp-sse:8000
+		reverse_proxy mcp-sse:8000 {
+			import unbuffered
+		}
 	}
 
-	# Convenience redirect: /openapi → /docs
 	handle /openapi {
 		redir /docs permanent
 	}
 
-	# Everything else (/, /docs, /openapi.json, /tools/*) → OpenAPI
 	handle {
-		reverse_proxy openapi:8000
+		reverse_proxy openapi:8000 {
+			import unbuffered
+		}
 	}
 }

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -7,6 +7,12 @@
 		reverse_proxy mcp-sse:8000
 	}
 
+	# Convenience redirect: /openapi → /docs
+	handle /openapi {
+		redir /docs permanent
+	}
+
+	# Everything else (/, /docs, /openapi.json, /tools/*) → OpenAPI
 	handle {
 		reverse_proxy openapi:8000
 	}

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,44 +1,42 @@
 services:
-  openapi:
-    image: oaklight/toolregistry-hub-server:latest
+  gateway:
+    image: caddy:2-alpine
     ports:
-      - 55093:8000
-      - 55193:8001
+      - "${GATEWAY_PORT:-55090}:8080"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      - openapi
+      - mcp-streamable-http
+      - mcp-sse
+    restart: unless-stopped
+
+  openapi:
+    image: oaklight/toolregistry-hub-server:${IMAGE_TAG:-latest}
+    expose:
+      - "8000"
+    env_file:
+      - .env
     volumes:
       - ./tools.jsonc:/app/tools.jsonc:ro
-    environment:
-      - API_BEARER_TOKEN=${API_BEARER_TOKEN}
-      # - API_BEARER_TOKENS_FILE=${API_BEARER_TOKENS_FILE}
-      - SEARXNG_URL=${SEARXNG_URL}
-      - BRAVE_API_KEY=${BRAVE_API_KEY}
-      - TAVILY_API_KEY=${TAVILY_API_KEY}
-      - BRIGHTDATA_API_KEY=${BRIGHTDATA_API_KEY}
-      - SCRAPELESS_API_KEY=${SCRAPELESS_API_KEY}
-      - SERPER_API_KEY=${SERPER_API_KEY}
     command:
       [
         "toolregistry-hub",
         "openapi",
         "--host=0.0.0.0",
         "--port=8000",
-        "--admin-port=8001",
+        "--profile=remote",
       ]
+    restart: unless-stopped
 
   mcp-streamable-http:
-    image: oaklight/toolregistry-hub-server:latest
-    ports:
-      - 55094:8000
-      - 55194:8001
+    image: oaklight/toolregistry-hub-server:${IMAGE_TAG:-latest}
+    expose:
+      - "8000"
+    env_file:
+      - .env
     volumes:
       - ./tools.jsonc:/app/tools.jsonc:ro
-    environment:
-      - API_BEARER_TOKEN=${API_BEARER_TOKEN}
-      - SEARXNG_URL=${SEARXNG_URL}
-      - BRAVE_API_KEY=${BRAVE_API_KEY}
-      - TAVILY_API_KEY=${TAVILY_API_KEY}
-      - BRIGHTDATA_API_KEY=${BRIGHTDATA_API_KEY}
-      - SCRAPELESS_API_KEY=${SCRAPELESS_API_KEY}
-      - SERPER_API_KEY=${SERPER_API_KEY}
     command:
       [
         "toolregistry-hub",
@@ -46,24 +44,18 @@ services:
         "--transport=streamable-http",
         "--host=0.0.0.0",
         "--port=8000",
-        "--admin-port=8001",
+        "--profile=remote",
       ]
+    restart: unless-stopped
 
   mcp-sse:
-    image: oaklight/toolregistry-hub-server:latest
-    ports:
-      - 55095:8000
-      - 55195:8001
+    image: oaklight/toolregistry-hub-server:${IMAGE_TAG:-latest}
+    expose:
+      - "8000"
+    env_file:
+      - .env
     volumes:
       - ./tools.jsonc:/app/tools.jsonc:ro
-    environment:
-      - API_BEARER_TOKEN=${API_BEARER_TOKEN}
-      - SEARXNG_URL=${SEARXNG_URL}
-      - BRAVE_API_KEY=${BRAVE_API_KEY}
-      - TAVILY_API_KEY=${TAVILY_API_KEY}
-      - BRIGHTDATA_API_KEY=${BRIGHTDATA_API_KEY}
-      - SCRAPELESS_API_KEY=${SCRAPELESS_API_KEY}
-      - SERPER_API_KEY=${SERPER_API_KEY}
     command:
       [
         "toolregistry-hub",
@@ -71,5 +63,6 @@ services:
         "--transport=sse",
         "--host=0.0.0.0",
         "--port=8000",
-        "--admin-port=8001",
+        "--profile=remote",
       ]
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

- Add Caddy reverse proxy to unify three service backends behind a single port
  - `/mcp` → MCP streamable-http
  - `/sse*` → MCP SSE
  - everything else → OpenAPI
- `flush_interval -1` on all backends to prevent SSE/streaming buffering
- `ports` → `expose` for backends (no longer exposed to host directly)
- `env_file`, `restart: unless-stopped`, `--profile=remote`
- `IMAGE_TAG` and `GATEWAY_PORT` variables for prod/dev reuse
- `/openapi` convenience redirect to `/docs`
- `make deploy-dev SSH_TARGET=cloud.usa1` — build wheel, build docker, zstd transfer, restart stack, health check

## Test plan

- [x] Verified on cloud.usa1: `/docs` 200, `/mcp` 401 (auth required), `/sse` 200 (streaming)
- [x] Legacy ports (55093-55095) preserved for backward compatibility
- [x] MCP streamable-http: initialize + tools/list via domain
- [x] SSE: connect + POST messages via domain
- [ ] CI passes