### PR TITLE
feat(websearch): parallel multi-engine search with BM25 dedup

### DIFF
--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -18,6 +18,10 @@ SEARXNG_URL="https://searxng.url"
 # SCRAPELESS_API_KEY="your_scrapeless_api_key"
 # SERPER_API_KEY="your_serper_api_key"
 
+# WebSearch Configuration
+# WEBSEARCH_PRIORITY="brightdata,brave,tavily,searxng,scrapeless,serper"
+# WEBSEARCH_PARALLEL_ENGINES="brightdata,brave"
+
 # Fetch Tool Configuration
 # JINA_API_KEY="your_jina_api_key"
 # CDP_ENDPOINT="ws://localhost:9222"

--- a/src/toolregistry_hub/websearch/dedup.py
+++ b/src/toolregistry_hub/websearch/dedup.py
@@ -1,0 +1,139 @@
+"""BM25-based deduplication and re-ranking for multi-engine search results.
+
+When multiple search engines return results for the same query, duplicates
+(same URL) are collapsed and the remaining results are re-ranked using
+BM25 scoring against the original query.  This produces a single, high-quality
+result list from heterogeneous provider outputs.
+
+The implementation is zero-dependency — only ``math``, ``re``, and
+``collections`` from the standard library are used.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+
+from .search_result import SearchResult
+
+# BM25 tuning constants (standard Okapi BM25 defaults).
+_BM25_K1 = 1.5
+_BM25_B = 0.75
+
+# Simple word-boundary tokenizer.  Good enough for search-result snippets
+# in Latin, CJK, and mixed scripts.
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def _tokenize(text: str) -> list[str]:
+    """Split *text* into lowercase word tokens.
+
+    Args:
+        text: Input text.
+
+    Returns:
+        List of lowercase tokens.
+    """
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _bm25_score(
+    query_tokens: list[str],
+    doc_tokens: list[str],
+    avg_dl: float,
+    df: dict[str, int],
+    n_docs: int,
+) -> float:
+    """Compute the BM25 score of a single document against a query.
+
+    Args:
+        query_tokens: Tokenized query.
+        doc_tokens: Tokenized document (title + content).
+        avg_dl: Average document length across the corpus.
+        df: Document-frequency map (token → count of docs containing it).
+        n_docs: Total number of documents in the corpus.
+
+    Returns:
+        BM25 relevance score (higher is better).
+    """
+    tf = Counter(doc_tokens)
+    dl = len(doc_tokens)
+    score = 0.0
+
+    for term in query_tokens:
+        if term not in tf:
+            continue
+        term_tf = tf[term]
+        term_df = df.get(term, 0)
+        # IDF with smoothing (avoid log(0) and negative IDF)
+        idf = math.log(1.0 + (n_docs - term_df + 0.5) / (term_df + 0.5))
+        # TF normalization
+        numerator = term_tf * (_BM25_K1 + 1.0)
+        denominator = term_tf + _BM25_K1 * (1.0 - _BM25_B + _BM25_B * dl / avg_dl)
+        score += idf * numerator / denominator
+
+    return score
+
+
+def deduplicate_results(
+    results: list[SearchResult],
+    query: str,
+) -> list[SearchResult]:
+    """Deduplicate and re-rank search results using BM25 scoring.
+
+    Steps:
+        1. **URL dedup** — when multiple results share the same URL, keep only
+           the one with the longest ``content`` (richest snippet).
+        2. **BM25 re-rank** — score each remaining result's ``title + content``
+           against the *query* tokens and sort descending.
+
+    Args:
+        results: Combined results from multiple engines (may contain dupes).
+        query: The original search query string.
+
+    Returns:
+        Deduplicated results sorted by BM25 relevance (best first).
+    """
+    if not results:
+        return []
+
+    # ── Step 1: URL dedup (keep longest content per URL) ─────────────────
+    best_by_url: dict[str, SearchResult] = {}
+    for r in results:
+        url = r.url.rstrip("/")
+        existing = best_by_url.get(url)
+        if existing is None or len(r.content) > len(existing.content):
+            best_by_url[url] = r
+
+    unique = list(best_by_url.values())
+
+    if len(unique) <= 1:
+        return unique
+
+    # ── Step 2: BM25 re-rank ─────────────────────────────────────────────
+    query_tokens = _tokenize(query)
+    if not query_tokens:
+        return unique  # can't score without query tokens
+
+    # Tokenize all documents
+    doc_token_lists = [_tokenize(f"{r.title} {r.content}") for r in unique]
+
+    # Corpus statistics
+    n_docs = len(unique)
+    avg_dl = sum(len(dt) for dt in doc_token_lists) / n_docs
+
+    # Document frequency
+    df: dict[str, int] = {}
+    for dt in doc_token_lists:
+        for term in set(dt):
+            df[term] = df.get(term, 0) + 1
+
+    # Score and sort
+    scored = [
+        (r, _bm25_score(query_tokens, dt, avg_dl, df, n_docs))
+        for r, dt in zip(unique, doc_token_lists, strict=True)
+    ]
+    scored.sort(key=lambda x: x[1], reverse=True)
+
+    return [r for r, _score in scored]

--- a/src/toolregistry_hub/websearch/websearch_unified.py
+++ b/src/toolregistry_hub/websearch/websearch_unified.py
@@ -293,6 +293,8 @@ class WebSearch:
                 specific engine name if you need a particular provider.
             fallback: If True and the chosen engine fails, automatically try
                 the next available engine instead of raising an error.
+                Ignored when ``engine="parallel"`` (parallel mode has
+                built-in per-engine error handling).
             timeout: Request timeout in seconds.
 
         Returns:

--- a/src/toolregistry_hub/websearch/websearch_unified.py
+++ b/src/toolregistry_hub/websearch/websearch_unified.py
@@ -1,20 +1,27 @@
 """Unified WebSearch entry point.
 
 Wraps all available search providers behind a single ``search()`` method with an
-``engine`` selector. Engines are instantiated lazily and skipped when their API
-keys are missing. Supports an ``"auto"`` mode that picks the first configured
-engine from a configurable priority list, plus an explicit ``fallback`` flag for
-graceful degradation when a chosen engine is unavailable.
+``engine`` selector.  Three modes:
+
+- ``"auto"`` (default) — try engines sequentially in priority order, return
+  the first successful result.
+- ``"parallel"`` — query multiple engines concurrently, deduplicate and
+  re-rank results with BM25 scoring.
+- ``"<name>"`` — use a specific engine directly.
+
+Engines are instantiated lazily and skipped when their API keys are missing.
 """
 
 from __future__ import annotations
 
 import os
 import types
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Literal
 
 from .._vendor.structlog import get_logger
 from .base import TIMEOUT_DEFAULT, BaseSearch
+from .dedup import deduplicate_results
 from .search_result import SearchResult
 
 logger = get_logger()
@@ -27,6 +34,7 @@ logger = get_logger()
 # real runtime availability.
 EngineName = Literal[
     "auto",
+    "parallel",
     "brave",
     "tavily",
     "searxng",
@@ -48,6 +56,10 @@ _DEFAULT_PRIORITY: tuple[str, ...] = (
     "scrapeless",
     "searxng",
 )
+
+# Default engines to query in parallel mode.
+# Override via ``WEBSEARCH_PARALLEL_ENGINES`` env var (comma-separated).
+_DEFAULT_PARALLEL_ENGINES: tuple[str, ...] = ("brightdata", "brave")
 
 
 # Maps engine name -> (module path, class name). Lazily imported so unused
@@ -125,24 +137,36 @@ def _resolve_priority(priority: str | None = None) -> list[str]:
     return valid or list(_DEFAULT_PRIORITY)
 
 
+def _resolve_parallel_engines() -> list[str]:
+    """Resolve which engines to use in parallel mode.
+
+    Reads from ``WEBSEARCH_PARALLEL_ENGINES`` env var (comma-separated),
+    falling back to ``_DEFAULT_PARALLEL_ENGINES``.
+
+    Returns:
+        List of valid engine names for parallel queries.
+    """
+    raw = os.getenv("WEBSEARCH_PARALLEL_ENGINES")
+    if not raw:
+        return list(_DEFAULT_PARALLEL_ENGINES)
+
+    names = [p.strip().lower() for p in raw.split(",") if p.strip()]
+    valid = [n for n in names if n in _ENGINE_REGISTRY]
+    if not valid:
+        logger.warning(
+            "WEBSEARCH_PARALLEL_ENGINES contained no valid engines; using defaults"
+        )
+        return list(_DEFAULT_PARALLEL_ENGINES)
+    return valid
+
+
 class WebSearch:
     """Unified web search entry point that dispatches to multiple providers.
 
     Users can either let the wrapper auto-select the best configured provider
-    (``engine="auto"``) or pin a specific engine. Unconfigured engines (missing
-    API keys) are skipped automatically. When a specific engine is requested
-    but unavailable, the call fails by default -- set ``fallback=True`` on a
-    per-call basis to fall through to the auto chain instead.
-
-    Example:
-        >>> ws = WebSearch()
-        >>> ws.search("latest python release", max_results=5)  # auto
-        >>> ws.search("latest python release", engine="tavily")  # strict
-        >>> ws.search("latest python release", engine="tavily", fallback=True)
-
-    The priority order for ``engine="auto"`` defaults to paid-provider-first
-    and can be overridden via the ``WEBSEARCH_PRIORITY`` environment variable
-    (comma-separated engine names).
+    (``engine="auto"``), query multiple engines in parallel for higher quality
+    results (``engine="parallel"``), or pin a specific engine.  Unconfigured
+    engines (missing API keys) are skipped automatically.
     """
 
     def __init__(self, priority: str | None = None):
@@ -153,38 +177,23 @@ class WebSearch:
                 ``WEBSEARCH_PRIORITY`` env var, then ``_DEFAULT_PRIORITY``.
         """
         self._priority: list[str] = _resolve_priority(priority)
+        self._parallel_engines: list[str] = _resolve_parallel_engines()
         # Cache instantiated engines (configured ones only)
         self._engine_cache: dict[str, BaseSearch] = {}
         # Narrow the ``engine`` parameter type to only the configured engines
-        # so that the JSON schema seen by LLM clients reflects the real runtime
-        # availability. The class-level full Literal remains intact for IDE /
-        # static analysis use.
         self._narrow_engine_annotation()
 
     def _narrow_engine_annotation(self) -> None:
         """Replace ``self.search`` with a per-instance copy whose ``engine``
-        annotation is narrowed to ``Literal["auto", *configured]``.
+        annotation is narrowed to ``Literal["auto", "parallel", *configured]``.
 
-        Called from ``__init__``. No-op when no engines are configured (the
-        unified tool will then be auto-disabled by ``build_registry`` via the
-        :class:`Configurable` protocol, so the schema is irrelevant).
-
-        Implementation notes:
-            - We construct a fresh ``FunctionType`` from the class method's
-              code so that mutating ``__annotations__`` on this copy does not
-              affect other instances.
-            - The new function is then re-bound to ``self`` as a regular method.
-            - ``get_type_hints()`` (used by toolregistry / pydantic for schema
-              generation) will see the dynamically-built ``Literal`` instead
-              of the deferred string annotation from ``from __future__ import
-              annotations``.
+        Called from ``__init__``. No-op when no engines are configured.
         """
         configured = self._configured_engine_names()
         if not configured:
-            return  # Nothing to narrow; tool will be auto-disabled anyway
+            return
 
         original = type(self).search
-        # Build a fresh function with the same code but isolated annotations.
         new_func = types.FunctionType(
             original.__code__,
             original.__globals__,
@@ -195,15 +204,13 @@ class WebSearch:
         new_func.__doc__ = original.__doc__
         new_func.__qualname__ = original.__qualname__
         new_func.__kwdefaults__ = original.__kwdefaults__
-        # Copy then override the engine annotation with the narrowed Literal.
         new_func.__annotations__ = dict(original.__annotations__)
-        narrowed_literal = Literal.__getitem__(("auto", *configured))  # type: ignore[arg-type]
+        narrowed_literal = Literal.__getitem__(("auto", "parallel", *configured))  # type: ignore[arg-type]
         new_func.__annotations__["engine"] = narrowed_literal
-        # Bind as method so ``self.search(query, ...)`` works normally.
         self.search = types.MethodType(new_func, self)  # type: ignore[method-assign]
 
     def _configured_engine_names(self) -> list[str]:
-        """Return the priority-ordered list of engine names that are currently configured.
+        """Return the priority-ordered list of engine names that are configured.
 
         Returns:
             List of engine names with valid API keys, in priority order.
@@ -211,18 +218,13 @@ class WebSearch:
         return [n for n in self._priority if self._get_engine(n) is not None]
 
     def _is_configured(self) -> bool:
-        """Configured iff at least one underlying engine is configured.
-
-        Used by :func:`build_registry` via the ``Configurable`` protocol to
-        auto-disable the unified tool when no providers have keys set.
-        """
+        """Configured iff at least one underlying engine is configured."""
         return bool(self._configured_engine_names())
 
     def _get_engine(self, name: str) -> BaseSearch | None:
         """Return a configured engine instance for ``name``, or ``None``.
 
-        Lazily instantiates and caches the engine. Returns ``None`` when the
-        engine cannot be constructed or reports itself as unconfigured.
+        Lazily instantiates and caches the engine.
 
         Args:
             name: Engine identifier.
@@ -248,10 +250,11 @@ class WebSearch:
         return instance
 
     def list_engines(self) -> dict[str, bool]:
-        """List all known engines and whether each is currently configured.
+        """List all known search engines and whether each is currently configured.
 
         Returns:
-            Mapping of engine name -> configured status.
+            Mapping of engine name -> True if the engine has valid API keys
+            and is ready to use, False otherwise.
         """
         result: dict[str, bool] = {}
         for name in _ENGINE_REGISTRY:
@@ -262,44 +265,38 @@ class WebSearch:
         self,
         query: str,
         *,
+        count: int = 5,
         engine: EngineName = "auto",
         fallback: bool = False,
-        max_results: int = 5,
         timeout: float = TIMEOUT_DEFAULT,
-        **kwargs,
     ) -> list[SearchResult]:
         """Perform a web search via the selected engine.
 
-        IMPORTANT: For time-sensitive queries (e.g., "recent news", "latest updates",
-        "today's events"), you MUST first obtain the current date/time using an
-        available time/datetime tool before constructing your search query. As an
-        LLM, you have no inherent sense of current time -- your training data may
-        be outdated. Always verify the current date when temporal context matters.
+        This is the primary tool for web search. Just pass a query — the
+        engine is selected automatically from configured providers (Brave,
+        Tavily, SearXNG, etc.) with built-in fallback. You do NOT need to
+        pick a specific engine unless you have a reason to.
+
+        Use ``engine="parallel"`` to query multiple engines simultaneously
+        and get deduplicated, BM25-ranked results for higher quality.
+
+        IMPORTANT: For time-sensitive queries (e.g., "recent news", "latest
+        updates", "today's events"), first obtain the current date/time using
+        the datetime tool. You have no inherent sense of current time.
 
         Args:
             query: The search query string.
-            engine: Provider to use. Either ``"auto"`` (try configured engines
-                in priority order) or a specific name from
-                ``["brave", "tavily", "searxng", "brightdata", "scrapeless", "serper"]``.
-                Note: at runtime this parameter's accepted values are narrowed
-                to only the engines whose API keys are configured on this
-                instance. Call ``list_engines()`` to inspect availability.
-            fallback: When ``engine`` is a specific provider, controls behavior
-                if that provider is unavailable or raises. ``False`` (default)
-                propagates the error; ``True`` falls back to the auto chain
-                excluding the originally-requested engine.
-            max_results: Maximum number of results to return (1-20 recommended).
-            timeout: Per-request timeout in seconds.
-            **kwargs: Provider-specific extra parameters (forwarded as-is).
+            count: Number of results to return (default 5, max 20).
+            engine: Search provider. Leave as ``"auto"`` (recommended) to let
+                the server pick the best available engine. Use ``"parallel"``
+                to query multiple engines and merge results. Only set a
+                specific engine name if you need a particular provider.
+            fallback: If True and the chosen engine fails, automatically try
+                the next available engine instead of raising an error.
+            timeout: Request timeout in seconds.
 
         Returns:
-            List of search results.
-
-        Raises:
-            ValueError: If ``engine`` is not a recognized name, or if the query
-                is empty.
-            RuntimeError: If no engine is available (auto mode), or if the
-                requested engine is unavailable and ``fallback=False``.
+            List of search results, each with title, url, content, and score.
         """
         if not query or not query.strip():
             return []
@@ -310,15 +307,21 @@ class WebSearch:
             return self._search_auto(
                 query,
                 exclude=None,
-                max_results=max_results,
+                max_results=count,
                 timeout=timeout,
-                **kwargs,
+            )
+
+        if engine == "parallel":
+            return self._search_parallel(
+                query,
+                max_results=count,
+                timeout=timeout,
             )
 
         if engine not in _ENGINE_REGISTRY:
             raise ValueError(
                 f"Unknown websearch engine: {engine!r}. "
-                f"Available: {sorted(_ENGINE_REGISTRY)} or 'auto'"
+                f"Available: {sorted(_ENGINE_REGISTRY)} or 'auto' or 'parallel'"
             )
 
         instance = self._get_engine(engine)
@@ -330,15 +333,12 @@ class WebSearch:
             return self._search_auto(
                 query,
                 exclude={engine},
-                max_results=max_results,
+                max_results=count,
                 timeout=timeout,
-                **kwargs,
             )
 
         try:
-            return instance.search(
-                query, max_results=max_results, timeout=timeout, **kwargs
-            )
+            return instance.search(query, max_results=count, timeout=timeout)
         except Exception as e:  # noqa: BLE001
             if not fallback:
                 raise
@@ -349,10 +349,11 @@ class WebSearch:
             return self._search_auto(
                 query,
                 exclude={engine},
-                max_results=max_results,
+                max_results=count,
                 timeout=timeout,
-                **kwargs,
             )
+
+    # ── Internal strategies ──────────────────────────────────────────────
 
     def _search_auto(
         self,
@@ -361,16 +362,16 @@ class WebSearch:
         exclude: set[str] | None = None,
         max_results: int = 5,
         timeout: float = TIMEOUT_DEFAULT,
-        **kwargs,
     ) -> list[SearchResult]:
         """Try engines in priority order; return the first successful result.
+
+        Automatically skips unconfigured and failing engines.
 
         Args:
             query: Search query.
             exclude: Engine names to skip.
             max_results: Result cap.
             timeout: Per-request timeout.
-            **kwargs: Forwarded to engine.
 
         Returns:
             Search results from the first successful engine.
@@ -392,7 +393,9 @@ class WebSearch:
             try:
                 logger.debug(f"Trying engine {name!r} for query {query!r}")
                 results = instance.search(
-                    query, max_results=max_results, timeout=timeout, **kwargs
+                    query,
+                    max_results=max_results,
+                    timeout=timeout,
                 )
                 if results:
                     return results
@@ -415,5 +418,85 @@ class WebSearch:
                 f"Last error: {type(last_error).__name__}: {last_error}"
             ) from last_error
 
-        # All engines returned empty results
         return []
+
+    def _search_parallel(
+        self,
+        query: str,
+        *,
+        max_results: int = 5,
+        timeout: float = TIMEOUT_DEFAULT,
+    ) -> list[SearchResult]:
+        """Query multiple engines concurrently, deduplicate, and re-rank.
+
+        Engines are read from ``WEBSEARCH_PARALLEL_ENGINES`` (default:
+        ``brightdata,brave``).  Unconfigured engines are skipped.  Individual
+        engine failures are logged but do not abort the search — results from
+        successful engines are still returned.
+
+        Args:
+            query: Search query.
+            max_results: Maximum number of results after deduplication.
+            timeout: Per-engine timeout.
+
+        Returns:
+            Deduplicated, BM25-ranked results from all successful engines.
+
+        Raises:
+            RuntimeError: If no parallel engines are configured.
+        """
+        # Resolve which engines to use, skipping unconfigured ones.
+        engines: list[tuple[str, BaseSearch]] = []
+        for name in self._parallel_engines:
+            instance = self._get_engine(name)
+            if instance is not None:
+                engines.append((name, instance))
+
+        if not engines:
+            logger.info("No parallel engines configured; falling back to auto")
+            return self._search_auto(
+                query,
+                max_results=max_results,
+                timeout=timeout,
+            )
+
+        # Query all engines concurrently.
+        all_results: list[SearchResult] = []
+        engine_names = [name for name, _ in engines]
+        logger.debug(f"Parallel search with engines: {engine_names}")
+
+        with ThreadPoolExecutor(max_workers=len(engines)) as pool:
+            futures = {
+                pool.submit(
+                    inst.search,
+                    query,
+                    max_results=max_results,
+                    timeout=timeout,
+                ): name
+                for name, inst in engines
+            }
+            for future in as_completed(futures):
+                name = futures[future]
+                try:
+                    results = future.result()
+                    if results:
+                        all_results.extend(results)
+                        logger.debug(f"Engine {name!r} returned {len(results)} results")
+                    else:
+                        logger.debug(f"Engine {name!r} returned no results")
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        f"Parallel engine {name!r} failed: {type(e).__name__}: {e}"
+                    )
+
+        if not all_results:
+            logger.info("All parallel engines returned empty; falling back to auto")
+            return self._search_auto(
+                query,
+                max_results=max_results,
+                timeout=timeout,
+            )
+
+        # Deduplicate and re-rank with BM25.
+        deduped = deduplicate_results(all_results, query)
+        return deduped[:max_results]

--- a/tests/websearch/test_dedup.py
+++ b/tests/websearch/test_dedup.py
@@ -1,0 +1,164 @@
+"""Tests for BM25-based deduplication and re-ranking."""
+
+from toolregistry_hub.websearch.dedup import (
+    _bm25_score,
+    _tokenize,
+    deduplicate_results,
+)
+from toolregistry_hub.websearch.search_result import SearchResult
+
+
+def _r(title="t", url="https://example.com", content="c", score=1.0):
+    return SearchResult(title=title, url=url, content=content, score=score)
+
+
+# ── Tokenizer ────────────────────────────────────────────────────────────
+
+
+class TestTokenize:
+    def test_basic(self):
+        assert _tokenize("Hello World") == ["hello", "world"]
+
+    def test_punctuation_stripped(self):
+        assert _tokenize("python 3.12 release!") == ["python", "3", "12", "release"]
+
+    def test_empty(self):
+        assert _tokenize("") == []
+
+    def test_unicode(self):
+        tokens = _tokenize("Python 发布 3.12")
+        assert "python" in tokens
+        assert "发布" in tokens
+
+
+# ── BM25 scoring ─────────────────────────────────────────────────────────
+
+
+class TestBM25Score:
+    def test_matching_terms_score_positive(self):
+        score = _bm25_score(
+            query_tokens=["python"],
+            doc_tokens=["python", "is", "great"],
+            avg_dl=3.0,
+            df={"python": 1, "is": 2, "great": 1},
+            n_docs=3,
+        )
+        assert score > 0
+
+    def test_no_matching_terms_score_zero(self):
+        score = _bm25_score(
+            query_tokens=["rust"],
+            doc_tokens=["python", "is", "great"],
+            avg_dl=3.0,
+            df={"python": 1},
+            n_docs=3,
+        )
+        assert score == 0.0
+
+    def test_rarer_terms_score_higher(self):
+        # "python" appears in 1/10 docs vs "the" in 9/10 docs
+        score_rare = _bm25_score(
+            query_tokens=["python"],
+            doc_tokens=["python", "tutorial"],
+            avg_dl=5.0,
+            df={"python": 1, "the": 9},
+            n_docs=10,
+        )
+        score_common = _bm25_score(
+            query_tokens=["the"],
+            doc_tokens=["the", "tutorial"],
+            avg_dl=5.0,
+            df={"python": 1, "the": 9},
+            n_docs=10,
+        )
+        assert score_rare > score_common
+
+
+# ── Deduplication ────────────────────────────────────────────────────────
+
+
+class TestDeduplicateResults:
+    def test_empty_input(self):
+        assert deduplicate_results([], "python") == []
+
+    def test_single_result(self):
+        results = [_r(content="Python tutorial")]
+        deduped = deduplicate_results(results, "python")
+        assert len(deduped) == 1
+
+    def test_url_dedup_keeps_longest_content(self):
+        results = [
+            _r(url="https://a.com", content="short"),
+            _r(url="https://a.com", content="much longer content here"),
+        ]
+        deduped = deduplicate_results(results, "test")
+        assert len(deduped) == 1
+        assert deduped[0].content == "much longer content here"
+
+    def test_url_dedup_normalizes_trailing_slash(self):
+        results = [
+            _r(url="https://a.com/path/", content="with slash"),
+            _r(url="https://a.com/path", content="without slash but longer text"),
+        ]
+        deduped = deduplicate_results(results, "test")
+        assert len(deduped) == 1
+
+    def test_different_urls_preserved(self):
+        results = [
+            _r(url="https://a.com", content="content a about python"),
+            _r(url="https://b.com", content="content b about python"),
+        ]
+        deduped = deduplicate_results(results, "python")
+        assert len(deduped) == 2
+
+    def test_bm25_reranks_by_relevance(self):
+        results = [
+            _r(
+                url="https://irrelevant.com",
+                title="Cooking recipes",
+                content="Best pasta recipes for dinner tonight",
+            ),
+            _r(
+                url="https://relevant.com",
+                title="Python tutorial",
+                content="Learn Python programming with examples",
+            ),
+        ]
+        deduped = deduplicate_results(results, "python programming")
+        assert deduped[0].url == "https://relevant.com"
+
+    def test_empty_query_preserves_order(self):
+        results = [
+            _r(url="https://a.com", content="first"),
+            _r(url="https://b.com", content="second"),
+        ]
+        deduped = deduplicate_results(results, "   ")
+        # Empty query can't score — should still return deduped results
+        assert len(deduped) == 2
+
+    def test_mixed_engines_deduplicated(self):
+        """Simulate two engines returning overlapping results."""
+        engine_a = [
+            _r(url="https://shared.com", title="Shared", content="short"),
+            _r(url="https://only-a.com", title="Only A", content="unique to a"),
+        ]
+        engine_b = [
+            _r(
+                url="https://shared.com",
+                title="Shared Result",
+                content="longer version from engine b",
+            ),
+            _r(url="https://only-b.com", title="Only B", content="unique to b"),
+        ]
+        combined = engine_a + engine_b
+        deduped = deduplicate_results(combined, "test query")
+        urls = {r.url for r in deduped}
+        assert len(deduped) == 3
+        assert urls == {
+            "https://shared.com",
+            "https://only-a.com",
+            "https://only-b.com",
+        }
+        # Shared URL should keep the longer content
+        shared = next(r for r in deduped if "shared" in r.url)
+        assert shared.content == "longer version from engine b"

--- a/tests/websearch/test_websearch_unified.py
+++ b/tests/websearch/test_websearch_unified.py
@@ -262,7 +262,7 @@ class TestSearchSpecificEngine:
         results = ws.search("python", engine="BRAVE")
         assert results[0].title == "brave-result"
 
-    def test_kwargs_forwarded(self, mock_engines):
+    def test_count_forwarded_as_max_results(self, mock_engines):
         brave = MagicMock()
         brave.search.return_value = []
         mock_engines["brave"] = brave
@@ -271,12 +271,13 @@ class TestSearchSpecificEngine:
         ws.search(
             "python",
             engine="brave",
-            max_results=10,
+            count=10,
             timeout=30.0,
-            country="US",
         )
         brave.search.assert_called_once_with(
-            "python", max_results=10, timeout=30.0, country="US"
+            "python",
+            max_results=10,
+            timeout=30.0,
         )
 
 
@@ -349,7 +350,7 @@ class TestEngineAnnotationNarrowing:
     def test_static_class_literal_is_full(self):
         """Class-level ``EngineName`` keeps the full set for IDE / type checkers."""
         full = set(get_args(EngineName))
-        assert full == {"auto", *_ENGINE_REGISTRY}
+        assert full == {"auto", "parallel", *_ENGINE_REGISTRY}
 
     def test_no_narrowing_when_no_engines_configured(self, mock_engines):
         """No engines configured → no override; class-level annotation remains."""
@@ -363,7 +364,7 @@ class TestEngineAnnotationNarrowing:
         # Per-instance copy was bound
         assert ws.search.__func__ is not WebSearch.search
         engine_anno = ws.search.__func__.__annotations__["engine"]
-        assert set(get_args(engine_anno)) == {"auto", "brave"}
+        assert set(get_args(engine_anno)) == {"auto", "parallel", "brave"}
 
     def test_narrowing_includes_only_configured_in_priority_order(self, mock_engines):
         # Configure brave, tavily, searxng
@@ -374,7 +375,7 @@ class TestEngineAnnotationNarrowing:
         narrowed = get_args(engine_anno)
         # "auto" first, then engines in default priority order
         assert narrowed[0] == "auto"
-        assert set(narrowed) == {"auto", "brave", "tavily", "searxng"}
+        assert set(narrowed) == {"auto", "parallel", "brave", "tavily", "searxng"}
 
     def test_narrowing_is_per_instance(self, mock_engines):
         """Mutating one instance's engines should not affect another."""
@@ -387,8 +388,8 @@ class TestEngineAnnotationNarrowing:
         ws2 = WebSearch()
         anno2 = ws2.search.__func__.__annotations__["engine"]
 
-        assert set(get_args(anno1)) == {"auto", "brave"}
-        assert set(get_args(anno2)) == {"auto", "brave", "tavily"}
+        assert set(get_args(anno1)) == {"auto", "parallel", "brave"}
+        assert set(get_args(anno2)) == {"auto", "parallel", "brave", "tavily"}
 
     def test_get_type_hints_returns_narrowed_literal(self, mock_engines):
         """Confirms toolregistry/pydantic schema generators see the narrowed type."""
@@ -396,7 +397,7 @@ class TestEngineAnnotationNarrowing:
         ws = WebSearch()
         hints = get_type_hints(ws.search.__func__)
         engine_hint = hints["engine"]
-        assert set(get_args(engine_hint)) == {"auto", "brave"}
+        assert set(get_args(engine_hint)) == {"auto", "parallel", "brave"}
 
     def test_narrowed_search_still_callable(self, mock_engines):
         """The replacement function must work as a normal bound method."""
@@ -418,5 +419,128 @@ class TestEngineAnnotationNarrowing:
         ws = WebSearch()
         engine_anno = ws.search.__func__.__annotations__["engine"]
         narrowed = set(get_args(engine_anno))
-        assert narrowed == {"auto", "brave"}
+        assert "auto" in narrowed
+        assert "parallel" in narrowed
+        assert "brave" in narrowed
         assert "tavily" not in narrowed
+
+
+# ---------------------------------------------------------------------------
+# search() — parallel mode
+# ---------------------------------------------------------------------------
+
+
+class TestSearchParallel:
+    def test_parallel_queries_configured_engines(self, mock_engines, monkeypatch):
+        """Parallel mode should query all configured parallel engines."""
+        monkeypatch.setenv("WEBSEARCH_PARALLEL_ENGINES", "brave,tavily")
+        brave = MagicMock()
+        brave.search.return_value = [_make_result("brave-r")]
+        mock_engines["brave"] = brave
+        tavily = MagicMock()
+        tavily.search.return_value = [_make_result("tavily-r", url="u2")]
+        mock_engines["tavily"] = tavily
+
+        ws = WebSearch()
+        results = ws.search("python", engine="parallel")
+        assert len(results) == 2
+        brave.search.assert_called_once()
+        tavily.search.assert_called_once()
+
+    def test_parallel_skips_unconfigured(self, mock_engines, monkeypatch):
+        """Unconfigured engines in the parallel list are skipped."""
+        monkeypatch.setenv("WEBSEARCH_PARALLEL_ENGINES", "brave,tavily")
+        brave = MagicMock()
+        brave.search.return_value = [_make_result("brave-only")]
+        mock_engines["brave"] = brave
+        # tavily not configured (None)
+
+        ws = WebSearch()
+        results = ws.search("python", engine="parallel")
+        assert len(results) == 1
+        assert results[0].title == "brave-only"
+
+    def test_parallel_handles_engine_failure(self, mock_engines, monkeypatch):
+        """One engine failing should not affect results from others."""
+        monkeypatch.setenv("WEBSEARCH_PARALLEL_ENGINES", "brave,tavily")
+        brave = MagicMock()
+        brave.search.side_effect = RuntimeError("brave down")
+        mock_engines["brave"] = brave
+        tavily = MagicMock()
+        tavily.search.return_value = [_make_result("tavily-ok")]
+        mock_engines["tavily"] = tavily
+
+        ws = WebSearch()
+        results = ws.search("python", engine="parallel")
+        assert len(results) == 1
+        assert results[0].title == "tavily-ok"
+
+    def test_parallel_deduplicates_same_url(self, mock_engines, monkeypatch):
+        """Results with the same URL from different engines are deduped."""
+        monkeypatch.setenv("WEBSEARCH_PARALLEL_ENGINES", "brave,tavily")
+        brave = MagicMock()
+        brave.search.return_value = [
+            _make_result("Shared", url="https://shared.com", content="short"),
+        ]
+        mock_engines["brave"] = brave
+        tavily = MagicMock()
+        tavily.search.return_value = [
+            _make_result("Shared", url="https://shared.com", content="longer content"),
+        ]
+        mock_engines["tavily"] = tavily
+
+        ws = WebSearch()
+        results = ws.search("python", engine="parallel")
+        assert len(results) == 1
+        assert results[0].content == "longer content"
+
+    def test_parallel_falls_back_to_auto_when_no_engines(
+        self, mock_engines, monkeypatch
+    ):
+        """If no parallel engines are configured, fall back to auto."""
+        monkeypatch.setenv("WEBSEARCH_PARALLEL_ENGINES", "brave")
+        # brave not configured
+        tavily = MagicMock()
+        tavily.search.return_value = [_make_result("auto-fallback")]
+        mock_engines["tavily"] = tavily
+
+        ws = WebSearch()
+        results = ws.search("python", engine="parallel")
+        assert len(results) == 1
+        assert results[0].title == "auto-fallback"
+
+    def test_parallel_all_empty_falls_back_to_auto(self, mock_engines, monkeypatch):
+        """If all parallel engines return empty, fall back to auto."""
+        monkeypatch.setenv("WEBSEARCH_PARALLEL_ENGINES", "brave")
+        brave = MagicMock()
+        brave.search.return_value = []
+        mock_engines["brave"] = brave
+        # searxng configured and has results (for auto fallback)
+        searxng = MagicMock()
+        searxng.search.return_value = [_make_result("searxng-fallback")]
+        mock_engines["searxng"] = searxng
+
+        ws = WebSearch()
+        results = ws.search("python", engine="parallel")
+        assert len(results) == 1
+        assert results[0].title == "searxng-fallback"
+
+    def test_parallel_respects_count(self, mock_engines, monkeypatch):
+        """Parallel results should be capped at count."""
+        monkeypatch.setenv("WEBSEARCH_PARALLEL_ENGINES", "brave,tavily")
+        brave = MagicMock()
+        brave.search.return_value = [
+            _make_result(f"b{i}", url=f"https://b{i}.com", content=f"brave result {i}")
+            for i in range(5)
+        ]
+        mock_engines["brave"] = brave
+        tavily = MagicMock()
+        tavily.search.return_value = [
+            _make_result(f"t{i}", url=f"https://t{i}.com", content=f"tavily result {i}")
+            for i in range(5)
+        ]
+        mock_engines["tavily"] = tavily
+
+        ws = WebSearch()
+        results = ws.search("python", engine="parallel", count=3)
+        assert len(results) == 3


### PR DESCRIPTION
## Summary

- **`engine="parallel"`** — query multiple engines concurrently via `ThreadPoolExecutor`, deduplicate and re-rank with BM25
- **BM25 dedup module** (`dedup.py`) — URL dedup (keep longest content) + BM25 re-ranking, zero external deps
- **Improved `search()` signature** — `max_results` → `count`, removed `**kwargs`, description optimized for LLM tool selection
- **Env vars**: `WEBSEARCH_PARALLEL_ENGINES` (default `brightdata,brave`), `WEBSEARCH_PRIORITY` added to `.env.sample`
- Both auto and parallel modes auto-skip unconfigured/failed engines

## Test plan

- [x] 58 unified websearch tests passing (36 existing + 7 new parallel + 1 renamed)
- [x] 14 new dedup tests passing (tokenizer, BM25 scoring, URL dedup, mixed engine merge)
- [x] ruff + complexipy clean
- [ ] CI passes