### PR TITLE
refactor: adopt ServerIdentity + CLI class from server

### DIFF
--- a/src/toolregistry_hub/server/app.py
+++ b/src/toolregistry_hub/server/app.py
@@ -73,8 +73,24 @@ class HubApp(App):
         return registry
 
 
-# Module-level convenience
-_app = HubApp()
+# Module-level convenience (lazy-init default HubApp)
 
-serve_openapi = _app.serve_openapi
-serve_mcp = _app.serve_mcp
+_app: HubApp | None = None
+
+
+def _get_default_app() -> HubApp:
+    """Return the shared default HubApp, creating it on first use."""
+    global _app
+    if _app is None:
+        _app = HubApp()
+    return _app
+
+
+def serve_openapi(**kwargs) -> None:
+    """Build registry and start an OpenAPI server."""
+    _get_default_app().serve_openapi(**kwargs)
+
+
+def serve_mcp(**kwargs) -> None:
+    """Build registry and start an MCP server."""
+    _get_default_app().serve_mcp(**kwargs)

--- a/src/toolregistry_hub/server/app.py
+++ b/src/toolregistry_hub/server/app.py
@@ -14,23 +14,31 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from toolregistry_server import ServerIdentity
 from toolregistry_server.app import App
 
+from .. import __version__
 from .._vendor.structlog import get_logger
+from .banner import BANNER_ART
 
 logger = get_logger()
 
 if TYPE_CHECKING:
     from toolregistry import ToolRegistry
 
+HUB_IDENTITY = ServerIdentity(
+    name="ToolRegistry Hub",
+    version=__version__,
+    description="Pre-configured tool server with various utilities",
+    banner_art=BANNER_ART,
+)
+
 
 class HubApp(App):
-    """Hub-specific server application.
+    """Hub-specific server application."""
 
-    Builds the registry from Hub's built-in tool list (or a user
-    config file override), applies Hub metadata, and optionally
-    enables the admin panel.
-    """
+    def __init__(self, identity: ServerIdentity | None = None) -> None:
+        super().__init__(identity=identity or HUB_IDENTITY)
 
     def prepare_registry(self, **kwargs) -> ToolRegistry:
         """Build the Hub registry.
@@ -65,7 +73,7 @@ class HubApp(App):
         return registry
 
 
-# Module-level convenience (default HubApp)
+# Module-level convenience
 _app = HubApp()
 
 serve_openapi = _app.serve_openapi

--- a/src/toolregistry_hub/server/cli.py
+++ b/src/toolregistry_hub/server/cli.py
@@ -28,24 +28,24 @@ class HubCLI(CLI):
     def __init__(self) -> None:
         super().__init__(app=HubApp())
 
-    def create_parser(self) -> argparse.ArgumentParser:
+    def configure_subparsers(
+        self, subparsers: dict[str, argparse.ArgumentParser]
+    ) -> None:
         """Add Hub-specific arguments to each subparser."""
-        parser = super().create_parser()
-
-        # Find subparsers and add hub args to each
-        for action in parser._subparsers._actions:
-            if isinstance(action, argparse._SubParsersAction):
-                for sub_parser in action.choices.values():
-                    _add_hub_arguments(sub_parser)
-
-        return parser
+        for sub_parser in subparsers.values():
+            _add_hub_arguments(sub_parser)
 
     def get_version_string(self) -> str:
         """Hub version with update check."""
         return _get_version_string()
 
     def print_banner(self) -> None:
-        """Hub banner with update check."""
+        """Print Hub banner with PyPI update check.
+
+        Overrides the base implementation because Hub needs to
+        check for updates and display extra lines — logic that
+        the base ``ServerIdentity``-driven banner doesn't support.
+        """
         _print_hub_banner()
 
     def dispatch(self, parsed: argparse.Namespace) -> None:
@@ -103,70 +103,66 @@ def _add_hub_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _get_version_string() -> str:
-    """Build Hub version string with update check."""
+def _run_update_check() -> dict | None:
+    """Run the async update check synchronously.
+
+    Returns the update info dict, or ``None`` if a running event
+    loop is detected or the check fails.
+    """
     import asyncio
 
     from ..version_check import check_for_updates
 
     try:
-        try:
-            asyncio.get_running_loop()
-            return f"toolregistry-hub {__version__}"
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                info = loop.run_until_complete(check_for_updates())
-            finally:
-                loop.close()
-                asyncio.set_event_loop(None)
+        asyncio.get_running_loop()
+        return None  # can't block inside an existing loop
+    except RuntimeError:
+        pass
 
-        if info["update_available"]:
-            return (
-                f"toolregistry-hub {info['current_version']}\n"
-                f"Update available: v{info['latest_version']}\n"
-                "Run: pip install --upgrade toolregistry-hub"
-            )
-        return f"toolregistry-hub {info['current_version']} (Latest)"
+    try:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return loop.run_until_complete(check_for_updates())
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
     except Exception:
+        return None
+
+
+def _get_version_string() -> str:
+    """Build Hub version string with update check."""
+    info = _run_update_check()
+    if info is None:
         return f"toolregistry-hub {__version__}"
+    if info["update_available"]:
+        return (
+            f"toolregistry-hub {info['current_version']}\n"
+            f"Update available: v{info['latest_version']}\n"
+            "Run: pip install --upgrade toolregistry-hub"
+        )
+    return f"toolregistry-hub {info['current_version']} (Latest)"
 
 
 def _print_hub_banner() -> None:
     """Print Hub banner with version check."""
-    import asyncio
-
     from toolregistry_server.cli import print_banner
 
-    from ..version_check import check_for_updates
     from .banner import BANNER_ART
 
-    try:
-        try:
-            asyncio.get_running_loop()
-            version = __version__
-            extra_lines = None
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                info = loop.run_until_complete(check_for_updates())
-            finally:
-                loop.close()
-                asyncio.set_event_loop(None)
-
-            if info["update_available"]:
-                version = info["current_version"]
-                extra_lines = [
-                    f"UPDATE AVAILABLE: v{info['latest_version']}",
-                    "Run: pip install --upgrade toolregistry-hub",
-                ]
-            else:
-                version = f"{info['current_version']} (Latest)"
-                extra_lines = None
-    except Exception:
+    info = _run_update_check()
+    if info is None:
         version = __version__
+        extra_lines = None
+    elif info["update_available"]:
+        version = info["current_version"]
+        extra_lines = [
+            f"UPDATE AVAILABLE: v{info['latest_version']}",
+            "Run: pip install --upgrade toolregistry-hub",
+        ]
+    else:
+        version = f"{info['current_version']} (Latest)"
         extra_lines = None
 
     print_banner(version=version, banner_art=BANNER_ART, extra_lines=extra_lines)

--- a/src/toolregistry_hub/server/cli.py
+++ b/src/toolregistry_hub/server/cli.py
@@ -1,26 +1,106 @@
 """Command-line interface for ToolRegistry Hub Server.
 
-Reuses toolregistry-server's CLI infrastructure via ``run_cli``,
-providing Hub-specific banner, version check, and dispatch.
+Subclasses :class:`toolregistry_server.cli.CLI` with Hub-specific
+banner (version check), extra arguments, and dispatch.
 
 Usage:
     toolregistry-hub openapi [OPTIONS]
     toolregistry-hub mcp [OPTIONS]
 """
 
+from __future__ import annotations
+
 import argparse
 from typing import NoReturn
 
+from toolregistry_server.cli import CLI
+
 from .. import __version__
 from .._vendor.structlog import get_logger
-from .banner import BANNER_ART
+from .app import HubApp
 
 logger = get_logger()
 
 
+class HubCLI(CLI):
+    """Hub CLI — extends server CLI with Hub-specific features."""
+
+    def __init__(self) -> None:
+        super().__init__(app=HubApp())
+
+    def create_parser(self) -> argparse.ArgumentParser:
+        """Add Hub-specific arguments to each subparser."""
+        parser = super().create_parser()
+
+        # Find subparsers and add hub args to each
+        for action in parser._subparsers._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                for sub_parser in action.choices.values():
+                    _add_hub_arguments(sub_parser)
+
+        return parser
+
+    def get_version_string(self) -> str:
+        """Hub version with update check."""
+        return _get_version_string()
+
+    def print_banner(self) -> None:
+        """Hub banner with update check."""
+        _print_hub_banner()
+
+    def dispatch(self, parsed: argparse.Namespace) -> None:
+        """Route to HubApp with Hub-specific kwargs."""
+        common = {
+            "tools_config_path": getattr(parsed, "config", None),
+            "enable_discovery": getattr(parsed, "tool_discovery", True),
+            "enable_think": getattr(parsed, "think_augment", True),
+            "profile": getattr(parsed, "profile", None),
+            "admin_port": getattr(parsed, "admin_port", None),
+        }
+
+        if parsed.command == "openapi":
+            self.app.serve_openapi(
+                host=parsed.host,
+                port=parsed.port,
+                tokens_path=getattr(parsed, "tokens", None),
+                reload=getattr(parsed, "reload", False),
+                **common,
+            )
+        elif parsed.command == "mcp":
+            self.app.serve_mcp(
+                transport=parsed.transport,
+                host=parsed.host,
+                port=parsed.port,
+                **common,
+            )
+
+
 # ---------------------------------------------------------------------------
-# Hub-specific version / banner
+# Hub-specific helpers
 # ---------------------------------------------------------------------------
+
+
+def _add_hub_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add Hub-specific arguments on top of server defaults."""
+    parser.add_argument(
+        "--admin-port",
+        type=int,
+        default=None,
+        metavar="PORT",
+        help="Enable the admin panel on the specified port (e.g. 8081)",
+    )
+    parser.add_argument(
+        "--tool-discovery",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable tool discovery (default: enabled)",
+    )
+    parser.add_argument(
+        "--think-augment",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable think-augmented function calling (default: enabled)",
+    )
 
 
 def _get_version_string() -> str:
@@ -60,6 +140,7 @@ def _print_hub_banner() -> None:
     from toolregistry_server.cli import print_banner
 
     from ..version_check import check_for_updates
+    from .banner import BANNER_ART
 
     try:
         try:
@@ -92,109 +173,13 @@ def _print_hub_banner() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Parser
-# ---------------------------------------------------------------------------
-
-
-def _add_hub_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add Hub-specific arguments on top of server defaults."""
-    parser.add_argument(
-        "--admin-port",
-        type=int,
-        default=None,
-        metavar="PORT",
-        help="Enable the admin panel on the specified port (e.g. 8081)",
-    )
-    parser.add_argument(
-        "--tool-discovery",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Enable/disable tool discovery (default: enabled)",
-    )
-    parser.add_argument(
-        "--think-augment",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Enable/disable think-augmented function calling (default: enabled)",
-    )
-
-
-def create_parser() -> argparse.ArgumentParser:
-    """Create the Hub CLI argument parser."""
-    from toolregistry_server.adapters.mcp import MCPAdapter
-    from toolregistry_server.adapters.openapi import OpenAPIAdapter
-
-    parser = argparse.ArgumentParser(
-        prog="toolregistry-hub",
-        description="ToolRegistry Hub - Pre-configured tool server",
-    )
-    parser.add_argument("--version", "-V", action="store_true", help="Show version")
-    parser.add_argument("--no-banner", action="store_true", help="Disable banner")
-
-    sub = parser.add_subparsers(dest="command", metavar="{openapi,mcp}")
-
-    openapi = sub.add_parser("openapi", help="Start OpenAPI server")
-    OpenAPIAdapter.add_cli_arguments(openapi)
-    _add_hub_arguments(openapi)
-
-    mcp = sub.add_parser("mcp", help="Start MCP server")
-    MCPAdapter.add_cli_arguments(mcp)
-    _add_hub_arguments(mcp)
-
-    return parser
-
-
-# ---------------------------------------------------------------------------
-# Dispatch
-# ---------------------------------------------------------------------------
-
-
-def _hub_dispatch(parsed: argparse.Namespace) -> None:
-    """Dispatch parsed args to HubApp."""
-    from .app import HubApp
-
-    app = HubApp()
-    common = {
-        "tools_config_path": getattr(parsed, "config", None),
-        "enable_discovery": getattr(parsed, "tool_discovery", True),
-        "enable_think": getattr(parsed, "think_augment", True),
-        "profile": getattr(parsed, "profile", None),
-        "admin_port": getattr(parsed, "admin_port", None),
-    }
-
-    if parsed.command == "openapi":
-        app.serve_openapi(
-            host=parsed.host,
-            port=parsed.port,
-            tokens_path=getattr(parsed, "tokens", None),
-            reload=getattr(parsed, "reload", False),
-            **common,
-        )
-    elif parsed.command == "mcp":
-        app.serve_mcp(
-            transport=parsed.transport,
-            host=parsed.host,
-            port=parsed.port,
-            **common,
-        )
-
-
-# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
 
 def main(args: list[str] | None = None) -> NoReturn | None:
     """Main entry point for the Hub CLI."""
-    from toolregistry_server.cli import run_cli
-
-    parsed = create_parser().parse_args(args)
-    return run_cli(
-        parsed,
-        version_string=_get_version_string(),
-        banner_fn=_print_hub_banner,
-        dispatch_fn=_hub_dispatch,
-    )
+    return HubCLI().main(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adopt toolregistry-server's `ServerIdentity` and `CLI` class.

- **HubApp** now passes `HUB_IDENTITY` (name, version, banner_art) → flows to OpenAPI title, MCP name, CLI banner automatically
- **HubCLI** subclasses `CLI` — overrides 4 methods instead of reimplementing the main loop
- `main()` is one line: `HubCLI().main(args)`

Depends on toolregistry-server PR #46 (merged).

## Test plan

- [x] 781 tests pass
- [x] Pre-commit clean