### PR TITLE
feat(dedup): normalize URLs before deduplication

### DIFF
--- a/src/toolregistry_hub/websearch/dedup.py
+++ b/src/toolregistry_hub/websearch/dedup.py
@@ -14,8 +14,71 @@ from __future__ import annotations
 import math
 import re
 from collections import Counter
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from .search_result import SearchResult
+
+# Query parameters injected by analytics / ad platforms.  Stripping these
+# prevents the same page from appearing as two different URLs when engines
+# return different tracking suffixes.
+_TRACKING_PARAMS: frozenset[str] = frozenset(
+    {
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+        "ref",
+        "fbclid",
+        "gclid",
+        "msclkid",
+        "mc_cid",
+        "mc_eid",
+    }
+)
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize a URL for deduplication purposes.
+
+    Applies the following transformations:
+        1. Strip trailing slashes from the path.
+        2. Remove ``www.`` prefix from the hostname.
+        3. Strip common tracking query parameters (utm_*, fbclid, etc.).
+
+    The original URL stored in the ``SearchResult`` is never modified —
+    this function is only used to build the dedup key.
+
+    Args:
+        url: Raw URL string.
+
+    Returns:
+        Normalized URL string suitable for equality comparison.
+    """
+    parts = urlsplit(url)
+
+    # Remove www. prefix
+    host = parts.hostname or ""
+    if host.startswith("www."):
+        host = host[4:]
+    # Reconstruct netloc (preserve port if present)
+    netloc = host
+    if parts.port:
+        netloc = f"{host}:{parts.port}"
+
+    # Strip trailing slashes from path
+    path = parts.path.rstrip("/")
+
+    # Remove tracking query parameters
+    if parts.query:
+        params = parse_qs(parts.query, keep_blank_values=True)
+        cleaned = {k: v for k, v in params.items() if k not in _TRACKING_PARAMS}
+        query = urlencode(cleaned, doseq=True)
+    else:
+        query = ""
+
+    return urlunsplit((parts.scheme, netloc, path, query, ""))
+
 
 # BM25 tuning constants (standard Okapi BM25 defaults).
 _BM25_K1 = 1.5
@@ -101,7 +164,7 @@ def deduplicate_results(
     # ── Step 1: URL dedup (keep longest content per URL) ─────────────────
     best_by_url: dict[str, SearchResult] = {}
     for r in results:
-        url = r.url.rstrip("/")
+        url = _normalize_url(r.url)
         existing = best_by_url.get(url)
         if existing is None or len(r.content) > len(existing.content):
             best_by_url[url] = r

--- a/tests/websearch/test_dedup.py
+++ b/tests/websearch/test_dedup.py
@@ -2,6 +2,7 @@
 
 from toolregistry_hub.websearch.dedup import (
     _bm25_score,
+    _normalize_url,
     _tokenize,
     deduplicate_results,
 )
@@ -74,6 +75,46 @@ class TestBM25Score:
         assert score_rare > score_common
 
 
+# ── URL normalization ────────────────────────────────────────────────────
+
+
+class TestNormalizeUrl:
+    def test_trailing_slash_stripped(self):
+        assert _normalize_url("https://example.com/path/") == _normalize_url(
+            "https://example.com/path"
+        )
+
+    def test_www_prefix_removed(self):
+        assert _normalize_url("https://www.example.com/page") == _normalize_url(
+            "https://example.com/page"
+        )
+
+    def test_tracking_params_stripped(self):
+        url = "https://example.com/page?q=test&utm_source=google&fbclid=abc"
+        normalized = _normalize_url(url)
+        assert "utm_source" not in normalized
+        assert "fbclid" not in normalized
+        assert "q=test" in normalized
+
+    def test_non_tracking_params_preserved(self):
+        url = "https://example.com/search?q=python&page=2"
+        normalized = _normalize_url(url)
+        assert "q=python" in normalized
+        assert "page=2" in normalized
+
+    def test_scheme_preserved(self):
+        http = _normalize_url("http://example.com/page")
+        https = _normalize_url("https://example.com/page")
+        assert http != https
+
+    def test_port_preserved(self):
+        url = _normalize_url("https://example.com:8080/path")
+        assert "8080" in url
+
+    def test_no_query_string(self):
+        assert _normalize_url("https://example.com") == "https://example.com"
+
+
 # ── Deduplication ────────────────────────────────────────────────────────
 
 
@@ -102,6 +143,30 @@ class TestDeduplicateResults:
         ]
         deduped = deduplicate_results(results, "test")
         assert len(deduped) == 1
+
+    def test_url_dedup_normalizes_www(self):
+        results = [
+            _r(url="https://www.example.com/page", content="with www short"),
+            _r(
+                url="https://example.com/page",
+                content="without www longer content here",
+            ),
+        ]
+        deduped = deduplicate_results(results, "test")
+        assert len(deduped) == 1
+        assert deduped[0].content == "without www longer content here"
+
+    def test_url_dedup_strips_tracking_params(self):
+        results = [
+            _r(url="https://example.com/page?utm_source=brave", content="from brave"),
+            _r(
+                url="https://example.com/page?utm_source=tavily",
+                content="from tavily with more text",
+            ),
+        ]
+        deduped = deduplicate_results(results, "test")
+        assert len(deduped) == 1
+        assert deduped[0].content == "from tavily with more text"
 
     def test_different_urls_preserved(self):
         results = [


### PR DESCRIPTION
## Summary

Improve dedup accuracy by normalizing URLs before comparison:
- Strip `www.` prefix (`www.example.com` → `example.com`)
- Remove tracking query params (`utm_*`, `fbclid`, `gclid`, `msclkid`, etc.)
- Trailing slash stripping (existing behavior, now via `_normalize_url`)

Original URLs in `SearchResult` are preserved — normalization is only used for the dedup key.

Follow-up from Milo's review comment on #142.

## Test plan

- [x] 7 new `TestNormalizeUrl` tests + 3 new dedup integration tests (www, tracking params)
- [x] All 24 dedup tests passing
- [ ] CI passes