### PR TITLE
refactor(registry): clean up tool visibility for LLM

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -18,7 +18,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./tools.jsonc:/app/tools.jsonc:ro
+      # - ./tools.jsonc:/app/tools.jsonc:ro  # optional: override default tool list
     command:
       [
         "toolregistry-hub",
@@ -36,7 +36,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./tools.jsonc:/app/tools.jsonc:ro
+      # - ./tools.jsonc:/app/tools.jsonc:ro  # optional: override default tool list
     command:
       [
         "toolregistry-hub",
@@ -55,7 +55,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./tools.jsonc:/app/tools.jsonc:ro
+      # - ./tools.jsonc:/app/tools.jsonc:ro  # optional: override default tool list
     command:
       [
         "toolregistry-hub",

--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -322,8 +322,8 @@ class Fetch:
         """
         return True
 
-    def clear_cache(self) -> None:
-        """Remove all cached URL results."""
+    def _clear_cache(self) -> None:
+        """Remove all cached URL results (internal, not exposed as a tool)."""
         if self._cache is not None:
             self._cache.clear()
 

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -66,11 +66,21 @@ _DEFAULT_TOOLS: list[PythonSource] = [
 # Metadata overrides for registered tools, keyed by namespace.
 _TOOL_METADATA: dict[str, dict] = {
     "calculator": {"defer": True, "tags": {ToolTag.READ_ONLY}},
-    "datetime": {"tags": {ToolTag.READ_ONLY}},
+    "datetime": {
+        "tags": {ToolTag.READ_ONLY},
+        "methods": {
+            "convert_timezone": {"defer": True},
+        },
+    },
     "think": {"tags": {ToolTag.READ_ONLY}},
     "file_ops": {"tags": {ToolTag.FILE_SYSTEM, ToolTag.DESTRUCTIVE}},
     "web/fetch": {"tags": {ToolTag.NETWORK, ToolTag.READ_ONLY}},
-    "web/websearch": {"tags": {ToolTag.NETWORK, ToolTag.READ_ONLY}},
+    "web/websearch": {
+        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
+        "methods": {
+            "list_engines": {"defer": True},
+        },
+    },
     "reader": {"defer": True, "tags": {ToolTag.FILE_SYSTEM, ToolTag.READ_ONLY}},
     "fs/file_search": {
         "defer": True,

--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -61,61 +61,16 @@ _DEFAULT_TOOLS: list[PythonSource] = [
         class_path="toolregistry_hub.websearch.websearch_unified.WebSearch",
         namespace="web/websearch",
     ),
-    PythonSource(
-        class_path="toolregistry_hub.websearch.websearch_brave.BraveSearch",
-        namespace="web/brave_search",
-    ),
-    PythonSource(
-        class_path="toolregistry_hub.websearch.websearch_tavily.TavilySearch",
-        namespace="web/tavily_search",
-    ),
-    PythonSource(
-        class_path="toolregistry_hub.websearch.websearch_searxng.SearXNGSearch",
-        namespace="web/searxng_search",
-    ),
-    PythonSource(
-        class_path="toolregistry_hub.websearch.websearch_brightdata.BrightDataSearch",
-        namespace="web/brightdata_search",
-    ),
-    PythonSource(
-        class_path="toolregistry_hub.websearch.websearch_scrapeless.ScrapelessSearch",
-        namespace="web/scrapeless_search",
-    ),
-    PythonSource(
-        class_path="toolregistry_hub.websearch.websearch_serper.SerperSearch",
-        namespace="web/serper_search",
-    ),
 ]
 
 # Metadata overrides for registered tools, keyed by namespace.
 _TOOL_METADATA: dict[str, dict] = {
-    "calculator": {"tags": {ToolTag.READ_ONLY}},
+    "calculator": {"defer": True, "tags": {ToolTag.READ_ONLY}},
     "datetime": {"tags": {ToolTag.READ_ONLY}},
     "think": {"tags": {ToolTag.READ_ONLY}},
     "file_ops": {"tags": {ToolTag.FILE_SYSTEM, ToolTag.DESTRUCTIVE}},
     "web/fetch": {"tags": {ToolTag.NETWORK, ToolTag.READ_ONLY}},
     "web/websearch": {"tags": {ToolTag.NETWORK, ToolTag.READ_ONLY}},
-    "web/brave_search": {"defer": True, "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY}},
-    "web/tavily_search": {
-        "defer": True,
-        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
-    },
-    "web/searxng_search": {
-        "defer": True,
-        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
-    },
-    "web/brightdata_search": {
-        "defer": True,
-        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
-    },
-    "web/scrapeless_search": {
-        "defer": True,
-        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
-    },
-    "web/serper_search": {
-        "defer": True,
-        "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY},
-    },
     "reader": {"defer": True, "tags": {ToolTag.FILE_SYSTEM, ToolTag.READ_ONLY}},
     "fs/file_search": {
         "defer": True,
@@ -129,7 +84,7 @@ _TOOL_METADATA: dict[str, dict] = {
     "cron": {"defer": True, "tags": {ToolTag.PRIVILEGED}},
     "todolist": {"defer": True, "tags": {ToolTag.READ_ONLY}},
     "unit_converter": {"defer": True, "tags": {ToolTag.READ_ONLY}},
-    "weather": {"tags": {ToolTag.NETWORK, ToolTag.READ_ONLY}},
+    "weather": {"defer": True, "tags": {ToolTag.NETWORK, ToolTag.READ_ONLY}},
 }
 
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1358,7 +1358,7 @@ class TestFetchCache:
         mock_extract.return_value = "content"
         fetcher = Fetch()
         fetcher.fetch_content("https://example.com")
-        fetcher.clear_cache()
+        fetcher._clear_cache()
         fetcher.fetch_content("https://example.com")
         assert mock_extract.call_count == 2
 
@@ -1371,9 +1371,9 @@ class TestFetchCache:
         assert mock_extract.call_count == 2
 
     def test_clear_cache_noop_when_disabled(self):
-        """clear_cache should not raise when cache is disabled."""
+        """_clear_cache should not raise when cache is disabled."""
         fetcher = Fetch(cache_ttl=0)
-        fetcher.clear_cache()  # should not raise
+        fetcher._clear_cache()  # should not raise
 
 
 # ============================================================

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -103,7 +103,14 @@ class TestBuildRegistry(unittest.TestCase):
         with patch.dict(os.environ, {"BRAVE_API_KEY": "test-key"}):
             reg = build_registry()
 
-            for ns in ("web/brave_search", "web/tavily_search", "web/searxng_search"):
+            for ns in (
+                "web/brave_search",
+                "web/tavily_search",
+                "web/searxng_search",
+                "web/brightdata_search",
+                "web/scrapeless_search",
+                "web/serper_search",
+            ):
                 tools = [t for t in reg._tools if reg._tools[t].namespace == ns]
                 self.assertEqual(
                     len(tools),

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -236,12 +236,17 @@ class TestToolMetadataAndDiscovery(unittest.TestCase):
         """Test that primary tools (always visible to LLM) are not deferred."""
         reg = build_registry(enable_discovery=False)
 
-        primary_namespaces = {"datetime", "think", "web/fetch", "web/websearch"}
-        for tool in reg._tools.values():
-            if tool.namespace in primary_namespaces:
+        primary_tools = {
+            "datetime-now",
+            "think-think",
+            "web/fetch-fetch_content",
+            "web/websearch-search",
+        }
+        for name in primary_tools:
+            if name in reg._tools:
                 self.assertFalse(
-                    tool.metadata.defer,
-                    f"Primary tool in namespace {tool.namespace} should not be deferred",
+                    reg._tools[name].metadata.defer,
+                    f"Primary tool {name} should not be deferred",
                 )
 
     def test_secondary_tools_deferred(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -83,73 +83,32 @@ class TestBuildRegistry(unittest.TestCase):
                     f"Tool {tool_name} should be disabled without SEARXNG_URL",
                 )
 
-    def test_websearch_tools_enabled_with_env(self):
-        """Test that websearch tools are enabled when env vars are set."""
+    def test_unified_websearch_enabled_with_env(self):
+        """Test that unified websearch is enabled when at least one engine has keys."""
         with patch.dict(os.environ, {"BRAVE_API_KEY": "test-key-for-brave"}):
             reg = build_registry()
 
-            brave_tools = [
-                t for t in reg._tools if reg._tools[t].namespace == "web/brave_search"
+            ws_tools = [
+                t for t in reg._tools if reg._tools[t].namespace == "web/websearch"
             ]
-            self.assertGreater(len(brave_tools), 0)
-            for tool_name in brave_tools:
+            self.assertGreater(len(ws_tools), 0)
+            for tool_name in ws_tools:
                 self.assertTrue(
                     reg.is_enabled(tool_name),
                     f"Tool {tool_name} should be enabled with BRAVE_API_KEY set",
                 )
 
-    def test_websearch_tools_enabled_with_tool_kwargs(self):
-        """Test that websearch tools are enabled when API keys are passed via tool_kwargs."""
-        with patch.dict(os.environ, {}, clear=True):
-            for var in [
-                "BRAVE_API_KEY",
-                "TAVILY_API_KEY",
-                "SEARXNG_URL",
-                "BRIGHTDATA_API_KEY",
-                "SCRAPELESS_API_KEY",
-            ]:
-                os.environ.pop(var, None)
+    def test_individual_search_providers_not_registered(self):
+        """Individual search providers are no longer registered as separate tools."""
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "test-key"}):
+            reg = build_registry()
 
-            reg = build_registry(
-                tool_kwargs={"brave_search": {"api_keys": "direct-test-key"}}
-            )
-
-            brave_tools = [
-                t for t in reg._tools if reg._tools[t].namespace == "web/brave_search"
-            ]
-            self.assertGreater(len(brave_tools), 0)
-            for tool_name in brave_tools:
-                self.assertTrue(
-                    reg.is_enabled(tool_name),
-                    f"Tool {tool_name} should be enabled with tool_kwargs API key",
-                )
-
-            tavily_tools = [
-                t for t in reg._tools if reg._tools[t].namespace == "web/tavily_search"
-            ]
-            for tool_name in tavily_tools:
-                self.assertFalse(
-                    reg.is_enabled(tool_name),
-                    f"Tool {tool_name} should be disabled without config",
-                )
-
-    def test_tool_kwargs_searxng_url(self):
-        """Test that SearXNG can be configured via tool_kwargs with base_url."""
-        with patch.dict(os.environ, {}, clear=True):
-            os.environ.pop("SEARXNG_URL", None)
-
-            reg = build_registry(
-                tool_kwargs={"searxng_search": {"base_url": "http://localhost:8080"}}
-            )
-
-            searxng_tools = [
-                t for t in reg._tools if reg._tools[t].namespace == "web/searxng_search"
-            ]
-            self.assertGreater(len(searxng_tools), 0)
-            for tool_name in searxng_tools:
-                self.assertTrue(
-                    reg.is_enabled(tool_name),
-                    f"Tool {tool_name} should be enabled with tool_kwargs base_url",
+            for ns in ("web/brave_search", "web/tavily_search", "web/searxng_search"):
+                tools = [t for t in reg._tools if reg._tools[t].namespace == ns]
+                self.assertEqual(
+                    len(tools),
+                    0,
+                    f"Individual provider namespace {ns} should not be registered",
                 )
 
     def test_core_tools_always_enabled(self):
@@ -273,16 +232,28 @@ class TestToolMetadataAndDiscovery(unittest.TestCase):
                     f"Tool in namespace {tool.namespace} should be deferred",
                 )
 
-    def test_core_tools_not_deferred(self):
-        """Test that core tools are not deferred."""
+    def test_primary_tools_not_deferred(self):
+        """Test that primary tools (always visible to LLM) are not deferred."""
         reg = build_registry(enable_discovery=False)
 
-        core_namespaces = {"calculator", "datetime", "think", "file_ops"}
+        primary_namespaces = {"datetime", "think", "web/fetch", "web/websearch"}
         for tool in reg._tools.values():
-            if tool.namespace in core_namespaces:
+            if tool.namespace in primary_namespaces:
                 self.assertFalse(
                     tool.metadata.defer,
-                    f"Core tool in namespace {tool.namespace} should not be deferred",
+                    f"Primary tool in namespace {tool.namespace} should not be deferred",
+                )
+
+    def test_secondary_tools_deferred(self):
+        """Test that secondary tools (calculator, weather) are deferred."""
+        reg = build_registry(enable_discovery=False)
+
+        deferred_namespaces = {"calculator", "weather"}
+        for tool in reg._tools.values():
+            if tool.namespace in deferred_namespaces:
+                self.assertTrue(
+                    tool.metadata.defer,
+                    f"Secondary tool in namespace {tool.namespace} should be deferred",
                 )
 
     def test_discovery_enabled(self):


### PR DESCRIPTION
## Summary

- **Remove individual search providers** (brave, tavily, searxng, brightdata, scrapeless, serper) from `_DEFAULT_TOOLS` — they are internal engines of the unified `WebSearch` and were confusing the LLM via `discover_tools`
- **Defer calculator** — not a primary tool, discoverable on demand
- **Defer weather** — not a primary tool, discoverable on demand
- **Method-level defer**: `convert_timezone`, `list_engines` — keep primary methods visible, secondary methods discoverable
- **`clear_cache` → `_clear_cache`** — internal method, not a tool
- **`tools.jsonc` mount commented out** in compose.yaml — default tool list from code is now the primary config

## Result

Remote profile LIVE tools (what the LLM sees directly):

| # | Tool | Purpose |
|---|------|---------|
| 1 | datetime-now | Time context |
| 2 | discover_tools | Progressive disclosure |
| 3 | think-think | Reasoning |
| 4 | web/fetch-fetch_content | Web content extraction |
| 5 | web/websearch-search | Web search (unified) |

Everything else is discoverable via `discover_tools` on demand.

## Test plan

- [x] 19 registry tests passing (updated expectations)
- [x] 207 total tests passing (fetch + registry)
- [x] All 6 individual search provider namespaces verified not registered
- [x] Method-level defer verified (`_apply_tool_metadata` already supports `methods` key)
- [x] CI passes