### PR TITLE
refactor(file_ops): align API with read/edit/write digest workflow

### DIFF
--- a/src/toolregistry_hub/file_ops.py
+++ b/src/toolregistry_hub/file_ops.py
@@ -1,29 +1,13 @@
-"""
-file_ops.py - Atomic file operations toolkit for LLM agents
-
-Key features:
-- All methods are static for stateless usage
-- Atomic writes with automatic backups
-- Unified error handling
-- Exact string replacement with disambiguation support
-- Encoding and line ending preservation
-"""
+"""Atomic file operations toolkit for LLM agents."""
 
 import difflib
-import fnmatch
+import hashlib
 import os
-import re
-import warnings
+from typing import Literal
 
 
 class FileOps:
-    """Core file operations toolkit designed for LLM agent integration.
-
-    Handles file reading, atomic writing, appending, searching, and exact
-    string replacement for file editing.
-    """
-
-    _read_files: set[str] = set()
+    """Core file operations with read/edit/write safety semantics."""
 
     # ======================
     #  Internal Helpers
@@ -31,15 +15,7 @@ class FileOps:
 
     @staticmethod
     def _detect_encoding(raw: bytes) -> tuple[str, bytes]:
-        """Detect file encoding from BOM bytes.
-
-        Args:
-            raw: Raw file bytes.
-
-        Returns:
-            Tuple of (encoding_name, bom_bytes). For utf-8-sig the codec
-            handles BOM transparently so bom is empty.
-        """
+        """Detect file encoding from BOM bytes."""
         if raw.startswith(b"\xef\xbb\xbf"):
             return ("utf-8-sig", b"")
         if raw.startswith(b"\xff\xfe"):
@@ -50,22 +26,33 @@ class FileOps:
 
     @staticmethod
     def _detect_line_ending(text: str) -> str:
-        """Detect dominant line ending in text.
-
-        Args:
-            text: Decoded file content.
-
-        Returns:
-            '\\r\\n' if CRLF is dominant, otherwise '\\n'.
-        """
+        """Detect dominant line ending in text."""
         crlf_count = text.count("\r\n")
         lf_count = text.count("\n") - crlf_count
         return "\r\n" if crlf_count > lf_count else "\n"
 
     @staticmethod
     def _real_path(path: str) -> str:
-        """Return absolute real path for access tracking."""
+        """Return absolute real path."""
         return os.path.realpath(os.path.abspath(path))
+
+    @staticmethod
+    def _digest(raw: bytes) -> str:
+        """Return SHA-256 digest for file content."""
+        return hashlib.sha256(raw).hexdigest()
+
+    @staticmethod
+    def _read_raw(path: str) -> bytes:
+        """Read file as bytes."""
+        with open(path, "rb") as f:
+            return f.read()
+
+    @staticmethod
+    def _decode(raw: bytes) -> tuple[str, str, bytes]:
+        """Decode raw bytes preserving encoding metadata."""
+        encoding, bom = FileOps._detect_encoding(raw)
+        text = raw[len(bom) :].decode(encoding) if bom else raw.decode(encoding)
+        return text, encoding, bom
 
     @staticmethod
     def _assert_not_symlink(path: str) -> None:
@@ -76,63 +63,82 @@ class FileOps:
                 "Resolve the symlink and pass the real target path explicitly."
             )
 
+    @staticmethod
+    def _assert_digest(path: str, digest: str | None, raw: bytes) -> None:
+        """Require and verify digest for existing file modifications."""
+        if digest is None:
+            raise ValueError(
+                f"digest is required for existing file: {path}. "
+                "Call read(path) first and pass the returned digest."
+            )
+        if digest != FileOps._digest(raw):
+            raise ValueError("File changed since digest was issued; read it again")
+
     # ======================
-    #  Content Modification
+    #  Public Tools
     # ======================
+
+    @staticmethod
+    def read(path: str) -> dict[str, str | bool]:
+        """Read text file content and return a digest for safe edits/writes.
+
+        Symlinks are allowed for reading. Writes through symlinks are rejected,
+        so callers should pass ``real_path`` to ``edit`` or ``write`` when
+        ``is_symlink`` is true.
+
+        Args:
+            path: File path to read.
+
+        Returns:
+            Dict with ``content``, ``digest``, ``is_symlink``, and ``real_path``.
+        """
+        raw = FileOps._read_raw(path)
+        text, _encoding, _bom = FileOps._decode(raw)
+        return {
+            "content": text,
+            "digest": FileOps._digest(raw),
+            "is_symlink": os.path.islink(path),
+            "real_path": FileOps._real_path(path),
+        }
 
     @staticmethod
     def edit(
         path: str,
         old_string: str,
         new_string: str,
+        digest: str,
         replace_all: bool = False,
         start_line: int | None = None,
-    ) -> str:
+    ) -> dict[str, str]:
         """Replace exact string in file.
 
         Args:
             path: Absolute path to file.
             old_string: Exact text to find. Must not be empty.
             new_string: Replacement text (must differ from old_string).
+            digest: SHA-256 digest returned by ``read(path)``.
             replace_all: Replace all occurrences instead of just one.
             start_line: Optional 1-based line number hint for disambiguation.
-                When multiple matches exist, selects the match whose start
-                line is closest to this value. Does not require exact precision.
 
         Returns:
-            Unified diff showing what changed (for display purposes).
-
-        Raises:
-            ValueError: If old_string is empty, identical to new_string,
-                not found, or ambiguous without start_line/replace_all.
-            FileNotFoundError: If path does not exist.
+            Dict with ``diff`` and updated ``digest``.
         """
         if not old_string:
             raise ValueError("old_string must not be empty")
         if old_string == new_string:
             raise ValueError("old_string and new_string are identical")
         FileOps._assert_not_symlink(path)
-        real_path = FileOps._real_path(path)
-        if real_path not in FileOps._read_files:
-            raise ValueError(
-                f"File must be read with read_file() before edit(). Unread path: {path}"
-            )
 
-        # Read file as bytes to preserve encoding
-        with open(path, "rb") as f:
-            raw = f.read()
+        raw = FileOps._read_raw(path)
+        FileOps._assert_digest(path, digest, raw)
 
-        encoding, bom = FileOps._detect_encoding(raw)
-        text = raw[len(bom) :].decode(encoding) if bom else raw.decode(encoding)
-
+        text, encoding, bom = FileOps._decode(raw)
         line_ending = FileOps._detect_line_ending(text)
 
-        # Normalize to \n for matching
         content = text.replace("\r\n", "\n")
         old_str = old_string.replace("\r\n", "\n")
         new_str = new_string.replace("\r\n", "\n")
 
-        # Find all non-overlapping occurrences
         positions: list[int] = []
         start = 0
         while True:
@@ -166,185 +172,81 @@ class FileOps:
                 f"replace all occurrences, or provide start_line to disambiguate."
             )
 
-        # Generate diff for display (on normalized content)
         diff_output = "\n".join(
             difflib.unified_diff(
                 content.splitlines(), new_content.splitlines(), lineterm=""
             )
         )
 
-        # Restore line endings
         if line_ending == "\r\n":
             new_content = new_content.replace("\n", "\r\n")
 
-        # Encode back
         encoded = bom + new_content.encode(encoding)
-
-        # Atomic write (binary)
         tmp_path = f"{path}.tmp"
+        FileOps._assert_not_symlink(tmp_path)
         with open(tmp_path, "wb") as f:
             f.write(encoded)
         os.replace(tmp_path, path)
 
-        return diff_output
+        return {"diff": diff_output, "digest": FileOps._digest(encoded)}
 
     @staticmethod
-    def search_files(path: str, regex: str, file_pattern: str = "*") -> list[dict]:
-        """Perform regex search across files in a directory, returning matches with context.
+    def write(
+        path: str,
+        content: str,
+        digest: str | None = None,
+        mode: Literal["overwrite", "append"] = "overwrite",
+    ) -> dict[str, str]:
+        """Write content to a file.
 
-        .. deprecated:: Use ``FileSearch.grep()`` instead.
+        Existing files require a digest from ``read(path)``.  New files can be
+        created without a digest.  ``mode="append"`` appends content without
+        requiring the caller to provide the full original file content.
 
         Args:
-            path: The directory path to search recursively.
-            regex: The regex pattern to search for.
-            file_pattern: Glob pattern to filter files (default='*').
+            path: Destination file path.
+            content: Content to write or append.
+            digest: Required when the file already exists.
+            mode: ``"overwrite"`` or ``"append"``.
 
         Returns:
-            List of dicts with keys:
-                - file: file path
-                - line_num: line number of match (1-based)
-                - line: matched line content
-                - context: list of context lines (tuples of line_num, line content)
+            Dict with updated ``digest``.
         """
-        warnings.warn(
-            "FileOps.search_files() is deprecated. Use FileSearch.grep() instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        pattern = re.compile(regex)
-        results = []
-        context_radius = 2  # lines before and after match to include as context
-
-        for root, _dirs, files in os.walk(path):
-            for filename in files:
-                if not fnmatch.fnmatch(filename, file_pattern):
-                    continue
-                file_path = os.path.join(root, filename)
-                try:
-                    with open(file_path, encoding="utf-8", errors="replace") as f:
-                        lines = f.readlines()
-                except Exception:
-                    continue
-
-                for i, line in enumerate(lines):
-                    if pattern.search(line):
-                        start_context = max(0, i - context_radius)
-                        end_context = min(len(lines), i + context_radius + 1)
-                        context_lines = [
-                            (ln + 1, lines[ln].rstrip("\n"))
-                            for ln in range(start_context, end_context)
-                            if ln != i
-                        ]
-                        results.append(
-                            {
-                                "file": file_path,
-                                "line_num": i + 1,
-                                "line": line.rstrip("\n"),
-                                "context": context_lines,
-                            }
-                        )
-        return results
-
-    # ======================
-    #  File I/O Operations
-    # ======================
-
-    @staticmethod
-    def read_file(path: str) -> str:
-        """Read text file content.
-
-        .. deprecated:: Use ``FileReader.read()`` instead (includes line numbers
-            and pagination).
-
-        Args:
-            path: File path to read
-
-        Returns:
-            File content as string
-
-        Raises:
-            FileNotFoundError: If path doesn't exist
-            UnicodeError: On encoding failures
-        """
-        warnings.warn(
-            "FileOps.read_file() is deprecated. Use FileReader.read() instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        with open(path, encoding="utf-8", errors="replace") as f:
-            content = f.read()
-        FileOps._read_files.add(FileOps._real_path(path))
-        return content
-
-    @staticmethod
-    def write_file(path: str, content: str) -> None:
-        """Atomically write content to a text file (overwrite). Creates the file if it doesn't exist.
-
-        Args:
-            path: Destination file path
-            content: Content to write
-        """
+        if mode not in {"overwrite", "append"}:
+            raise ValueError('mode must be "overwrite" or "append"')
         FileOps._assert_not_symlink(path)
+
+        existing = b""
+        if os.path.exists(path):
+            existing = FileOps._read_raw(path)
+            FileOps._assert_digest(path, digest, existing)
+
+        if mode == "append" and existing:
+            existing_text, encoding, bom = FileOps._decode(existing)
+            raw = bom + (existing_text + content).encode(encoding)
+        else:
+            raw = content.encode("utf-8")
+
         tmp_path = f"{path}.tmp"
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            f.write(content)
+        FileOps._assert_not_symlink(tmp_path)
+        with open(tmp_path, "wb") as f:
+            f.write(raw)
         os.replace(tmp_path, path)
 
-    @staticmethod
-    def append_file(path: str, content: str) -> None:
-        """Append content to a text file. Creates the file if it doesn't exist.
-
-        Args:
-            path: Destination file path
-            content: Content to append
-        """
-        FileOps._assert_not_symlink(path)
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(content)
+        return {"digest": FileOps._digest(raw)}
 
     # ======================
-    #  Content Generation
+    #  Internal Utilities
     # ======================
 
     @staticmethod
-    def make_diff(ours: str, theirs: str) -> str:
-        """Generate unified diff text between two strings.
-
-        .. deprecated:: This utility method will be removed in a future release.
-
-        Args:
-            ours: The 'ours' version string.
-            theirs: The 'theirs' version string.
-
-        Returns:
-            Unified diff text
-        """
-        warnings.warn(
-            "FileOps.make_diff() is deprecated and will be removed.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    def _make_diff(ours: str, theirs: str) -> str:
+        """Generate unified diff text between two strings."""
         return "\n".join(
             difflib.unified_diff(ours.splitlines(), theirs.splitlines(), lineterm="")
         )
 
     @staticmethod
-    def make_git_conflict(ours: str, theirs: str) -> str:
-        """Generate git merge conflict marker text between two strings.
-
-        .. deprecated:: This utility method will be removed in a future release.
-
-        Args:
-            ours: The 'ours' version string.
-            theirs: The 'theirs' version string.
-
-        Returns:
-            Text with conflict markers
-        """
-        warnings.warn(
-            "FileOps.make_git_conflict() is deprecated and will be removed.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    def _make_git_conflict(ours: str, theirs: str) -> str:
+        """Generate git merge conflict marker text between two strings."""
         return f"<<<<<<< HEAD\n{ours}\n=======\n{theirs}\n>>>>>>> incoming\n"

--- a/src/toolregistry_hub/file_ops.py
+++ b/src/toolregistry_hub/file_ops.py
@@ -23,6 +23,8 @@ class FileOps:
     string replacement for file editing.
     """
 
+    _read_files: set[str] = set()
+
     # ======================
     #  Internal Helpers
     # ======================
@@ -60,6 +62,20 @@ class FileOps:
         lf_count = text.count("\n") - crlf_count
         return "\r\n" if crlf_count > lf_count else "\n"
 
+    @staticmethod
+    def _real_path(path: str) -> str:
+        """Return absolute real path for access tracking."""
+        return os.path.realpath(os.path.abspath(path))
+
+    @staticmethod
+    def _assert_not_symlink(path: str) -> None:
+        """Reject writes through symlinks."""
+        if os.path.islink(path):
+            raise ValueError(
+                f"Refusing to write through symlink: {path}. "
+                "Resolve the symlink and pass the real target path explicitly."
+            )
+
     # ======================
     #  Content Modification
     # ======================
@@ -95,6 +111,12 @@ class FileOps:
             raise ValueError("old_string must not be empty")
         if old_string == new_string:
             raise ValueError("old_string and new_string are identical")
+        FileOps._assert_not_symlink(path)
+        real_path = FileOps._real_path(path)
+        if real_path not in FileOps._read_files:
+            raise ValueError(
+                f"File must be read with read_file() before edit(). Unread path: {path}"
+            )
 
         # Read file as bytes to preserve encoding
         with open(path, "rb") as f:
@@ -251,7 +273,9 @@ class FileOps:
             stacklevel=2,
         )
         with open(path, encoding="utf-8", errors="replace") as f:
-            return f.read()
+            content = f.read()
+        FileOps._read_files.add(FileOps._real_path(path))
+        return content
 
     @staticmethod
     def write_file(path: str, content: str) -> None:
@@ -261,6 +285,7 @@ class FileOps:
             path: Destination file path
             content: Content to write
         """
+        FileOps._assert_not_symlink(path)
         tmp_path = f"{path}.tmp"
         with open(tmp_path, "w", encoding="utf-8") as f:
             f.write(content)
@@ -274,7 +299,7 @@ class FileOps:
             path: Destination file path
             content: Content to append
         """
-        # Use 'a' mode for appending, creates file if it doesn't exist
+        FileOps._assert_not_symlink(path)
         with open(path, "a", encoding="utf-8") as f:
             f.write(content)
 

--- a/tests/test_file_ops.py
+++ b/tests/test_file_ops.py
@@ -13,6 +13,7 @@ class TestFileOps:
 
     def setup_method(self):
         """Set up test environment before each test."""
+        FileOps._read_files.clear()
         self.temp_dir = tempfile.mkdtemp()
         self.test_file = os.path.join(self.temp_dir, "test.txt")
         self.test_content = "Hello, World!\nThis is a test file.\nLine 3"
@@ -137,10 +138,38 @@ class TestFileOps:
         assert len(results) == 1
         assert "script.py" in results[0]["file"]
 
+    def test_edit_requires_prior_read(self):
+        """Test edit requires the file to be read first."""
+        with pytest.raises(ValueError, match="must be read"):
+            FileOps.edit(self.test_file, "Hello", "Hi")
+
+    def test_edit_rejects_symlink(self):
+        """Test edit refuses to write through symlinks."""
+        link_path = os.path.join(self.temp_dir, "link.txt")
+        os.symlink(self.test_file, link_path)
+        FileOps.read_file(link_path)
+        with pytest.raises(ValueError, match="Refusing to write through symlink"):
+            FileOps.edit(link_path, "Hello", "Hi")
+
+    def test_write_rejects_symlink(self):
+        """Test write_file refuses to write through symlinks."""
+        link_path = os.path.join(self.temp_dir, "link.txt")
+        os.symlink(self.test_file, link_path)
+        with pytest.raises(ValueError, match="Refusing to write through symlink"):
+            FileOps.write_file(link_path, "new content")
+
+    def test_append_rejects_symlink(self):
+        """Test append_file refuses to write through symlinks."""
+        link_path = os.path.join(self.temp_dir, "link.txt")
+        os.symlink(self.test_file, link_path)
+        with pytest.raises(ValueError, match="Refusing to write through symlink"):
+            FileOps.append_file(link_path, "more")
+
     def test_edit_single_match(self):
         """Test editing with a single match."""
         content = "line1\nline2\nline3\n"
         FileOps.write_file(self.test_file, content)
+        FileOps.read_file(self.test_file)
 
         diff = FileOps.edit(self.test_file, "line2", "modified line2")
 
@@ -151,6 +180,7 @@ class TestFileOps:
 
     def test_edit_no_match(self):
         """Test editing with no match raises ValueError."""
+        FileOps.read_file(self.test_file)
         with pytest.raises(ValueError, match="not found"):
             FileOps.edit(self.test_file, "nonexistent", "replacement")
 
@@ -159,6 +189,7 @@ class TestFileOps:
         content = "TODO item1\nTODO item2\nTODO item3\n"
         FileOps.write_file(self.test_file, content)
 
+        FileOps.read_file(self.test_file)
         FileOps.edit(self.test_file, "TODO", "DONE", replace_all=True)
 
         result = FileOps.read_file(self.test_file)
@@ -178,6 +209,7 @@ class TestFileOps:
         content = "".join(lines)
         FileOps.write_file(self.test_file, content)
 
+        FileOps.read_file(self.test_file)
         FileOps.edit(self.test_file, "TODO", "DONE", start_line=5)
 
         result = FileOps.read_file(self.test_file)
@@ -189,6 +221,7 @@ class TestFileOps:
         content = "dup\ndup\ndup\n"
         FileOps.write_file(self.test_file, content)
 
+        FileOps.read_file(self.test_file)
         with pytest.raises(ValueError, match="3 times"):
             FileOps.edit(self.test_file, "dup", "unique")
 
@@ -207,6 +240,7 @@ class TestFileOps:
         with open(self.test_file, "wb") as f:
             f.write(b"line1\r\nline2\r\nline3\r\n")
 
+        FileOps.read_file(self.test_file)
         FileOps.edit(self.test_file, "line2", "modified")
 
         with open(self.test_file, "rb") as f:
@@ -218,6 +252,7 @@ class TestFileOps:
         with open(self.test_file, "wb") as f:
             f.write(b"line1\nline2\nline3\n")
 
+        FileOps.read_file(self.test_file)
         FileOps.edit(self.test_file, "line2", "modified")
 
         with open(self.test_file, "rb") as f:
@@ -231,6 +266,7 @@ class TestFileOps:
         with open(self.test_file, "wb") as f:
             f.write(bom + b"line1\nline2\n")
 
+        FileOps.read_file(self.test_file)
         FileOps.edit(self.test_file, "line1", "changed")
 
         with open(self.test_file, "rb") as f:
@@ -242,6 +278,7 @@ class TestFileOps:
         """Test that edit returns a valid unified diff string."""
         content = "aaa\nbbb\nccc\n"
         FileOps.write_file(self.test_file, content)
+        FileOps.read_file(self.test_file)
 
         diff = FileOps.edit(self.test_file, "bbb", "xxx")
 
@@ -256,6 +293,7 @@ class TestFileOps:
         content = "keep\nDELETE_ME\nkeep\n"
         FileOps.write_file(self.test_file, content)
 
+        FileOps.read_file(self.test_file)
         FileOps.edit(self.test_file, "DELETE_ME\n", "")
 
         result = FileOps.read_file(self.test_file)

--- a/tests/test_file_ops.py
+++ b/tests/test_file_ops.py
@@ -13,12 +13,10 @@ class TestFileOps:
 
     def setup_method(self):
         """Set up test environment before each test."""
-        FileOps._read_files.clear()
         self.temp_dir = tempfile.mkdtemp()
         self.test_file = os.path.join(self.temp_dir, "test.txt")
         self.test_content = "Hello, World!\nThis is a test file.\nLine 3"
 
-        # Create a test file
         with open(self.test_file, "w", encoding="utf-8") as f:
             f.write(self.test_content)
 
@@ -29,285 +27,213 @@ class TestFileOps:
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
-    def test_read_file(self):
-        """Test reading file content."""
-        content = FileOps.read_file(self.test_file)
-        assert content == self.test_content
+    def _read(self, path: str | None = None) -> dict[str, str | bool]:
+        return FileOps.read(path or self.test_file)
 
-    def test_read_file_not_found(self):
-        """Test reading non-existent file."""
-        non_existent = os.path.join(self.temp_dir, "non_existent.txt")
+    # ── read ─────────────────────────────────────────────────────────────
+
+    def test_read(self):
+        result = self._read()
+        assert result["content"] == self.test_content
+        assert isinstance(result["digest"], str)
+        assert result["is_symlink"] is False
+        assert result["real_path"] == os.path.realpath(self.test_file)
+
+    def test_read_not_found(self):
         with pytest.raises(FileNotFoundError):
-            FileOps.read_file(non_existent)
+            FileOps.read(os.path.join(self.temp_dir, "missing.txt"))
 
-    def test_write_file(self):
-        """Test writing file content."""
-        new_file = os.path.join(self.temp_dir, "new_file.txt")
-        new_content = "New content for testing"
-
-        FileOps.write_file(new_file, new_content)
-
-        # Verify file was created and content is correct
-        assert os.path.exists(new_file)
-        with open(new_file, encoding="utf-8") as f:
-            assert f.read() == new_content
-
-    def test_write_file_overwrite(self):
-        """Test overwriting existing file."""
-        new_content = "Overwritten content"
-        FileOps.write_file(self.test_file, new_content)
-
-        content = FileOps.read_file(self.test_file)
-        assert content == new_content
-
-    def test_append_file(self):
-        """Test appending content to file."""
-        append_content = "\nAppended line"
-        FileOps.append_file(self.test_file, append_content)
-
-        content = FileOps.read_file(self.test_file)
-        assert content == self.test_content + append_content
-
-    def test_append_file_new_file(self):
-        """Test appending to non-existent file (should create it)."""
-        new_file = os.path.join(self.temp_dir, "append_test.txt")
-        content = "New file content"
-
-        FileOps.append_file(new_file, content)
-
-        assert os.path.exists(new_file)
-        assert FileOps.read_file(new_file) == content
-
-    def test_make_diff(self):
-        """Test generating unified diff."""
-        ours = "line1\nline2\nline3"
-        theirs = "line1\nmodified line2\nline3"
-
-        diff = FileOps.make_diff(ours, theirs)
-        assert isinstance(diff, str)
-        assert "line2" in diff
-        assert "modified line2" in diff
-
-    def test_make_git_conflict(self):
-        """Test generating git conflict markers."""
-        ours = "our version"
-        theirs = "their version"
-
-        conflict = FileOps.make_git_conflict(ours, theirs)
-        assert "<<<<<<< HEAD" in conflict
-        assert "=======" in conflict
-        assert ">>>>>>> incoming" in conflict
-        assert ours in conflict
-        assert theirs in conflict
-
-    def test_search_files(self):
-        """Test searching files with regex."""
-        # Create additional test files
-        file1 = os.path.join(self.temp_dir, "file1.py")
-        file2 = os.path.join(self.temp_dir, "file2.txt")
-
-        with open(file1, "w") as f:
-            f.write("def function():\n    return 'test'\n")
-
-        with open(file2, "w") as f:
-            f.write("This is a test file\nwith multiple lines\n")
-
-        # Search for 'test' pattern
-        results = FileOps.search_files(self.temp_dir, r"test", "*.txt")
-
-        assert len(results) >= 1
-        assert any("test" in result["line"] for result in results)
-        assert all("file" in result for result in results)
-        assert all("line_num" in result for result in results)
-
-    def test_search_files_with_pattern(self):
-        """Test searching files with file pattern filter."""
-        # Create files with different extensions
-        py_file = os.path.join(self.temp_dir, "script.py")
-        txt_file = os.path.join(self.temp_dir, "document.txt")
-
-        with open(py_file, "w") as f:
-            f.write("print('hello')")
-
-        with open(txt_file, "w") as f:
-            f.write("hello world")
-
-        # Search only in Python files
-        results = FileOps.search_files(self.temp_dir, r"hello", "*.py")
-
-        assert len(results) == 1
-        assert "script.py" in results[0]["file"]
-
-    def test_edit_requires_prior_read(self):
-        """Test edit requires the file to be read first."""
-        with pytest.raises(ValueError, match="must be read"):
-            FileOps.edit(self.test_file, "Hello", "Hi")
-
-    def test_edit_rejects_symlink(self):
-        """Test edit refuses to write through symlinks."""
+    def test_read_symlink_allowed(self):
         link_path = os.path.join(self.temp_dir, "link.txt")
         os.symlink(self.test_file, link_path)
-        FileOps.read_file(link_path)
-        with pytest.raises(ValueError, match="Refusing to write through symlink"):
-            FileOps.edit(link_path, "Hello", "Hi")
+        result = FileOps.read(link_path)
+        assert result["content"] == self.test_content
+        assert result["is_symlink"] is True
+        assert result["real_path"] == os.path.realpath(self.test_file)
+
+    # ── write ────────────────────────────────────────────────────────────
+
+    def test_write_new_file_without_digest(self):
+        new_file = os.path.join(self.temp_dir, "new.txt")
+        result = FileOps.write(new_file, "new content")
+        assert isinstance(result["digest"], str)
+        assert FileOps.read(new_file)["content"] == "new content"
+
+    def test_write_existing_requires_digest(self):
+        with pytest.raises(ValueError, match="digest is required"):
+            FileOps.write(self.test_file, "new content")
+
+    def test_write_existing_with_digest(self):
+        digest = self._read()["digest"]
+        result = FileOps.write(self.test_file, "new content", digest=digest)
+        assert isinstance(result["digest"], str)
+        assert self._read()["content"] == "new content"
+
+    def test_write_rejects_stale_digest(self):
+        digest = self._read()["digest"]
+        with open(self.test_file, "w", encoding="utf-8") as f:
+            f.write("external change")
+        with pytest.raises(ValueError, match="changed since digest"):
+            FileOps.write(self.test_file, "new content", digest=digest)
+
+    def test_write_append_mode(self):
+        digest = self._read()["digest"]
+        result = FileOps.write(
+            self.test_file, "\nappended", digest=digest, mode="append"
+        )
+        assert isinstance(result["digest"], str)
+        assert self._read()["content"] == self.test_content + "\nappended"
+
+    def test_write_append_preserves_utf8_bom(self):
+        bom = b"\xef\xbb\xbf"
+        with open(self.test_file, "wb") as f:
+            f.write(bom + b"line1\n")
+        digest = self._read()["digest"]
+        FileOps.write(self.test_file, "line2\n", digest=digest, mode="append")
+        with open(self.test_file, "rb") as f:
+            raw = f.read()
+        assert raw.startswith(bom)
+        assert b"line1\nline2\n" in raw
+
+    def test_write_invalid_mode(self):
+        with pytest.raises(ValueError, match="mode must"):
+            FileOps.write(os.path.join(self.temp_dir, "new.txt"), "content", mode="bad")
 
     def test_write_rejects_symlink(self):
-        """Test write_file refuses to write through symlinks."""
         link_path = os.path.join(self.temp_dir, "link.txt")
         os.symlink(self.test_file, link_path)
         with pytest.raises(ValueError, match="Refusing to write through symlink"):
-            FileOps.write_file(link_path, "new content")
+            FileOps.write(link_path, "new content")
 
-    def test_append_rejects_symlink(self):
-        """Test append_file refuses to write through symlinks."""
-        link_path = os.path.join(self.temp_dir, "link.txt")
-        os.symlink(self.test_file, link_path)
+    def test_write_rejects_tmp_symlink(self):
+        new_file = os.path.join(self.temp_dir, "new.txt")
+        tmp_link = f"{new_file}.tmp"
+        os.symlink(self.test_file, tmp_link)
         with pytest.raises(ValueError, match="Refusing to write through symlink"):
-            FileOps.append_file(link_path, "more")
+            FileOps.write(new_file, "new content")
+
+    # ── edit ─────────────────────────────────────────────────────────────
+
+    def test_edit_requires_digest(self):
+        with pytest.raises(ValueError, match="digest is required"):
+            FileOps.edit(self.test_file, "Hello", "Hi", digest=None)  # type: ignore[arg-type]
 
     def test_edit_single_match(self):
-        """Test editing with a single match."""
-        content = "line1\nline2\nline3\n"
-        FileOps.write_file(self.test_file, content)
-        FileOps.read_file(self.test_file)
+        digest = self._read()["digest"]
+        result = FileOps.edit(self.test_file, "Hello", "Hi", digest=digest)
+        assert "diff" in result
+        assert isinstance(result["digest"], str)
+        assert self._read()["content"].startswith("Hi, World!")
 
-        diff = FileOps.edit(self.test_file, "line2", "modified line2")
+    def test_edit_digest_can_chain_multiple_edits(self):
+        digest = self._read()["digest"]
+        first = FileOps.edit(self.test_file, "Hello", "Hi", digest=digest)
+        second = FileOps.edit(
+            self.test_file, "World", "Universe", digest=first["digest"]
+        )
+        assert isinstance(second["digest"], str)
+        assert self._read()["content"].startswith("Hi, Universe!")
 
-        result = FileOps.read_file(self.test_file)
-        assert result == "line1\nmodified line2\nline3\n"
-        assert isinstance(diff, str)
-        assert len(diff) > 0
+    def test_edit_rejects_stale_digest(self):
+        digest = self._read()["digest"]
+        with open(self.test_file, "w", encoding="utf-8") as f:
+            f.write("external change")
+        with pytest.raises(ValueError, match="changed since digest"):
+            FileOps.edit(self.test_file, "external", "new", digest=digest)
 
     def test_edit_no_match(self):
-        """Test editing with no match raises ValueError."""
-        FileOps.read_file(self.test_file)
+        digest = self._read()["digest"]
         with pytest.raises(ValueError, match="not found"):
-            FileOps.edit(self.test_file, "nonexistent", "replacement")
+            FileOps.edit(self.test_file, "missing", "replacement", digest=digest)
 
     def test_edit_multiple_matches_replace_all(self):
-        """Test editing with replace_all=True replaces all occurrences."""
-        content = "TODO item1\nTODO item2\nTODO item3\n"
-        FileOps.write_file(self.test_file, content)
-
-        FileOps.read_file(self.test_file)
-        FileOps.edit(self.test_file, "TODO", "DONE", replace_all=True)
-
-        result = FileOps.read_file(self.test_file)
-        assert result == "DONE item1\nDONE item2\nDONE item3\n"
-        assert "TODO" not in result
+        FileOps.write(self.test_file, "TODO 1\nTODO 2\n", digest=self._read()["digest"])
+        digest = self._read()["digest"]
+        FileOps.edit(self.test_file, "TODO", "DONE", digest=digest, replace_all=True)
+        assert self._read()["content"] == "DONE 1\nDONE 2\n"
 
     def test_edit_multiple_matches_start_line(self):
-        """Test editing with start_line disambiguation."""
-        lines = [
-            "line1\n",
-            "TODO first\n",
-            "line3\n",
-            "line4\n",
-            "TODO second\n",
-            "line6\n",
-        ]
-        content = "".join(lines)
-        FileOps.write_file(self.test_file, content)
-
-        FileOps.read_file(self.test_file)
-        FileOps.edit(self.test_file, "TODO", "DONE", start_line=5)
-
-        result = FileOps.read_file(self.test_file)
+        content = "TODO first\nline\nTODO second\n"
+        FileOps.write(self.test_file, content, digest=self._read()["digest"])
+        digest = self._read()["digest"]
+        FileOps.edit(self.test_file, "TODO", "DONE", digest=digest, start_line=3)
+        result = self._read()["content"]
         assert "TODO first" in result
         assert "DONE second" in result
 
     def test_edit_multiple_matches_no_disambiguation(self):
-        """Test editing with multiple matches and no disambiguation raises ValueError."""
-        content = "dup\ndup\ndup\n"
-        FileOps.write_file(self.test_file, content)
-
-        FileOps.read_file(self.test_file)
-        with pytest.raises(ValueError, match="3 times"):
-            FileOps.edit(self.test_file, "dup", "unique")
+        FileOps.write(self.test_file, "dup\ndup\n", digest=self._read()["digest"])
+        digest = self._read()["digest"]
+        with pytest.raises(ValueError, match="2 times"):
+            FileOps.edit(self.test_file, "dup", "unique", digest=digest)
 
     def test_edit_identical_strings(self):
-        """Test editing with identical old and new strings raises ValueError."""
+        digest = self._read()["digest"]
         with pytest.raises(ValueError, match="identical"):
-            FileOps.edit(self.test_file, "same", "same")
+            FileOps.edit(self.test_file, "same", "same", digest=digest)
 
     def test_edit_empty_old_string(self):
-        """Test editing with empty old_string raises ValueError."""
+        digest = self._read()["digest"]
         with pytest.raises(ValueError, match="must not be empty"):
-            FileOps.edit(self.test_file, "", "something")
+            FileOps.edit(self.test_file, "", "something", digest=digest)
 
     def test_edit_preserves_crlf(self):
-        """Test that edit preserves CRLF line endings."""
         with open(self.test_file, "wb") as f:
-            f.write(b"line1\r\nline2\r\nline3\r\n")
-
-        FileOps.read_file(self.test_file)
-        FileOps.edit(self.test_file, "line2", "modified")
-
+            f.write(b"line1\r\nline2\r\n")
+        digest = self._read()["digest"]
+        FileOps.edit(self.test_file, "line2", "changed", digest=digest)
         with open(self.test_file, "rb") as f:
-            raw = f.read()
-        assert raw == b"line1\r\nmodified\r\nline3\r\n"
+            assert f.read() == b"line1\r\nchanged\r\n"
 
     def test_edit_preserves_lf(self):
-        """Test that edit preserves LF line endings."""
         with open(self.test_file, "wb") as f:
-            f.write(b"line1\nline2\nline3\n")
-
-        FileOps.read_file(self.test_file)
-        FileOps.edit(self.test_file, "line2", "modified")
-
+            f.write(b"line1\nline2\n")
+        digest = self._read()["digest"]
+        FileOps.edit(self.test_file, "line2", "changed", digest=digest)
         with open(self.test_file, "rb") as f:
             raw = f.read()
         assert b"\r\n" not in raw
-        assert raw == b"line1\nmodified\nline3\n"
+        assert raw == b"line1\nchanged\n"
 
     def test_edit_preserves_utf8_bom(self):
-        """Test that edit preserves UTF-8 BOM."""
         bom = b"\xef\xbb\xbf"
         with open(self.test_file, "wb") as f:
-            f.write(bom + b"line1\nline2\n")
-
-        FileOps.read_file(self.test_file)
-        FileOps.edit(self.test_file, "line1", "changed")
-
+            f.write(bom + b"line1\n")
+        digest = self._read()["digest"]
+        FileOps.edit(self.test_file, "line1", "changed", digest=digest)
         with open(self.test_file, "rb") as f:
             raw = f.read()
         assert raw.startswith(bom)
         assert b"changed" in raw
 
-    def test_edit_returns_unified_diff(self):
-        """Test that edit returns a valid unified diff string."""
-        content = "aaa\nbbb\nccc\n"
-        FileOps.write_file(self.test_file, content)
-        FileOps.read_file(self.test_file)
-
-        diff = FileOps.edit(self.test_file, "bbb", "xxx")
-
-        assert "---" in diff
-        assert "+++" in diff
-        assert "@@" in diff
-        assert "-bbb" in diff
-        assert "+xxx" in diff
-
     def test_edit_delete_string(self):
-        """Test editing with empty new_string deletes the old_string."""
-        content = "keep\nDELETE_ME\nkeep\n"
-        FileOps.write_file(self.test_file, content)
+        digest = self._read()["digest"]
+        FileOps.edit(self.test_file, "This is a test file.\n", "", digest=digest)
+        assert self._read()["content"] == "Hello, World!\nLine 3"
 
-        FileOps.read_file(self.test_file)
-        FileOps.edit(self.test_file, "DELETE_ME\n", "")
+    def test_edit_rejects_symlink(self):
+        link_path = os.path.join(self.temp_dir, "link.txt")
+        os.symlink(self.test_file, link_path)
+        digest = self._read()["digest"]
+        with pytest.raises(ValueError, match="Refusing to write through symlink"):
+            FileOps.edit(link_path, "Hello", "Hi", digest=digest)
 
-        result = FileOps.read_file(self.test_file)
-        assert result == "keep\nkeep\n"
+    def test_edit_rejects_tmp_symlink(self):
+        digest = self._read()["digest"]
+        tmp_link = f"{self.test_file}.tmp"
+        os.symlink(self.test_file, tmp_link)
+        with pytest.raises(ValueError, match="Refusing to write through symlink"):
+            FileOps.edit(self.test_file, "Hello", "Hi", digest=digest)
 
-    def test_atomic_write_operation(self):
-        """Test that write operations are atomic."""
-        # This test verifies that temporary files are used during write
-        original_content = "original"
-        FileOps.write_file(self.test_file, original_content)
+    # ── internal utilities ───────────────────────────────────────────────
 
-        # Verify no .tmp files remain after successful write
-        temp_files = [f for f in os.listdir(self.temp_dir) if f.endswith(".tmp")]
-        assert len(temp_files) == 0
+    def test_make_diff(self):
+        diff = FileOps._make_diff("a\nb", "a\nc")
+        assert "-b" in diff
+        assert "+c" in diff
 
-        # Verify content is correct
-        assert FileOps.read_file(self.test_file) == original_content
+    def test_make_git_conflict(self):
+        conflict = FileOps._make_git_conflict("ours", "theirs")
+        assert "<<<<<<< HEAD" in conflict
+        assert "ours" in conflict
+        assert "theirs" in conflict


### PR DESCRIPTION
## Summary

Align `FileOps` with a small Claude Code-style file API:

- `read(path) -> {content, digest, is_symlink, real_path}`
- `edit(path, old_string, new_string, digest, ...) -> {diff, digest}`
- `write(path, content, digest=None, mode="overwrite"|"append") -> {digest}`

## Safety semantics

- `edit` and `write` reject symlink paths
- `edit` and `write` also reject symlink `.tmp` paths
- Existing-file edits/writes require the digest returned by `read(path)`
- Digest must match current file bytes, so external modifications force a new read
- `read` allows symlinks and reports `is_symlink` + `real_path`
- `write(mode="append")` supports append without requiring the caller to send the full original file

This removes server-side receipt state entirely; SHA-256 digest is the version proof.

## Breaking change

This replaces the deprecated `read_file` / `write_file` / `append_file` API surface with `read` / `edit` / `write`. `append_file` is removed as a tool; append is now `write(..., mode="append")`.

## Test plan

- [x] `ruff check src/toolregistry_hub/file_ops.py tests/test_file_ops.py`
- [x] `pytest tests/test_file_ops.py` — 29 passed