### PR TITLE
fix: let user config tool_metadata override hub defaults

### DIFF
--- a/src/toolregistry_hub/server/registry.py
+++ b/src/toolregistry_hub/server/registry.py
@@ -257,6 +257,10 @@ def build_registry(
     # Hub-specific metadata overrides (tags, defer)
     _apply_tool_metadata(registry)
 
+    # Re-apply user config overrides so they take precedence over hub defaults
+    if config.tool_metadata:
+        registry.apply_metadata_config(config.tool_metadata)
+
     if enable_discovery:
         registry.enable_tool_discovery()
 


### PR DESCRIPTION
## Summary

- `build_registry()` applied hub's `_apply_tool_metadata()` after `apply_config()`, clobbering any `tool_metadata` overrides from the user's config file (e.g. `defer: false` for bash-execute)
- Re-apply config overrides last so user config always takes precedence over hub defaults

## Test plan

- [x] Verified with a config file setting `bash-execute` to `defer: false` — tool now appears in default `tools/list` response