### PR TITLE
fix: return error result instead of raising FetchError in fetch_content

### DIFF
--- a/src/toolregistry_hub/fetch.py
+++ b/src/toolregistry_hub/fetch.py
@@ -458,11 +458,9 @@ class Fetch:
 
         Returns:
             Structured result with content, strategy, quality, cache status,
-            elapsed time, and metadata.
-
-        Raises:
-            FetchError: If every extraction strategy fails or the deadline
-                is exceeded before any content can be retrieved.
+            elapsed time, and metadata.  When extraction fails, a result
+            with ``quality="error"`` and an error message in ``content``
+            is returned instead of raising an exception.
         """
         started_at = time.monotonic()
         strategy = strategy.lower().strip()  # type: ignore[assignment]
@@ -497,11 +495,30 @@ class Fetch:
             if self._cache is not None:
                 self._cache.put(cache_key, result)
             return result
-        except FetchError:
-            raise
+        except FetchError as e:
+            logger.warning(f"FetchError for {url}: {e}")
+            return FetchResult(
+                content=f"[FetchError] {e}",
+                url=url,
+                strategy=strategy,
+                quality="error",
+                content_type="",
+                cached=False,
+                elapsed_ms=int((time.monotonic() - started_at) * 1000),
+                metadata={},
+            )
         except Exception as e:
             logger.error(f"Failed to fetch content from {url}: {e}")
-            raise FetchError(f"Failed to fetch content from {url}: {e}") from e
+            return FetchResult(
+                content=f"[FetchError] Failed to fetch content from {url}: {e}",
+                url=url,
+                strategy=strategy,
+                quality="error",
+                content_type="",
+                cached=False,
+                elapsed_ms=int((time.monotonic() - started_at) * 1000),
+                metadata={},
+            )
 
 
 def _should_skip_soup(

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1380,8 +1380,8 @@ class TestFetchCache:
     def test_fetch_error_not_cached(self, mock_extract):
         mock_extract.side_effect = [FetchError("fail"), _fetch_result("success")]
         fetcher = Fetch()
-        with pytest.raises(FetchError):
-            fetcher.fetch_content("https://fail.com")
+        err_result = fetcher.fetch_content("https://fail.com")
+        assert err_result["quality"] == "error"
         # Second call should retry (not cached)
         result = fetcher.fetch_content("https://fail.com")
         assert result["content"] == "success"
@@ -1535,21 +1535,22 @@ class TestJinaApiKey:
 
 
 class TestFetchContentErrorSignaling:
-    """`fetch_content` must raise on failure so MCP can set isError=true."""
+    """`fetch_content` returns quality='error' result on failure."""
 
     @patch("toolregistry_hub.fetch._extract")
-    def test_raises_fetch_error_on_unrecoverable_failure(self, mock_extract):
+    def test_returns_error_result_on_unrecoverable_failure(self, mock_extract):
         mock_extract.side_effect = FetchError("Unable to fetch content from x")
-        with pytest.raises(FetchError):
-            Fetch().fetch_content("https://this-domain-does-not-exist-12345.com")
+        result = Fetch().fetch_content("https://this-domain-does-not-exist-12345.com")
+        assert result["quality"] == "error"
+        assert "Unable to fetch content from x" in result["content"]
 
     @patch("toolregistry_hub.fetch._extract")
-    def test_wraps_unexpected_exceptions_as_fetch_error(self, mock_extract):
-        """Non-FetchError exceptions still surface as FetchError."""
+    def test_wraps_unexpected_exceptions_as_error_result(self, mock_extract):
+        """Non-FetchError exceptions return an error result."""
         mock_extract.side_effect = RuntimeError("boom")
-        with pytest.raises(FetchError) as excinfo:
-            Fetch().fetch_content("https://example.com")
-        assert isinstance(excinfo.value.__cause__, RuntimeError)
+        result = Fetch().fetch_content("https://example.com")
+        assert result["quality"] == "error"
+        assert "boom" in result["content"]
 
     @patch("toolregistry_hub.fetch._extract")
     def test_returns_string_on_success(self, mock_extract):


### PR DESCRIPTION
## Problem

`fetch_content()` raised `FetchError` on extraction failure, which propagated unhandled through the OpenAPI adapter, causing **500 Internal Server Error** responses.

Observed on cloud.usa1 openapi instance (v0.9.0) with SEC EDGAR XML URLs:
- `https://www.sec.gov/Archives/edgar/data/.../wk-form4_1782260879.xml`
- `https://www.sec.gov/Archives/edgar/data/.../wk-form4_1782168242.xml`

## Fix

Catch `FetchError` and unexpected exceptions in `fetch_content()`, returning a structured `FetchResult` with `quality="error"` and the error message in `content` instead of raising.

Callers can detect failures via `result["quality"] == "error"` without server-side crashes.

## Changes

- **`src/toolregistry_hub/fetch.py`**: Catch exceptions and return error results; update docstring
- **`tests/test_fetch.py`**: Update 3 tests to assert on returned error result instead of expecting raised exception

All 189 fetch tests pass.